### PR TITLE
Expose /pub directory

### DIFF
--- a/src/roles/httpd/defaults/main.yml
+++ b/src/roles/httpd/defaults/main.yml
@@ -2,3 +2,4 @@ httpd_ssl_dir: /etc/pki/httpd
 httpd_pulp_api_backend: http://localhost:24817
 httpd_pulp_content_backend: http://localhost:24816
 httpd_foreman_backend: http://localhost:3000
+httpd_pub_dir: /var/www/html/pub

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -27,6 +27,14 @@
     - "{{ httpd_ssl_dir }}/certs"
     - "{{ httpd_ssl_dir }}/private"
 
+- name: Create pub directory
+  ansible.builtin.file:
+    path: "{{ httpd_pub_dir }}"
+    state: directory
+    group: apache
+    owner: apache
+    mode: "0755"
+
 - name: Deploy certificates
   ansible.builtin.copy:
     src: "{{ item.src }}"
@@ -42,6 +50,13 @@
       dest: "certs/katello-apache.crt"
     - src: "{{ httpd_server_key }}"
       dest: "private/katello-apache.key"
+
+- name: Copy CA certificate to pub directory for client trust
+  ansible.builtin.copy:
+    src: "{{ httpd_server_ca_certificate }}"
+    dest: "{{ httpd_pub_dir }}/katello-server-ca.crt"
+    remote_src: true
+    mode: "0644"
 
 - name: Configure foreman-ssl vhost
   ansible.builtin.template:

--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -60,6 +60,13 @@
     ProxyPassReverse {{ httpd_pulp_api_backend }}/pulp/api/v3
   </Location>
 
+  Alias /pub {{ httpd_pub_dir }}
+
+  <Location /pub>
+    Options +FollowSymLinks +Indexes
+    Require all granted
+  </Location>
+
   ProxyPass /pulp/assets/ {{ httpd_pulp_api_backend }}/pulp/assets/
   ProxyPassReverse /pulp/assets/ {{ httpd_pulp_api_backend }}/pulp/assets/
 
@@ -68,6 +75,7 @@
   ProxyPreserveHost On
   ProxyAddHeaders On
   ProxyPass /pulp !
+  ProxyPass /pub !
   ProxyPass /icons !
   ProxyPass /server-status !
   ProxyPass / {{ httpd_foreman_backend }}/ retry=0 timeout=900

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -1,43 +1,53 @@
 HTTP_HOST = 'localhost'
 HTTP_PORT = 80
 HTTPS_PORT = 443
-
+HTTPD_PUB_DIR = '/var/www/html/pub'
 
 def test_httpd_service(server):
     httpd = server.service("httpd")
     assert httpd.is_running
     assert httpd.is_enabled
 
-
 def test_http_port(server):
     httpd = server.addr(HTTP_HOST)
     assert httpd.port(HTTP_PORT).is_reachable
 
-
 def test_https_port(server):
     httpd = server.addr(HTTP_HOST)
     assert httpd.port(HTTPS_PORT).is_reachable
-
 
 def test_https_foreman_ping(server, certificates, server_fqdn):
     cmd = server.run(f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null --write-out '%{{http_code}}' https://{server_fqdn}/api/v2/ping")
     assert cmd.succeeded
     assert cmd.stdout == '200'
 
-
 def test_https_pulp_status(server, certificates, server_fqdn):
     cmd = server.run(f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null --write-out '%{{http_code}}' https://{server_fqdn}/pulp/api/v3/status/")
     assert cmd.succeeded
     assert cmd.stdout == '200'
-
 
 def test_https_pulp_content(server, certificates, server_fqdn):
     cmd = server.run(f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null --write-out '%{{http_code}}' https://{server_fqdn}/pulp/content/")
     assert cmd.succeeded
     assert cmd.stdout == '200'
 
-
 def test_https_pulp_auth(server, certificates, server_fqdn):
     cmd = server.run(f"curl --cacert {certificates['ca_certificate']} --silent --write-out '%{{stderr}}%{{http_code}}' --cert {certificates['client_certificate']} --key {certificates['client_key']} https://{server_fqdn}/pulp/api/v3/users/")
     assert cmd.succeeded
     assert cmd.stderr == '200'
+
+def test_pub_directory_exists(server):
+    pub_dir = server.file(HTTPD_PUB_DIR)
+    assert pub_dir.exists
+    assert pub_dir.is_directory
+    assert pub_dir.mode == 0o755
+
+def test_pub_directory_accessible(server, certificates, server_fqdn):
+    cmd = server.run(f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null --write-out '%{{http_code}}' https://{server_fqdn}/pub/")
+    assert cmd.succeeded
+    assert cmd.stdout == '200'
+
+def test_pub_ca_certificate_downloadable(server, certificates, server_fqdn):
+    cmd = server.run(f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null --write-out '%{{http_code}}' https://{server_fqdn}/pub/katello-server-ca.crt")
+    assert cmd.succeeded
+    assert cmd.stdout == '200'


### PR DESCRIPTION
This PR exposes /pub directory. it is a initial work around and currently only exposes `katello-server-ca.crt`.