### PR TITLE
introduce default vars that should be "always" available

### DIFF
--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -4,11 +4,11 @@
     - quadlet
   become: true
   vars_files:
+    - "../../vars/defaults.yml"
     - "../../vars/{{ certificate_source }}_certificates.yml"
     - "../../vars/images.yml"
     - "../../vars/database.yml"
   vars:
-    certificate_source: default
     certificates_hostnames:
       - "{{ ansible_fqdn }}"
       - localhost

--- a/src/playbooks/setup-hammer/setup-hammer.yaml
+++ b/src/playbooks/setup-hammer/setup-hammer.yaml
@@ -4,6 +4,7 @@
     - quadlet
   become: true
   vars_files:
+    - "../../vars/defaults.yml"
     - "../../vars/{{ certificate_source }}_certificates.yml"
   vars:
     hammer_ca_certificate: "{{ server_ca_certificate }}"

--- a/src/vars/defaults.yml
+++ b/src/vars/defaults.yml
@@ -1,0 +1,2 @@
+---
+certificate_source: default


### PR DESCRIPTION
setup-hammer needs to know the certificate source, but if the deploy call before that didn't pass --certificate-source, the variable is not persisted (as nobody passed it) and setup-hammer fails