### PR TITLE
Bump default PostgreSQL `max_connections` to 500

### DIFF
--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -31,6 +31,8 @@
       - "{{ postgresql_data_dir }}:/var/lib/pgsql/data:Z"
     secrets:
       - 'postgresql_admin_password,target=POSTGRESQL_ADMIN_PASSWORD,type=env'
+    env:
+      POSTGRESQL_MAX_CONNECTIONS: "{{ postgresql_max_connections }}"
     quadlet_options:
       - |
         [Install]

--- a/src/vars/database.yml
+++ b/src/vars/database.yml
@@ -43,3 +43,5 @@ postgresql_users:
     password: "{{ foreman_database_password }}"
   - name: "{{ pulp_database_name }}"
     password: "{{ pulp_database_password }}"
+
+postgresql_max_connections: 500


### PR DESCRIPTION
The value used by default by the container image is 100 which is too low.

Installing to a system with 16 CPUs and 64 GiB of RAM led to:

```
FATAL:  remaining connection slots are reserved for non-replication superuser connections
```

The value of 500 has been chosen to match the default value applied by Satellite, and works even with 32 Puma workers.