### PR TITLE
Only use ansible_fqdn

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -119,7 +119,7 @@
 
 - name: Wait for Foreman service to be accessible
   ansible.builtin.uri:
-    url: 'http://{{ ansible_hostname }}:3000/api/v2/ping'
+    url: 'http://{{ ansible_fqdn }}:3000/api/v2/ping'
   until: foreman_status.status == 200
   retries: 60
   delay: 5
@@ -137,7 +137,7 @@
 
 - name: Wait for Foreman tasks to be ready
   ansible.builtin.uri:
-    url: 'http://{{ ansible_hostname }}:3000/api/v2/ping'
+    url: 'http://{{ ansible_fqdn }}:3000/api/v2/ping'
   until: foreman_tasks_status.json['results']['katello']['services']['foreman_tasks']['status'] == 'ok'
   retries: 60
   delay: 5

--- a/src/roles/foreman_proxy/tasks/main.yaml
+++ b/src/roles/foreman_proxy/tasks/main.yaml
@@ -79,6 +79,6 @@
 
 - name: Wait for Foreman Proxy service to be accessible
   ansible.builtin.wait_for:
-    host: "{{ ansible_hostname }}"
+    host: "{{ ansible_fqdn }}"
     port: 9090
     timeout: 300

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -142,7 +142,7 @@
 
 - name: Wait for Pulp API service to be accessible
   ansible.builtin.wait_for:
-    host: "{{ ansible_hostname }}"
+    host: "{{ ansible_fqdn}}"
     port: 24817
     timeout: 300
 
@@ -154,7 +154,7 @@
 
 - name: Wait for Pulp Content service to be accessible
   ansible.builtin.wait_for:
-    host: "{{ ansible_hostname }}"
+    host: "{{ ansible_fqdn }}"
     port: 24816
     timeout: 600
 


### PR DESCRIPTION
The value for `ansible_hostname` may be the short name (i.e., host) while `ansible_fqdn` contains the FQDN (i.e., hostname.example.com). Mixing the two can give inconsistent results.