### PR TITLE
don't ignore paths when running CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
 
 
 concurrency:


### PR DESCRIPTION
it's confusing for contributors when a PR that only changes .md files seems stuck in CI with a pending required check never triggering.