### PR TITLE
update  defaults to define 4 generic timers

### DIFF
--- a/src/roles/foreman/defaults/main.yaml
+++ b/src/roles/foreman/defaults/main.yaml
@@ -25,27 +25,15 @@ foreman_puma_workers: "{{ [32, ansible_facts['processor_nproc'] * 1.5, (ansible_
 
 foreman_recurring_tasks_enabled: true
 foreman_recurring_tasks:
-  - instance: reports-daily
-    rake: "reports:daily"
+  - instance: hourly
+    rake: "cron:hourly"
+    schedule: "hourly"
+  - instance: daily
+    rake: "cron:daily"
     schedule: "daily"
-  - instance: db-sessions-clear
-    rake: "db:sessions:clear"
-    schedule: "daily"
-  - instance: reports-expire
-    rake: "reports:expire"
-    schedule: "daily"
-  - instance: audits-expire
-    rake: "audits:expire"
-    schedule: "daily"
-  - instance: reports-weekly
-    rake: "reports:weekly"
+  - instance: weekly
+    rake: "cron:weekly"
     schedule: "weekly"
-  - instance: reports-monthly
-    rake: "reports:monthly"
+  - instance: monthly
+    rake: "cron:monthly"
     schedule: "monthly"
-  - instance: notifications-clean
-    rake: "notifications:clean"
-    schedule: "weekly"
-  - instance: ldap-refresh_usergroups
-    rake: "ldap:refresh_usergroups"
-    schedule: "*-*-* *:00,30:00"

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -6,14 +6,10 @@ FOREMAN_HOST = 'localhost'
 FOREMAN_PORT = 3000
 
 RECURRING_INSTANCES = [
-    "reports-daily",
-    "db-sessions-clear",
-    "reports-expire",
-    "audits-expire",
-    "reports-weekly",
-    "reports-monthly",
-    "notifications-clean",
-    "ldap-refresh_usergroups",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
 ]
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman/pull/10784
- Update `foreman_recurring_tasks` defaults to define 4 generic
  timers:
  * hourly → `cron:hourly`
  * daily → `cron:daily`
  * weekly → `cron:weekly`
  * monthly → `cron:monthly`
- Keep `ldap:refresh_usergroups` as a separate recurring job with
  its existing `OnCalendar` expression, since it runs every 30
  minutes and does not fit cleanly into the hourly/daily/weekly
  buckets yet.