### PR TITLE
explicitly checkout ${{ github.ref }} when doing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        # the "ref: github.ref" is required for the tag to be properly checked out, as a workaround
+        # for https://github.com/actions/checkout/issues/1638
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.ref }}
       - name: Build tarball
         run: make dist
       - name: Upload tarball to GitHub cache


### PR DESCRIPTION
This is required for the tag to be properly checked out, as a workaround for https://github.com/actions/checkout/issues/1638