### PR TITLE
Change default Puma threads min and max values to match Foreman ones

### DIFF
--- a/src/roles/foreman/defaults/main.yaml
+++ b/src/roles/foreman/defaults/main.yaml
@@ -12,7 +12,13 @@ foreman_database_sslrootcert:
 
 foreman_url: "http://{{ ansible_facts['fqdn'] }}:3000"
 
+# Puma threads calculation:
+# Max calculation is based on the default for MRI https://puma.io/puma6/#thread-pool
+# Min calculation is based on testing that showed that having the same value as the max led to
+# lower memory usage
+foreman_puma_threads_max: 5
+foreman_puma_threads_min: "{{ foreman_puma_threads_max }}"
 # Puma workers calculation:
-# CPU based calculation is based on https://github.com/puma/puma/blob/master/docs/deployment.md#mri
-# Memory based calculation is based on https://docs.gitlab.com/ee/install/requirements.html#puma-settings
+# CPU calculation is based on https://github.com/puma/puma/blob/master/docs/deployment.md#mri
+# Memory calculation is based on https://docs.gitlab.com/ee/install/requirements.html#puma-settings
 foreman_puma_workers: "{{ [32, ansible_facts['processor_nproc'] * 1.5, (ansible_facts['memtotal_mb'] / 1024) - 1.5] | min | int }}"

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -104,6 +104,8 @@
       - 'foreman-client-cert,type=mount,target=/etc/foreman/client_cert.pem'
       - 'foreman-client-key,type=mount,target=/etc/foreman/client_key.pem'
     env:
+      FOREMAN_PUMA_THREADS_MIN: "{{ foreman_puma_threads_min }}"
+      FOREMAN_PUMA_THREADS_MAX: "{{ foreman_puma_threads_max }}"
       FOREMAN_PUMA_WORKERS: "{{ foreman_puma_workers }}"
     quadlet_options:
       - |


### PR DESCRIPTION
The values are taken from:

https://github.com/theforeman/puppet-foreman/blob/master/manifests/init.pp

Because this is the first stab at this, they'll be hardcoded and will be configurable in a later commit.