### PR TITLE
Configure hammer for root

### DIFF
--- a/src/playbooks/setup-hammer/setup-hammer.yaml
+++ b/src/playbooks/setup-hammer/setup-hammer.yaml
@@ -6,6 +6,7 @@
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/{{ certificate_source }}_certificates.yml"
+    - "../../vars/foreman.yml"
   vars:
     hammer_ca_certificate: "{{ server_ca_certificate }}"
   roles:

--- a/src/roles/hammer/tasks/main.yml
+++ b/src/roles/hammer/tasks/main.yml
@@ -10,3 +10,20 @@
     owner: root
     group: root
     mode: '0644'
+
+- name: 'Add hammer module config directory'
+  ansible.builtin.file:
+    path: '/root/.hammer/cli.modules.d'
+    state: directory
+    owner: root
+    group: root
+    mode: '0600'
+
+- name: 'Configure Hammer Root Credentials file'
+  ansible.builtin.template:
+    src: hammer-root.yml.j2
+    dest: /root/.hammer/cli.modules.d/foreman.yml
+    owner: root
+    group: root
+    mode: '0600'
+

--- a/src/roles/hammer/tasks/main.yml
+++ b/src/roles/hammer/tasks/main.yml
@@ -17,7 +17,7 @@
     state: directory
     owner: root
     group: root
-    mode: '0600'
+    mode: '0700'
 
 - name: 'Configure Hammer Root Credentials file'
   ansible.builtin.template:
@@ -26,4 +26,3 @@
     owner: root
     group: root
     mode: '0600'
-

--- a/src/roles/hammer/templates/hammer-root.yml.j2
+++ b/src/roles/hammer/templates/hammer-root.yml.j2
@@ -1,0 +1,4 @@
+:foreman:
+  # Credentials. You'll be asked for them interactively if you leave them blank here
+  :username: '{{ foreman_initial_admin_username }}'
+  :password: '{{ foreman_initial_admin_password }}'

--- a/tests/hammer_test.py
+++ b/tests/hammer_test.py
@@ -1,3 +1,7 @@
 def test_hammer_ping(server):
     hammer = server.run("hammer ping")
     assert hammer.succeeded
+
+def test_hammer_organizations_list(server):
+    hammer = server.run("hammer organization list")
+    assert hammer.succeeded


### PR DESCRIPTION
With the current hammer deployment, for each hammer command we need to pass username and password.
in the current deployment we configure the credentials for root so that root does not need to pass username/password with each hammer command.

reference from current-installer(https://github.com/theforeman/puppet-foreman/blob/master/manifests/cli.pp#L72)