### PR TITLE
Don't set pulp_rhsm_url

### DIFF
--- a/src/roles/pulp/defaults/main.yaml
+++ b/src/roles/pulp/defaults/main.yaml
@@ -15,7 +15,6 @@ pulp_content_container_name: pulp-content
 pulp_worker_container_name: pulp-worker
 
 pulp_content_origin: "http://{{ ansible_fqdn }}:24816"
-pulp_rhsm_url: "https://{{ ansible_fqdn }}/rhsm"
 pulp_pulp_url: "http://{{ ansible_fqdn }}:24817"
 
 pulp_enable_analytics: false
@@ -47,7 +46,6 @@ pulp_settings_other_env:
   PULP_REMOTE_USER_ENVIRON_NAME: "HTTP_REMOTE_USER"
   PULP_REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES: >-
     ['rest_framework.authentication.SessionAuthentication', 'pulpcore.app.authentication.PulpRemoteUserAuthentication']
-  PULP_SMART_PROXY_RHSM_URL: "{{ pulp_rhsm_url }}"
   PULP_SMART_PROXY_PULP_URL: "{{ pulp_pulp_url }}"
 
 pulp_settings_env: "{{ pulp_settings_database_env | ansible.builtin.combine(pulp_settings_other_env) }}"


### PR DESCRIPTION
This has become optional and Katello now interprets it as telling the users to connect directly.

Link: https://github.com/Katello/katello/commit/46abdb24234df46c94424cf376b6119e386c8c70