### PR TITLE
Can't enable generated services

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -187,7 +187,6 @@
 - name: Start services
   ansible.builtin.systemd:
     name: "{{ item }}"
-    enabled: true
     state: started
   async: 60
   poll: 0

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -48,7 +48,6 @@
 - name: Start the PostgreSQL Service
   ansible.builtin.systemd:
     name: "{{ postgresql_container_name }}"
-    enabled: true
     state: started
 
 # SCRAM-SHA-256 is default for PostgreSQL 14+,

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -189,7 +189,6 @@
 - name: Start Pulp services
   ansible.builtin.systemd:
     name: "{{ item }}"
-    enabled: true
     state: started
   async: 60
   poll: 0

--- a/src/roles/redis/tasks/main.yaml
+++ b/src/roles/redis/tasks/main.yaml
@@ -37,5 +37,4 @@
 - name: Start the Redis Service
   ansible.builtin.systemd:
     name: redis
-    enabled: true
     state: started


### PR DESCRIPTION
When we try to enable a generated service manually we get the error
```
systemctl enable redis.service 
Failed to enable unit: Unit /run/systemd/generator/redis.service is transient or generated.
```
although we don't get error when using ansible, but its good to have things in sync.