### PR TITLE
SAT-40191 Compute resources & plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Add optional feature - foreman-proxy
         run: |
           ./foremanctl deploy --add-feature foreman-proxy
+      - name: Add optional feature - foreman_azure_rm and foreman_google
+        run: |
+          ./foremanctl deploy --add-feature foreman_azure_rm --add-feature foreman_google
       - name: Run tests
         run: |
           ./forge test --pytest-args="--certificate-source=${{ matrix.certificate_source }} --database-mode=${{ matrix.database }}"
@@ -211,6 +214,9 @@ jobs:
       - name: Add optional feature - foreman-proxy
         run: |
           ./foremanctl deploy --add-feature foreman-proxy
+      - name: Add optional feature - foreman_azure_rm and foreman_google
+        run: |
+          ./foremanctl deploy --add-feature foreman_azure_rm --add-feature foreman_google
       - name: Stop services
         run:
           vagrant ssh quadlet -- sudo systemctl stop foreman.target

--- a/tests/foreman_compute_resources_test.py
+++ b/tests/foreman_compute_resources_test.py
@@ -1,0 +1,10 @@
+import pytest
+
+FOREMAN_HOST = 'localhost'
+FOREMAN_PORT = 3000
+
+@pytest.mark.parametrize("compute_resource", ['AzureRm', 'EC2', 'GCE', 'Libvirt', 'Openstack', 'Vmware'])
+def test_foreman_compute_resources(server, compute_resource):
+    hammer = server.run("hammer compute-resource create --help | grep provider")
+    assert hammer.succeeded
+    assert compute_resource in hammer.stdout

--- a/tests/foreman_plugins_test.py
+++ b/tests/foreman_plugins_test.py
@@ -1,0 +1,6 @@
+import pytest
+
+@pytest.mark.parametrize("foreman_plugin", ['foreman_azure_rm', 'foreman_google'])
+def test_foreman_compute_resources(foremanapi, foreman_plugin):
+    plugins = [plugin['name'] for plugin in foremanapi.list('plugins')]
+    assert foreman_plugin in plugins


### PR DESCRIPTION
Allow enabling and installing of two features:
foreman_azure_rm  & foreman_google

This includes foreman plugins and hammer-cli plugins.

How to test:
```
foremanctl deploy --add-feature foreman_azure_rm
foremanctl deploy --add-feature foreman_google
```

Related tasks
* https://github.com/theforeman/foreman-oci-images/commit/5c09bfbc3dc5522e63991798b8484e04ee6d23c1