### PR TITLE
Bump default PostgreSQL `shared_buffers` to 512MB

### DIFF
--- a/src/roles/postgresql/defaults/main.yml
+++ b/src/roles/postgresql/defaults/main.yml
@@ -10,3 +10,4 @@ postgresql_data_dir: /var/lib/pgsql/data
 postgresql_admin_password: "CHANGEME"
 
 postgresql_max_connections: 500
+postgresql_shared_buffers: 512MB

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -33,6 +33,7 @@
       - 'postgresql_admin_password,target=POSTGRESQL_ADMIN_PASSWORD,type=env'
     env:
       POSTGRESQL_MAX_CONNECTIONS: "{{ postgresql_max_connections }}"
+      POSTGRESQL_SHARED_BUFFERS: "{{ postgresql_shared_buffers }}"
     quadlet_options:
       - |
         [Install]


### PR DESCRIPTION
The value used by default by the container image is 32MB.

The chosen value matches https://github.com/theforeman/foreman-installer/blob/develop/config/foreman.hiera/tuning/common.yaml#L14