### PR TITLE
Run `pulpcore-manager check --deploy` as part of the tests

### DIFF
--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -69,3 +69,7 @@ def test_pulp_worker_target(server):
     pulp_worker_target = server.service("pulp-worker.target")
     assert pulp_worker_target.is_running
     assert pulp_worker_target.is_enabled
+
+def test_pulp_manager_check(server):
+    result = server.run("podman exec -ti pulp-api pulpcore-manager check --deploy")
+    assert result.succeeded


### PR DESCRIPTION
Django has a checks framework that can detect problems in a deployment. It's also extensible and allows Pulp and plugin developers to add their own checks. This allows detection of misconfigurations.

Some checks run implicitly before running certain commands but others don't for performance reasons.

`--deploy` signals that a production setup is used, which enables more checks.

Ideally, we'd also run with `--fail-level WARNING`, but there are too many warnings right now to fix them all.

https://docs.djangoproject.com/en/5.2/topics/checks/