### PR TITLE
Use named parameters style database URI

### DIFF
--- a/src/roles/candlepin/templates/candlepin.conf.j2
+++ b/src/roles/candlepin/templates/candlepin.conf.j2
@@ -23,7 +23,7 @@ jpa.config.hibernate.hbm2ddl.auto=validate
 jpa.config.hibernate.connection.username={{ candlepin_database_user }}
 jpa.config.hibernate.connection.password={{ candlepin_database_password }}
 jpa.config.hibernate.connection.driver_class=org.postgresql.Driver
-jpa.config.hibernate.connection.url=jdbc:postgresql://{{ candlepin_database_host }}:{{ candlepin_database_port }}/{{ candlepin_database_name }}?sslmode={{ candlepin_database_ssl_mode }}{% if candlepin_database_ssl_ca is defined %}&sslrootcert={{ candlepin_database_ssl_ca }}{% endif %}
+jpa.config.hibernate.connection.url=jdbc:postgresql://{{ candlepin_database_name }}?host={{ candlepin_database_host }}{% if candlepin_database_port is defined %}&port={{ candlepin_database_port }}{% endif %}&sslmode={{ candlepin_database_ssl_mode }}{% if candlepin_database_ssl_ca is defined %}&sslrootcert={{ candlepin_database_ssl_ca }}{% endif %}
 
 
 org.quartz.jobStore.misfireThreshold=60000
@@ -37,4 +37,4 @@ org.quartz.dataSource.myDS.driver=org.postgresql.Driver
 org.quartz.dataSource.myDS.user={{ candlepin_database_user }}
 org.quartz.dataSource.myDS.password={{ candlepin_database_password }}
 org.quartz.dataSource.myDS.maxConnections=5
-org.quartz.dataSource.myDS.URL=jdbc:postgresql://{{ candlepin_database_host }}:{{ candlepin_database_port }}/{{ candlepin_database_name }}?sslmode={{ candlepin_database_ssl_mode }}{% if candlepin_database_ssl_ca is defined %}&sslrootcert={{ candlepin_database_ssl_ca }}{% endif %}
+org.quartz.dataSource.myDS.URL=jdbc:postgresql://{{ candlepin_database_name }}?host={{ candlepin_database_host }}{% if candlepin_database_port is defined %}&port={{ candlepin_database_port }}{% endif %}&sslmode={{ candlepin_database_ssl_mode }}{% if candlepin_database_ssl_ca is defined %}&sslrootcert={{ candlepin_database_ssl_ca }}{% endif %}

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -8,7 +8,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-database-url
-    data: "postgresql://{{ foreman_database_user }}:{{ foreman_database_password }}@{{ foreman_database_host }}:{{ foreman_database_port }}/{{ foreman_database_name }}?pool={{ foreman_database_pool }}&sslmode={{ foreman_database_sslmode }}{% if foreman_database_ssl_ca is defined %}&sslrootcert={{ foreman_database_ssl_ca }}{% endif %}" # yamllint disable-line rule:line-length
+    data: "postgresql://{{ foreman_database_name }}?host={{ foreman_database_host }}{% if foreman_database_port is defined %}&port={{ foreman_database_port }}{% endif %}&user={{ foreman_database_user }}&password={{ foreman_database_password }}&pool={{ foreman_database_pool }}&sslmode={{ foreman_database_sslmode }}{% if foreman_database_ssl_ca is defined %}&sslrootcert={{ foreman_database_ssl_ca }}{% endif %}" # yamllint disable-line rule:line-length
 
 - name: Create settings config secret
   containers.podman.podman_secret:


### PR DESCRIPTION
This switches Foreman and Candlepin to use named parameters for specifying database URI details. This can allow for advanced setups like connecting to PostgreSQL it's socket.