### PR TITLE
Add a command to deploy foremanctl with a set of default options for development.

### DIFF
--- a/development/playbooks/deploy-default/deploy-default.yaml
+++ b/development/playbooks/deploy-default/deploy-default.yaml
@@ -1,0 +1,8 @@
+---
+- name: Deploy Foreman with default settings
+  ansible.builtin.import_playbook: ../../../src/playbooks/deploy/deploy.yaml
+  vars:
+    foreman_initial_admin_password: changeme
+    features:
+      - hammer
+      - foreman-proxy

--- a/development/playbooks/deploy-default/metadata.obsah.yaml
+++ b/development/playbooks/deploy-default/metadata.obsah.yaml
@@ -1,0 +1,9 @@
+---
+help: |
+  Deploy Foreman with default settings including Hammer CLI and Foreman Proxy.
+  Uses password 'changeme' for the initial admin user.
+
+variables:
+  target_host:
+    help: Target hostname or IP address for deployment
+    action: store

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Setup quadlet demo machine
-  hosts:
-    - quadlet
+  hosts: "{{ target_host if target_host is defined and target_host != '' else 'quadlet' }}"
   become: true
   vars_files:
     - "../../vars/defaults.yml"


### PR DESCRIPTION
This is currently not working. @evgeni any idea why the vars in the playbook do not seem to pass through or override?