### PR TITLE
use network:host for redis too

### DIFF
--- a/src/roles/redis/tasks/main.yaml
+++ b/src/roles/redis/tasks/main.yaml
@@ -23,8 +23,7 @@
     command: ["run-redis", "--supervised", "systemd"]
     volumes:
       - /var/lib/redis:/data:Z
-    ports:
-      - "6379:6379"
+    network: host
     quadlet_options:
       - |
         [Install]


### PR DESCRIPTION
this is consistent with the other services and allows connecting via ipv6-localhost too