### PR TITLE
Derive the version from git tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+VERSION export-subst

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := foremanctl
-VERSION := $(shell cat VERSION)
+VERSION := $(shell git describe)
 REQUIREMENTS_YML := $(firstword $(wildcard src/requirements-lock.yml src/requirements.yml))
 
 dist: $(NAME)-$(VERSION).tar.gz

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,10 @@
 # Release
 
-To create a release, bump `VERSION`, create a commit and tag.
+To create a release, create a tag.
 It must follow the x.y.z pattern without any prefix.
 
 ```
 VERSION=x.y.z
-echo $VERSION > VERSION
-git commit -m "Release $VERSION" VERSION
 git tag -s "$VERSION" -m "Release $VERSION"
 git push --follow-tags
 ```

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.0.0
+$Format:%(describe)$


### PR DESCRIPTION
Rather than copying the version and keeping them in sync, this uses git describe to determine that. It still delivers the version in a VERSION file by letting git replace the version on export.

This will fail until a tag exists.