### PR TITLE
Set the libvirt management domain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,8 @@ jobs:
           python-version: '3.12'
       - name: Setup libvirt for Vagrant
         uses: voxpupuli/setup-vagrant@v0
+        with:
+          configure_dns: true
       - name: Install Ansible
         run: pip install --upgrade ansible-core
       - name: Setup environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,8 @@ jobs:
           python-version: '3.12'
       - name: Setup libvirt for Vagrant
         uses: voxpupuli/setup-vagrant@v0
+        with:
+          configure_dns: true
       - name: Install Ansible
         run: pip install --upgrade ansible-core
       - name: Setup environment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+DOMAIN = 'example.com'.freeze
+
 Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant"
 
@@ -12,21 +14,23 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "quadlet" do |override|
     override.vm.box = ENV.fetch("FOREMANCTL_BASE_BOX", "centos/stream9")
-    override.vm.hostname = "quadlet.example.com"
+    override.vm.hostname = "quadlet.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 10240
       libvirt.cpus = 4
       libvirt.machine_virtual_size = 30
+      libvirt.management_network_domain = DOMAIN
     end
   end
 
   config.vm.define "client" do |override|
     override.vm.box = "centos/stream9"
-    override.vm.hostname = "client.example.com"
+    override.vm.hostname = "client.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 1024
+      libvirt.management_network_domain = DOMAIN
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+DOMAIN = ENV.fetch('VAGRANT_DOMAIN', 'example.com'.freeze)
+
 Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant"
 
@@ -10,9 +12,13 @@ Vagrant.configure("2") do |config|
     ansible_provisioner.playbook = 'development/playbooks/resize_disk.yaml'
   end
 
+  config.vm.provider "libvirt" do |libvirt|
+    libvirt.management_network_domain = DOMAIN
+  end
+
   config.vm.define "quadlet" do |override|
     override.vm.box = ENV.fetch("FOREMANCTL_BASE_BOX", "centos/stream9")
-    override.vm.hostname = "quadlet.example.com"
+    override.vm.hostname = "quadlet.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 10240
@@ -23,7 +29,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "client" do |override|
     override.vm.box = "centos/stream9"
-    override.vm.hostname = "client.example.com"
+    override.vm.hostname = "client.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 1024
@@ -32,7 +38,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "database" do |override|
     override.vm.box = "centos/stream9"
-    override.vm.hostname = "database.example.com"
+    override.vm.hostname = "database.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 2048

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,8 @@ def server_hostname():
 
 
 @pytest.fixture(scope="module")
-def server_fqdn(server_hostname):
-    return f'{server_hostname}.example.com'
+def server_fqdn(server):
+    return server.check_output('hostname -f')
 
 
 @pytest.fixture(scope="module")
@@ -42,8 +42,8 @@ def client_hostname():
 
 
 @pytest.fixture(scope="module")
-def client_fqdn(client_hostname):
-    return f'{client_hostname}.example.com'
+def client_fqdn(client):
+    return client.check_output('hostname -f')
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This makes sure the domain is set when the management domain is created, which makes libvirt configure dnsmasq as a proper DNS server. This can be used together with systemd-resolved on the host to look up guest IPs.

It also configures Vagrant in CI with DNS set up to utilize this.