### PR TITLE
explicit become: false for the install flag creation

### DIFF
--- a/src/roles/post_install/tasks/main.yaml
+++ b/src/roles/post_install/tasks/main.yaml
@@ -13,3 +13,4 @@
     content: ''
     mode: '0640'
   delegate_to: localhost
+  become: false


### PR DESCRIPTION
when run in dev mode, you don't need sudo to write to .var
when run in prod mode, you're root already to write to /var