### PR TITLE
Switch to using nightly images

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,53 @@
 # Release
 
-To create a release, create a tag.
-It must follow the x.y.z pattern without any prefix.
+## Version Scheme
+
+- `master` always contains a tag with the current development version: `X.Y-develop`
+- Stable branches are named `X.Y-stable`
+- Release candidate tags on stable branches follow `X.Y.Z-rcN` (e.g. `3.18.0-rc1`)
+- Release tags on stable branches follow `X.Y.Z` (e.g., `3.18.0`, `3.18.1`)
+
+## Branching for a Release
+
+When ready to stabilize a version (e.g., 3.18):
+
+1. Create the stable branch from master:
+
+   ```
+   git fetch origin
+   git checkout -b 3.18-stable origin/master
+   git push --set-upstream origin HEAD
+   ```
+
+2. Update `src/vars/images.yml` on the stable branch to reference the release images (e.g., `3.18`).
+
+   ```
+   sed -i '/container_tag_stream:/ s/:.*/: "3.18"/' src/vars/images.yml
+   ```
+
+3. Bump master to the next development version:
+
+   ```
+   git checkout master
+   git tag -s "3.19-develop" -m "Start 3.19 development"
+   git push --follow-tags
+   ```
+
+## Cutting a Release
+
+To release from a stable branch (e.g., 3.18.0):
 
 ```
-VERSION=x.y.z
-git tag -s "$VERSION" -m "Release $VERSION"
+git checkout 3.18-stable
+git tag -s "3.18.0" -m "Release 3.18.0"
 git push --follow-tags
 ```
 
 This will create a GitHub release and attach the created tarball to it.
 
-Once that is done, the packaging is handled in the `foreman-packaging` repository where the spec file is maintained:
+## Packaging
+
+Once that is done, the packaging is handled in the [foreman-packaging](https://github.com/theforeman/foreman-packaging) repository where the spec file is maintained:
 
     obal update foremanctl --version $VERSION
     gh pr create --base rpm/develop

--- a/src/vars/images.yml
+++ b/src/vars/images.yml
@@ -6,7 +6,7 @@ postgresql_registry_auth_file: "{{ registry_auth_file }}"
 pulp_registry_auth_file: "{{ registry_auth_file }}"
 redis_registry_auth_file: "{{ registry_auth_file }}"
 
-container_tag_stream: "3.18"
+container_tag_stream: "nightly"
 candlepin_container_image: quay.io/foreman/candlepin
 candlepin_container_tag: "foreman-{{ container_tag_stream }}"
 foreman_container_image: quay.io/foreman/foreman


### PR DESCRIPTION
The mainline development branch for the installer should use the most up to date images as we iterate. This would change to use the nightly image tags going foward.