### PR TITLE
Add cname support

### DIFF
--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -51,14 +51,25 @@ After deployment, certificates are available at:
 - Server Certificate: `/root/ssl-build/<hostname>/<hostname>-apache.crt`
 - Client Certificate: `/root/ssl-build/<hostname>/<hostname>-foreman-client.crt`
 
+### CNAME Support
+
+foremanctl supports Subject Alternative Names (SANs) for multi-domain certificates:
+
+```bash
+# Generate certificates with multiple DNS names
+foremanctl deploy \
+  --certificate-cname api.example.com \
+  --certificate-cname foreman.example.com \
+  --certificate-cname satellite.example.com
+```
+
+When CNAMEs are specified, certificates will include all names in the Subject Alternative Name field, allowing the same certificate to be valid for multiple hostnames.
+
 ### Current Limitations
 
-- Only supports single hostname (no multiple DNS names)
 - Cannot provide custom certificate files during deployment
 - Fixed 20-year certificate validity period
 - Limited certificate customization options
-
----
 
 ## Internal Design
 
@@ -89,7 +100,8 @@ src/roles/certificates/
 
 2. **Host Certificate Issuance** (for each hostname in `certificates_hostnames`):
    - Generate 4096-bit RSA private key
-   - Create certificate signing request (CSR)
+   - Create certificate signing request (CSR) with Subject Alternative Names
+   - Include primary hostname and any additional CNAMEs from `certificate_cname`
    - Sign certificate with CA (includes serverAuth/clientAuth extensions)
    - Generate both server and client certificates per hostname
 
@@ -146,5 +158,6 @@ The `certificate_checks` role uses `foreman-certificate-check` binary to validat
 
 **OpenSSL Configuration:**
 - Custom configuration template supports SAN extensions
-- Single DNS entry per certificate: `subjectAltName = DNS:{{ certificates_hostname }}`
+- Multiple DNS entries supported: `subjectAltName = DNS:{{ certificates_hostname }}{% for cname in certificate_cname %},DNS:{{ cname }}{% endfor %}`
 - Uses OpenSSL's `req` and `ca` commands for generation and signing
+- CNAMEs configured via `certificate_cname` variable (list of additional DNS names)

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -61,6 +61,7 @@ There are multiple use cases from the users perspective that dictate what parame
 
 | Parameter | Description | foreman-installer Parameter |
 | ----------| ----------- | --------------------------- |
+| `--certificate-cname` | Allows defining CNAME for default certificates | --certs-cname |
 
 ##### Unmapped
 

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -18,6 +18,11 @@ variables:
       - ipa_with_api
   external_authentication_pam_service:
     help: Name of the PAM service to use for IPA authentication
+  certificates_cnames:
+    help: Additional DNS name to include in Subject Alternative Names for certificates. Can be specified multiple times.
+    action: append_unique
+    type: FQDN
+    parameter: --certificate-cname
 
 include:
   - _certificate_source

--- a/src/roles/certificates/defaults/main.yml
+++ b/src/roles/certificates/defaults/main.yml
@@ -4,3 +4,4 @@ certificates_ca_directory: /root/certificates # Change this to /var/lib?
 certificates_ca_directory_keys: "{{ certificates_ca_directory }}/private"
 certificates_ca_directory_certs: "{{ certificates_ca_directory }}/certs"
 certificates_ca_directory_requests: "{{ certificates_ca_directory }}/requests"
+certificates_cnames: []

--- a/src/roles/certificates/tasks/issue.yml
+++ b/src/roles/certificates/tasks/issue.yml
@@ -14,7 +14,7 @@
       -config "{{ certificates_ca_directory }}/openssl.cnf"
       -key "{{ certificates_ca_directory_keys }}/{{ certificates_hostname }}.key"
       -subj "/CN={{ certificates_hostname }}"
-      -addext "subjectAltName = DNS:{{ certificates_hostname }}"
+      -addext "subjectAltName = DNS:{{ certificates_hostname }}{% for cname in certificates_cnames %},DNS:{{ cname }}{% endfor %}"
       -out "{{ certificates_ca_directory_requests }}/{{ certificates_hostname }}.csr"
   args:
     creates: "{{ certificates_ca_directory_requests }}/{{ certificates_hostname }}.csr"


### PR DESCRIPTION
This includes https://github.com/theforeman/foremanctl/pull/294

This aims to add cname support to the default set of certificates, which is functionality foreman-installer allowed.