### PR TITLE
Add foreman service handler for certificate changes

### DIFF
--- a/src/roles/foreman/handlers/main.yaml
+++ b/src/roles/foreman/handlers/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: Restart foreman service
+  ansible.builtin.systemd:
+    name: foreman
+    state: restarted

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -33,18 +33,24 @@
     name: foreman-ca-cert
     path: "{{ foreman_ca_certificate }}"
     state: present
+  notify:
+    - Restart foreman service
 
 - name: Create the podman secret for Foreman client certificate
   containers.podman.podman_secret:
     state: present
     name: foreman-client-cert
     path: "{{ foreman_client_certificate }}"
+  notify:
+    - Restart foreman service
 
 - name: Create the podman secret for Foreman client key
   containers.podman.podman_secret:
     state: present
     name: foreman-client-key
     path: "{{ foreman_client_key }}"
+  notify:
+    - Restart foreman service
 
 - name: Deploy Foreman Container
   containers.podman.podman_container:


### PR DESCRIPTION
Taking an initial tactic on using handler to handle changes to certificate secrets. I know there are more secrets that should trigger a change. I am keeping this focused to start with as I think the "things changed and services need to restart" paradigm is the part to get right to start with.

@evgeni I recall you had some reservations about handlers.


I am also wondering what if anything happens with the initial service start we have and the "wait for" task in a handler based setup:

```
- name: Start the Foreman Service
  ansible.builtin.systemd:
    name: foreman
    enabled: true
    state: started

- name: Wait for Foreman service to be accessible
  ansible.builtin.uri:
    url: 'http://{{ ansible_hostname }}:3000/api/v2/ping'
  until: foreman_status.status == 200
  retries: 60
  delay: 5
  register: foreman_status
```