### PR TITLE
Fixes #72 - Replace sidekiq-selinux wrapper with direct sidekiq call

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -154,7 +154,7 @@
       DYNFLOW_REDIS_URL: "redis://localhost:6379/6"
       REDIS_PROVIDER: "DYNFLOW_REDIS_URL"
       FOREMAN_ENABLED_PLUGINS: "{{ foreman_plugins | join(' ') }}"
-    command: "/usr/libexec/foreman/sidekiq-selinux -e production -r ./extras/dynflow-sidekiq.rb -C /etc/foreman/dynflow/%i.yml"
+    command: "sidekiq -e production -r /usr/share/foreman/extras/dynflow-sidekiq.rb -C /etc/foreman/dynflow/%i.yml"
     quadlet_options:
       - |
         [Install]


### PR DESCRIPTION
The sidekiq-selinux wrapper at /usr/libexec/foreman/sidekiq-selinux is a packaging artifact that only exists for SELinux domain transition on bare-metal RPM installations. Its entire content is:

    exec sidekiq "\'$@"\'

In containers where SELinux is disabled (label=disable), this wrapper serves no purpose. This replaces the wrapper call with a direct sidekiq invocation and uses an absolute path for the dynflow-sidekiq.rb script.

Based on the discussion in https://github.com/evgeni/talks/pull/4#discussion_r1932083989

cc @ekohl @evgeni