### PR TITLE
ensure apps are started after databases, and stopped before

### DIFF
--- a/development/roles/foreman_development/templates/foreman-development.service.j2
+++ b/development/roles/foreman_development/templates/foreman-development.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Foreman Development Server
-After=postgresql.service
-Wants=postgresql.service
+After=redis.service postgresql.service
+Wants=redis.service postgresql.service
 
 [Service]
 Type=simple

--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -85,6 +85,8 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
+        Wants=redis.service postgresql.service
+        After=redis.service postgresql.service
         [Service]
         TimeoutStartSec=300
     healthcheck: curl --fail --insecure https://localhost:23443/candlepin/status

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -143,6 +143,8 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
+        Wants=redis.service postgresql.service
+        After=redis.service postgresql.service
       - |
         [Service]
         Restart=on-failure

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -99,7 +99,8 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
-        Wants=postgresql.service
+        Wants=redis.service postgresql.service
+        After=redis.service postgresql.service
         [Service]
         Restart=always
         RestartSec=3
@@ -127,7 +128,8 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
-        Wants=postgresql.service
+        Wants=redis.service postgresql.service
+        After=redis.service postgresql.service
         [Service]
         Restart=always
         RestartSec=3
@@ -154,7 +156,8 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
-        Wants=postgresql.service
+        Wants=redis.service postgresql.service
+        After=redis.service postgresql.service
         [Service]
         Restart=always
         RestartSec=3


### PR DESCRIPTION
That way `systemctl stop foreman.target` doesn't result in failed containers which got their DB connection aborted.