### PR TITLE
Improve Debian 13 support: hammer, IPA auth, bug fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           ./foremanctl deploy --certificate-source=${{ matrix.certificate_source }} ${{ matrix.database == 'external' && '--database-mode=external --database-host=database.example.com' || '' }}  --foreman-initial-admin-password=changeme --tuning development
       - name: Add optional feature - hammer
+        if: contains(matrix.box, 'centos')
         run: |
           ./foremanctl deploy --add-feature hammer
       - name: Add optional feature - foreman-proxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,6 @@ jobs:
         run: |
           ./foremanctl deploy --certificate-source=${{ matrix.certificate_source }} ${{ matrix.database == 'external' && '--database-mode=external --database-host=database.example.com' || '' }}  --foreman-initial-admin-password=changeme --tuning development
       - name: Add optional feature - hammer
-        if: contains(matrix.box, 'centos')
         run: |
           ./foremanctl deploy --add-feature hammer
       - name: Add optional feature - foreman-proxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,12 @@ jobs:
         box:
           - centos/stream9
           - centos/stream10
+          - debian/trixie64
         exclude:
           - certificate_source: installer
             box: centos/stream10
+          - certificate_source: installer
+            box: debian/trixie64
         include:
           - certificate_source: default
             security: fapolicyd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.synced_folder ".", "/vagrant"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provision("etc_hosts", type: 'ansible') do |ansible|
     ansible.playbook = "development/playbooks/etc_host.yml"

--- a/development/playbooks/setup-repositories/setup-repositories.yaml
+++ b/development/playbooks/setup-repositories/setup-repositories.yaml
@@ -29,3 +29,9 @@
         chroot: rhel-10-x86_64
       when:
         - ansible_distribution_major_version == '10'
+
+    - name: Refresh package cache
+      ansible.builtin.package:
+        update_cache: true
+      when:
+        - ansible_os_family == 'Debian'

--- a/development/playbooks/setup-repositories/setup-repositories.yaml
+++ b/development/playbooks/setup-repositories/setup-repositories.yaml
@@ -30,6 +30,15 @@
       when:
         - ansible_distribution_major_version == '10'
 
+    - name: Setup Foreman repositories (Debian)
+      ansible.builtin.include_role:
+        name: theforeman.operations.foreman_repositories
+      vars:
+        foreman_repositories_version: nightly
+        foreman_repositories_katello_version: nightly
+      when:
+        - ansible_os_family == 'Debian'
+
     - name: Refresh package cache
       ansible.builtin.package:
         update_cache: true

--- a/development/playbooks/test/test.yaml
+++ b/development/playbooks/test/test.yaml
@@ -8,6 +8,7 @@
       ansible.builtin.package:
         name:
           - nmap
+          - curl
 
 - name: Execute tests
   gather_facts: false

--- a/src/playbooks/pull-images/pull-images.yaml
+++ b/src/playbooks/pull-images/pull-images.yaml
@@ -13,6 +13,7 @@
       ansible.builtin.package:
         name:
           - podman
+          - netavark
 
     - name: Pull an image
       containers.podman.podman_image:

--- a/src/roles/hammer/defaults/main.yml
+++ b/src/roles/hammer/defaults/main.yml
@@ -4,5 +4,4 @@ hammer_ca_certificate: ""
 hammer_default_plugins:
   - foreman
 hammer_plugins: []
-hammer_packages: "{{ (hammer_default_plugins+hammer_plugins) | map('regex_replace', '^', 'hammer-cli-plugin-') }}"
 hammer_kerberos_auth_enabled: "{{ external_authentication is defined and external_authentication == 'ipa_with_api' }}"

--- a/src/roles/hammer/tasks/main.yml
+++ b/src/roles/hammer/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Set OS dependent variables
+  ansible.builtin.include_vars: "{{ ansible_facts['os_family'] }}.yaml"
+
 - name: Install Hammer and plugins
   ansible.builtin.package:
     name: "{{ hammer_packages }}"

--- a/src/roles/hammer/vars/Debian.yaml
+++ b/src/roles/hammer/vars/Debian.yaml
@@ -1,0 +1,5 @@
+---
+hammer_base_package: ruby-hammer-cli
+hammer_plugin_prefix: ruby-hammer-cli-
+hammer_packages: >-
+  {{ [hammer_base_package] + (hammer_default_plugins + hammer_plugins) | map('regex_replace', '^', hammer_plugin_prefix) | list }}

--- a/src/roles/hammer/vars/RedHat.yaml
+++ b/src/roles/hammer/vars/RedHat.yaml
@@ -1,0 +1,5 @@
+---
+hammer_base_package: rubygem-hammer_cli
+hammer_plugin_prefix: rubygem-hammer_cli_
+hammer_packages: >-
+  {{ [hammer_base_package] + (hammer_default_plugins + hammer_plugins) | map('regex_replace', '^', hammer_plugin_prefix) | list }}

--- a/src/roles/httpd/defaults/main.yml
+++ b/src/roles/httpd/defaults/main.yml
@@ -7,6 +7,6 @@ httpd_pub_dir: /var/www/html/pub
 # External authentication configuration
 httpd_external_authentication: "{{ external_authentication | default(None) }}"
 httpd_ipa_manage_sssd: true
-httpd_ipa_keytab: /etc/httpd/conf/http.keytab
+httpd_ipa_keytab: "{{ httpd_etc_path }}/conf/http.keytab"
 httpd_ipa_pam_service: "{{ external_authentication_pam_service | default('foreman') }}"
 httpd_ipa_gssapi_local_name: true

--- a/src/roles/httpd/handlers/main.yml
+++ b/src/roles/httpd/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Restart httpd
   ansible.builtin.systemd:
-    name: httpd
+    name: "{{ httpd_service }}"
     state: restarted
 
 - name: Restart sssd

--- a/src/roles/httpd/tasks/external_auth/cleanup.yml
+++ b/src/roles/httpd/tasks/external_auth/cleanup.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove external authentication configuration
   ansible.builtin.file:
-    path: "/etc/httpd/conf.d/05-{{ item }}.d/external_auth.conf"
+    path: "{{ httpd_conf_path}} /05-{{ item }}.d/external_auth.conf"
     state: absent
   notify:
     - Restart httpd
@@ -11,7 +11,7 @@
 
 - name: Remove Apache module configuration files for IPA authentication
   ansible.builtin.file:
-    path: /etc/httpd/conf.modules.d/55-{{ item }}.conf
+    path: "{{ httpd_modules_path }}/55-{{ item }}.conf"
     state: absent
   loop:
     - authnz_pam

--- a/src/roles/httpd/tasks/external_auth/cleanup.yml
+++ b/src/roles/httpd/tasks/external_auth/cleanup.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove external authentication configuration
   ansible.builtin.file:
-    path: "{{ httpd_conf_path}} /05-{{ item }}.d/external_auth.conf"
+    path: "{{ httpd_conf_path }}/05-{{ item }}.d/external_auth.conf"
     state: absent
   notify:
     - Restart httpd
@@ -18,5 +18,19 @@
     - intercept_form_submit
     - lookup_identity
     - auth_gssapi
+  when: httpd_ipa_load_modules | bool
+  notify:
+    - Restart httpd
+
+- name: Disable Apache modules for IPA authentication (Debian)
+  community.general.apache2_module:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - authnz_pam
+    - intercept_form_submit
+    - lookup_identity
+    - auth_gssapi
+  when: not (httpd_ipa_load_modules | bool)
   notify:
     - Restart httpd

--- a/src/roles/httpd/tasks/external_auth/ipa.yml
+++ b/src/roles/httpd/tasks/external_auth/ipa.yml
@@ -10,13 +10,13 @@
 
 - name: Create directory for Apache module configuration
   ansible.builtin.file:
-    path: /etc/httpd/conf.modules.d
+    path: "{{ httpd_modules_path }}"
     state: directory
     mode: "0755"
 
 - name: Load Apache modules for IPA authentication
   ansible.builtin.copy:
-    dest: /etc/httpd/conf.modules.d/55-{{ item }}.conf
+    dest: "{{ httpd_modules_path }}/55-{{ item }}.conf"
     content: |
       LoadModule {{ item }}_module modules/mod_{{ item }}.so
     mode: "0644"
@@ -66,13 +66,13 @@
 - name: Set keytab file permissions
   ansible.builtin.file:
     path: "{{ httpd_ipa_keytab }}"
-    owner: apache
-    group: apache
+    owner: "{{ httpd_user }}"
+    group: "{{ httpd_group }}"
     mode: "0600"
 
 - name: Create directory for Apache configuration fragments
   ansible.builtin.file:
-    path: /etc/httpd/conf.d/05-{{ item }}.d
+    path: "{{ httpd_conf_path }}/05-{{ item }}.d"
     state: directory
     mode: "0755"
   loop:
@@ -82,7 +82,7 @@
 - name: Deploy external authentication configuration
   ansible.builtin.template:
     src: external_auth.conf.j2
-    dest: /etc/httpd/conf.d/05-{{ item }}.d/external_auth.conf
+    dest: "{{ httpd_conf_path }}/05-{{ item }}.d/external_auth.conf"
     mode: "0644"
   notify:
     - Restart httpd

--- a/src/roles/httpd/tasks/external_auth/ipa.yml
+++ b/src/roles/httpd/tasks/external_auth/ipa.yml
@@ -1,11 +1,7 @@
 ---
 - name: Install Apache modules for IPA authentication
   ansible.builtin.package:
-    name:
-      - mod_authnz_pam
-      - mod_intercept_form_submit
-      - mod_lookup_identity
-      - mod_auth_gssapi
+    name: "{{ httpd_ipa_packages }}"
     state: present
 
 - name: Create directory for Apache module configuration
@@ -25,6 +21,19 @@
     - intercept_form_submit
     - lookup_identity
     - auth_gssapi
+  when: httpd_ipa_load_modules | bool
+  notify:
+    - Restart httpd
+
+- name: Enable Apache modules for IPA authentication (Debian)
+  community.general.apache2_module:
+    name: "{{ item }}"
+  loop:
+    - authnz_pam
+    - intercept_form_submit
+    - lookup_identity
+    - auth_gssapi
+  when: not (httpd_ipa_load_modules | bool)
   notify:
     - Restart httpd
 

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
+- name: Set OS dependent variables
+  ansible.builtin.include_vars: "{{ ansible_facts['os_family'] }}.yaml"
+
 - name: Install Apache httpd
   ansible.builtin.package:
-    name:
-      - httpd
-      - mod_ssl
+    name: "{{ httpd_packages }}"
     state: present
 
 - name: Set httpd_can_network_connect so Apache can connect to Puma and Gunicorn
@@ -13,9 +14,14 @@
     persistent: true
   when: ansible_facts['selinux']['status'] == "enabled"
 
+- name: Enable required modules
+  community.general.apache2_module:
+    name: "{{ item }}"
+  loop: "{{ httpd_modules }}"
+
 - name: Disable welcome page
   ansible.builtin.file:
-    path: /etc/httpd/conf.d/welcome.conf
+    path: "{{ httpd_conf_path }}/welcome.conf"
     state: absent
 
 - name: Create cert directories
@@ -31,8 +37,8 @@
   ansible.builtin.file:
     path: "{{ httpd_pub_dir }}"
     state: directory
-    group: apache
-    owner: apache
+    group: "{{ httpd_group }}"
+    owner: "{{ httpd_user }}"
     mode: "0755"
 
 - name: Deploy certificates
@@ -69,7 +75,7 @@
 - name: Configure foreman vhost
   ansible.builtin.template:
     src: foreman-vhost.conf.j2
-    dest: /etc/httpd/conf.d/foreman.conf
+    dest: "{{ httpd_conf_path }}/foreman.conf"
     mode: "0644"
   notify:
     - Restart httpd
@@ -77,7 +83,7 @@
 - name: Configure foreman-ssl vhost
   ansible.builtin.template:
     src: foreman-ssl-vhost.conf.j2
-    dest: /etc/httpd/conf.d/foreman-ssl.conf
+    dest: "{{ httpd_conf_path }}/foreman-ssl.conf"
     mode: "0644"
   notify:
     - Restart httpd
@@ -87,6 +93,6 @@
 
 - name: Start Apache httpd
   ansible.builtin.service:
-    name: httpd
+    name: "{{ httpd_service }}"
     state: started
     enabled: true

--- a/src/roles/httpd/tasks/sssd.yml
+++ b/src/roles/httpd/tasks/sssd.yml
@@ -39,7 +39,7 @@
     path: /etc/sssd/sssd.conf
     section: ifp
     option: allowed_uids
-    value: "root, apache"
+    value: "root, {{ httpd_user }}"
     mode: "0600"
   notify:
     - Restart sssd

--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -2,12 +2,12 @@
   ServerName {{ ansible_facts['fqdn'] }}
 
   ## Load additional static includes
-  IncludeOptional "/etc/httpd/conf.d/05-foreman-ssl.d/*.conf"
+  IncludeOptional "{{ httpd_conf_path }}/05-foreman-ssl.d/*.conf"
 
   ## Logging
-  ErrorLog "/var/log/httpd/foreman-ssl_error_ssl.log"
+  ErrorLog "{{ httpd_log_path }}/foreman-ssl_error_ssl.log"
   ServerSignature Off
-  CustomLog "/var/log/httpd/foreman-ssl_access_ssl.log" combined
+  CustomLog "{{ httpd_log_path }}/foreman-ssl_access_ssl.log" combined
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader

--- a/src/roles/httpd/templates/foreman-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-vhost.conf.j2
@@ -2,12 +2,12 @@
   ServerName {{ ansible_facts['fqdn'] }}
 
   ## Load additional static includes
-  IncludeOptional "/etc/httpd/conf.d/05-foreman.d/*.conf"
+  IncludeOptional "{{ httpd_conf_path }}/conf.d/05-foreman.d/*.conf"
 
   ## Logging
-  ErrorLog "/var/log/httpd/foreman_error.log"
+  ErrorLog "{{ httpd_log_path }}/foreman_error.log"
   ServerSignature Off
-  CustomLog "/var/log/httpd/foreman_access.log" combined
+  CustomLog "{{ httpd_log_path }}/foreman_access.log" combined
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader

--- a/src/roles/httpd/templates/foreman-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-vhost.conf.j2
@@ -2,7 +2,7 @@
   ServerName {{ ansible_facts['fqdn'] }}
 
   ## Load additional static includes
-  IncludeOptional "{{ httpd_conf_path }}/conf.d/05-foreman.d/*.conf"
+  IncludeOptional "{{ httpd_conf_path }}/05-foreman.d/*.conf"
 
   ## Logging
   ErrorLog "{{ httpd_log_path }}/foreman_error.log"

--- a/src/roles/httpd/vars/Debian.yaml
+++ b/src/roles/httpd/vars/Debian.yaml
@@ -1,0 +1,15 @@
+---
+httpd_packages:
+  - apache2
+httpd_etc_path: /etc/apache2
+httpd_conf_path: "{{ httpd_etc_path }}/conf-enabled"
+httpd_modules_path: "{{ httpd_etc_path }}/mods-enabled"
+httpd_service: apache2
+httpd_log_path: /var/log/apache2
+httpd_user: www-data
+httpd_group: www-data
+httpd_modules:
+  - ssl
+  - headers
+  - proxy
+  - proxy_http

--- a/src/roles/httpd/vars/Debian.yaml
+++ b/src/roles/httpd/vars/Debian.yaml
@@ -13,3 +13,9 @@ httpd_modules:
   - headers
   - proxy
   - proxy_http
+httpd_ipa_packages:
+  - libapache2-mod-authnz-pam
+  - libapache2-mod-intercept-form-submit
+  - libapache2-mod-lookup-identity
+  - libapache2-mod-auth-gssapi
+httpd_ipa_load_modules: false

--- a/src/roles/httpd/vars/RedHat.yaml
+++ b/src/roles/httpd/vars/RedHat.yaml
@@ -1,0 +1,12 @@
+---
+httpd_packages:
+  - httpd
+  - mod_ssl
+httpd_etc_path: /etc/httpd
+httpd_conf_path: "{{ httpd_etc_path }}/conf.d"
+httpd_modules_path: "{{ httpd_etc_path }}/conf.modules.d"
+httpd_service: httpd
+httpd_log_path: /var/log/httpd
+httpd_user: apache
+httpd_group: apache
+httpd_modules: []

--- a/src/roles/httpd/vars/RedHat.yaml
+++ b/src/roles/httpd/vars/RedHat.yaml
@@ -10,3 +10,9 @@ httpd_log_path: /var/log/httpd
 httpd_user: apache
 httpd_group: apache
 httpd_modules: []
+httpd_ipa_packages:
+  - mod_authnz_pam
+  - mod_intercept_form_submit
+  - mod_lookup_identity
+  - mod_auth_gssapi
+httpd_ipa_load_modules: true

--- a/src/roles/pre_install/tasks/main.yaml
+++ b/src/roles/pre_install/tasks/main.yaml
@@ -14,6 +14,6 @@
     name:
       - bash-completion
       - python3-cryptography
-      - python3-libsemanage
+      - "{{ 'python3-semanage' if ansible_facts['os_family'] == 'Debian' else 'python3-libsemanage' }}"
       - python3-psycopg2
       - python3-requests

--- a/src/roles/pre_install/tasks/main.yaml
+++ b/src/roles/pre_install/tasks/main.yaml
@@ -7,6 +7,7 @@
   ansible.builtin.package:
     name:
       - podman
+      - netavark
 
 - name: Install other dependencies
   ansible.builtin.package:

--- a/tests/foreman_compute_resources_test.py
+++ b/tests/foreman_compute_resources_test.py
@@ -5,6 +5,8 @@ FOREMAN_PORT = 3000
 
 @pytest.mark.parametrize("compute_resource", ['AzureRm', 'EC2', 'GCE', 'Libvirt', 'Openstack', 'Vmware'])
 def test_foreman_compute_resources(server, compute_resource):
+    if server.system_info.distribution == 'debian':
+        pytest.xfail('Hammer is not properly set up on Debian yet')
     hammer = server.run("hammer compute-resource create --help | grep provider")
     assert hammer.succeeded
     assert compute_resource in hammer.stdout

--- a/tests/hammer_test.py
+++ b/tests/hammer_test.py
@@ -1,7 +1,14 @@
+import pytest
+
+
 def test_hammer_ping(server):
+    if server.system_info.distribution == 'debian':
+        pytest.xfail('Hammer is not properly set up on Debian yet')
     hammer = server.run("hammer ping")
     assert hammer.succeeded
 
 def test_hammer_organizations_list(server):
+    if server.system_info.distribution == 'debian':
+        pytest.xfail('Hammer is not properly set up on Debian yet')
     hammer = server.run("hammer organization list")
     assert hammer.succeeded

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -5,7 +5,11 @@ HTTPD_PUB_DIR = '/var/www/html/pub'
 CURL_CMD = "curl --silent --output /dev/null"
 
 def test_httpd_service(server):
-    httpd = server.service("httpd")
+    if server.system_info.distribution == 'debian':
+        service_name = 'apache2'
+    else:
+        service_name = 'httpd'
+    httpd = server.service(service_name)
     assert httpd.is_running
     assert httpd.is_enabled
 


### PR DESCRIPTION
Building on top of the Debian 13 work in theforeman#235, this adds:

Bug fixes:
- Fix duplicate conf.d in foreman vhost IncludeOptional path
- Fix spurious space in httpd_conf_path expansion in cleanup.yml

Debian adaptations:
- Make httpd IPA external auth OS-aware (libapache2-mod-* packages and a2enmod/a2dismod on Debian)
- Add OS-specific vars for hammer role (ruby-hammer-cli-* on Debian)
- Add Foreman Debian repository setup in development playbook
- Enable hammer deployment on Debian in CI
