### PR TITLE
Fix Dynflow container restart policy

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -145,8 +145,8 @@
         PartOf=foreman.target
       - |
         [Service]
-        RestartPolicy="on-failure"
-        Restart=1
+        Restart=on-failure
+        RestartSec=1
 
 - name: Create Dynflow Container instances
   ansible.builtin.file:


### PR DESCRIPTION
It's Restart/RestartSec, not RestartPolicy/Restart.

Fixes: 3c0ec9ca701dc196c693f812a265f558c1e3d511