### PR TITLE
Refactor SSH config generation from vagrant to ansible inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build/
 foremanctl-*.tar.gz
 
 .var
+.tmp

--- a/development/playbooks/test/test.yaml
+++ b/development/playbooks/test/test.yaml
@@ -14,19 +14,32 @@
   hosts:
     - localhost
   tasks:
-    - name: Capture vagrant ssh-config
-      ansible.builtin.command:
-        cmd: vagrant ssh-config
-      args:
-        chdir: "{{ inventory_dir }}/../"
-      register: ssh_config
-      changed_when: false
-
-    - name: Write ssh_config
-      ansible.builtin.copy:
-        dest: "{{ inventory_dir }}/../.vagrant/ssh-config"
-        content: "{{ ssh_config.stdout }}"
+    - name: Ensure .tmp directory exists
+      ansible.builtin.file:
+        path: "{{ inventory_dir }}/../.tmp"
+        state: directory
         mode: "0755"
+
+    - name: Generate ssh_config from ansible inventory
+      ansible.builtin.copy:
+        dest: "{{ inventory_dir }}/../.tmp/ssh-config"
+        content: |
+          {% for host in groups['all'] %}
+          Host {{ host }}
+            HostName {{ hostvars[host]['ansible_host'] | default(host) }}
+            User {{ hostvars[host]['ansible_user'] | default('vagrant') }}
+            Port {{ hostvars[host]['ansible_port'] | default('22') }}
+            UserKnownHostsFile /dev/null
+            StrictHostKeyChecking no
+            PasswordAuthentication no
+          {% if hostvars[host]['ansible_ssh_private_key_file'] is defined %}
+            IdentityFile {{ hostvars[host]['ansible_ssh_private_key_file'] }}
+          {% endif %}
+            IdentitiesOnly yes
+            LogLevel FATAL
+
+          {% endfor %}
+        mode: "0644"
 
     - name: Run pytest
       ansible.builtin.command:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
-VAGRANT_SSH_CONFIG='./.vagrant/ssh-config'
+SSH_CONFIG='./.tmp/ssh-config'
 
 
 def pytest_addoption(parser):
@@ -44,17 +44,17 @@ def certificates(pytestconfig, server_fqdn):
 
 @pytest.fixture(scope="module")
 def server(server_hostname):
-    yield testinfra.get_host(f'paramiko://{server_hostname}', sudo=True, ssh_config=VAGRANT_SSH_CONFIG)
+    yield testinfra.get_host(f'paramiko://{server_hostname}', sudo=True, ssh_config=SSH_CONFIG)
 
 
 @pytest.fixture(scope="module")
 def client():
-    yield testinfra.get_host('paramiko://client', sudo=True, ssh_config=VAGRANT_SSH_CONFIG)
+    yield testinfra.get_host('paramiko://client', sudo=True, ssh_config=SSH_CONFIG)
 
 
 @pytest.fixture(scope="module")
 def ssh_config(server_hostname):
-    config = paramiko.SSHConfig.from_path(VAGRANT_SSH_CONFIG)
+    config = paramiko.SSHConfig.from_path(SSH_CONFIG)
     return config.lookup(server_hostname)
 
 


### PR DESCRIPTION
This is intended to allow running the test suite against more targets than just Vagrant environments.