### PR TITLE
Add ability to config pulp worker

### DIFF
--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -9,6 +9,8 @@ variables:
     help: Initial password for the admin user.
   foreman_puma_workers:
     help: Number of workers for Puma.
+  pulp_worker_count:
+    help: Number of Pulp workers. Defaults to 8 or the number of CPU cores, whichever is smaller.
 
 include:
   - _certificate_source

--- a/src/roles/pulp/defaults/main.yaml
+++ b/src/roles/pulp/defaults/main.yaml
@@ -5,7 +5,7 @@ pulp_api_image: "{{ pulp_container_image }}:{{ pulp_container_tag }}"
 pulp_content_image: "{{ pulp_container_image }}:{{ pulp_container_tag }}"
 pulp_worker_image: "{{ pulp_container_image }}:{{ pulp_container_tag }}"
 
-pulp_worker_count: 2
+pulp_worker_count: "{{ [8, ansible_facts['processor_nproc']] | min }}"
 pulp_content_service_worker_count: "{{ (2 * ([8, ansible_facts['processor_nproc']] | min)) + 1 }}"
 pulp_api_service_worker_count: "{{ ([4, ansible_facts['processor_nproc']] | min) + 1 }}"
 
@@ -53,3 +53,9 @@ pulp_settings_other_env:
   PULP_CONTENT_WORKERS: "{{ pulp_content_service_worker_count }}"
 
 pulp_settings_env: "{{ pulp_settings_database_env | ansible.builtin.combine(pulp_settings_other_env) }}"
+
+pulp_all_services: "{{ ['pulp-api', 'pulp-content'] + pulp_worker_services }}"
+pulp_worker_services: >-
+  {{
+    range(1, pulp_worker_count | int + 1) | map('string') | map('regex_replace', '^', pulp_worker_container_name ~ '@') | list
+  }}

--- a/src/roles/pulp/handlers/main.yml
+++ b/src/roles/pulp/handlers/main.yml
@@ -11,5 +11,5 @@
 
 - name: Restart pulp-worker
   ansible.builtin.systemd:
-    name: pulp-worker
+    name: pulp-worker.target
     state: restarted

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -137,14 +137,15 @@
         RestartSec=3
   notify: Restart pulp-content
 
-- name: Deploy Pulp Worker Container
+- name: Deploy Pulp Worker Template
   containers.podman.podman_container:
-    name: "{{ pulp_worker_container_name }}"
+    name: "{{ pulp_worker_container_name }}-%i"
+    quadlet_filename: "{{ pulp_worker_container_name }}@"
     image: "{{ pulp_worker_image }}"
     state: quadlet
     command: pulp-worker
     network: host
-    hostname: "pulp-worker.{{ ansible_facts['fqdn'] }}"
+    hostname: "pulp-worker-%i.{{ ansible_facts['fqdn'] }}"
     volumes: "{{ pulp_volumes }}"
     security_opt:
       - "label=disable"
@@ -156,17 +157,43 @@
     quadlet_options:
       - |
         [Install]
-        WantedBy=default.target foreman.target
+        WantedBy=foreman.target pulp-worker.target
         [Unit]
-        PartOf=foreman.target
+        PartOf=pulp-worker.target foreman.target
         Wants=redis.service postgresql.service
         After=redis.service postgresql.service
         [Service]
         Restart=always
         RestartSec=3
+        SyslogIdentifier={{ pulp_worker_container_name }}@%i
   notify: Restart pulp-worker
 
-- name: Run daemon reload to make Quadlet create the service files
+- name: Create Pulp Worker Container instances
+  ansible.builtin.file:
+    state: link
+    src: "/etc/containers/systemd/{{ pulp_worker_container_name }}@.container"
+    dest: "/etc/containers/systemd/{{ item }}.container"
+  loop: "{{ pulp_worker_services }}"
+
+- name: Create pulp-worker.target
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/pulp-worker.target
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [Unit]
+      Description=Pulp Worker Services
+      [Install]
+      WantedBy=foreman.target
+
+- name: Enable and start pulp-worker.target
+  ansible.builtin.systemd:
+    name: pulp-worker.target
+    enabled: true
+    state: started
+
+- name: Run daemon reload to load service files
   ansible.builtin.systemd:
     daemon_reload: true
 
@@ -193,10 +220,7 @@
     state: started
   async: 60
   poll: 0
-  loop:
-    - pulp-api
-    - pulp-content
-    - pulp-worker
+  loop: "{{ pulp_all_services }}"
   register: pulp_services
 
 - name: Wait for Pulp services
@@ -207,6 +231,32 @@
   retries: 100
   delay: 1
   loop: "{{ pulp_services.results }}"
+
+- name: Gather service facts to find existing pulp-worker instances
+  ansible.builtin.service_facts:
+
+- name: Build list of existing pulp-worker services
+  ansible.builtin.set_fact:
+    pulp_existing_workers: "{{ ansible_facts.services.keys() | select('match', '^' + pulp_worker_container_name + '@\\d+\\.service$') | list }}"
+
+- name: Stop and disable old pulp-worker instances
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: false
+    state: stopped
+  loop: "{{ pulp_existing_workers }}"
+  when:
+    - pulp_existing_workers | length > 0
+    - (item | regex_replace('^' + pulp_worker_container_name + '@(\\d+)\\.service$', '\\1') | int) > (pulp_worker_count | int)
+
+- name: Remove container symlinks for old pulp-worker instances
+  ansible.builtin.file:
+    path: "/etc/containers/systemd/{{ item | regex_replace('\\.service$', '.container') }}"
+    state: absent
+  loop: "{{ pulp_existing_workers }}"
+  when:
+    - pulp_existing_workers | length > 0
+    - (item | regex_replace('^' + pulp_worker_container_name + '@(\\d+)\\.service$', '\\1') | int) > (pulp_worker_count | int)
 
 - name: Ensure Pulp admin user exists
   containers.podman.podman_container_exec:

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -23,10 +23,15 @@ def test_pulp_content_service(server):
     assert pulp_content.is_running
     assert pulp_content.is_enabled
 
-def test_pulp_worker_service(server):
-    pulp_worker = server.service("pulp-worker")
-    assert pulp_worker.is_running
-    assert pulp_worker.is_enabled
+def test_pulp_worker_services(server):
+    result = server.run("systemctl list-units --all --type=service --no-legend 'pulp-worker@*.service' | awk '{print $1}'")
+    worker_services = [s.strip() for s in result.stdout.split('\n') if s.strip()]
+    assert len(worker_services) > 0
+
+    for worker_service in worker_services:
+        worker = server.service(worker_service)
+        assert worker.is_running
+        assert worker.is_enabled
 
 def test_pulp_api_port(server):
     pulp_api = server.addr(PULP_HOST)


### PR DESCRIPTION
This PR adds ability to configure `pulp-workers`. pulp-worker container has one `pulpcore-worker` process running inside it.
This adds a way to scale `pulp-workers` . the approach used here is to horizontal scaling of `pulp-worker` containers where each container has one pulpcore-worker` process running inside it.

How does the scaling works:-

- when we deploy using `foremanctl deploy`, we calculate the no. of workers based on `"{{ [8, ansible_facts['processor_nproc']] | min }}"`, means Defaults to 8 or the number of CPU cores, whichever is smaller. and exactly that no. of pulp-worker containers are deployed.
- if we want to scale up/down, you can use `--pulp-worker-count` option while deploying to set require no. of pulp-worker containers