### PR TITLE
Set PostgreSQL tuning values

### DIFF
--- a/src/roles/postgresql/defaults/main.yml
+++ b/src/roles/postgresql/defaults/main.yml
@@ -11,3 +11,4 @@ postgresql_admin_password: "CHANGEME"
 
 postgresql_max_connections: 500
 postgresql_shared_buffers: 512MB
+postgresql_effective_cache_size: 1GB

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -34,6 +34,7 @@
     env:
       POSTGRESQL_MAX_CONNECTIONS: "{{ postgresql_max_connections }}"
       POSTGRESQL_SHARED_BUFFERS: "{{ postgresql_shared_buffers }}"
+      POSTGRESQL_EFFECTIVE_CACHE_SIZE: "{{ postgresql_effective_cache_size }}"
     quadlet_options:
       - |
         [Install]

--- a/src/vars/tuning/extra-extra-large.yml
+++ b/src/vars/tuning/extra-extra-large.yml
@@ -1,3 +1,7 @@
 ---
 min_cpu_cores: 48
 min_ram_mb: 262144
+
+postgresql_max_connections: 1000
+postgresql_shared_buffers: 32GB
+postgresql_effective_cache_size: 64GB

--- a/src/vars/tuning/extra-large.yml
+++ b/src/vars/tuning/extra-large.yml
@@ -1,3 +1,7 @@
 ---
 min_cpu_cores: 32
 min_ram_mb: 131072
+
+postgresql_max_connections: 1000
+postgresql_shared_buffers: 16GB
+postgresql_effective_cache_size: 32GB

--- a/src/vars/tuning/large.yml
+++ b/src/vars/tuning/large.yml
@@ -1,3 +1,7 @@
 ---
 min_cpu_cores: 16
 min_ram_mb: 65536
+
+postgresql_max_connections: 1000
+postgresql_shared_buffers: 8GB
+postgresql_effective_cache_size: 16GB

--- a/src/vars/tuning/medium.yml
+++ b/src/vars/tuning/medium.yml
@@ -1,3 +1,7 @@
 ---
 min_cpu_cores: 8
 min_ram_mb: 32768
+
+postgresql_max_connections: 1000
+postgresql_shared_buffers: 4GB
+postgresql_effective_cache_size: 8GB


### PR DESCRIPTION
We can only set:

- max_connections
- shared_buffers
- effective_cache_size

Because they're the only ones exposed as configurable by the container image.

Right now the ones missing from the non-containerized world would be:

- checkpoint_completion_target
- work_mem
- autovacuum_vacuum_cost_limit
- log_line_prefix
- log_min_duration_statement
- log_rotation_size