### PR TITLE
Install python dependencies in a single run & detect active virtual env

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z "${GITHUB_ACTIONS}" ]]; then
+if [[ -z "${GITHUB_ACTIONS}" ]] && [[ -z "${VIRTUAL_ENV}" ]]; then
   python -m venv .venv
   source .venv/bin/activate
 fi

--- a/setup-environment
+++ b/setup-environment
@@ -4,8 +4,7 @@ if [[ -z "${GITHUB_ACTIONS}" ]] && [[ -z "${VIRTUAL_ENV}" ]]; then
   python -m venv .venv
   source .venv/bin/activate
 fi
-pip install -r src/requirements.txt
-pip install -r development/requirements.txt
+pip install -r src/requirements.txt -r development/requirements.txt
 make build/collections/foremanctl build/collections/forge
 
 printf "\n\nSetup complete.\n"


### PR DESCRIPTION
This will work better in case there are conflicting requirements.

It also skips creation and activation of the virtual environment if one is already active. Doing so makes it easy to use [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/) or other tooling.