### PR TITLE
Drop checks role from setup-foreman-proxy

### DIFF
--- a/src/playbooks/setup-foreman-proxy/setup-foreman-proxy.yaml
+++ b/src/playbooks/setup-foreman-proxy/setup-foreman-proxy.yaml
@@ -13,5 +13,4 @@
 
   roles:
     - pre_install
-    - checks
     - foreman_proxy


### PR DESCRIPTION
In their current form, the checks only apply to the Foreman itself. 