### PR TITLE
drop the usage of the callbacks from ansible.posix in production

### DIFF
--- a/src/ansible.cfg
+++ b/src/ansible.cfg
@@ -1,6 +1,3 @@
 [defaults]
 host_key_checking = False
-stdout_callback=debug
-stderr_callback=debug
 roles_path = ~/.ansible/roles:./roles
-callbacks_enabled = profile_tasks


### PR DESCRIPTION
- `profile_tasks` adds quite some output at the end of the run, which is useful when you want to develop roles etc, but the end-user shouldn't be bothered with that
- `debug` is about pretty-printing stderr etc, but we don't have much of that