### PR TITLE
Reduce service healthcheck interval

### DIFF
--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -101,6 +101,7 @@
         [Service]
         TimeoutStartSec=300
     healthcheck: curl --fail --insecure https://localhost:23443/candlepin/status
+    healthcheck_interval: 5s
     sdnotify: healthy
 
 - name: Run daemon reload to make Quadlet create the service files

--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -91,7 +91,9 @@
         [Service]
         TimeoutStartSec=300
     healthcheck: curl --fail --insecure https://localhost:23443/candlepin/status
+    health_startup_cmd: curl --fail --insecure https://localhost:23443/candlepin/status
     health_startup_interval: 5s
+    health_on_failure: kill
     sdnotify: healthy
 
 - name: Run daemon reload to make Quadlet create the service files

--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -91,6 +91,7 @@
         [Service]
         TimeoutStartSec=300
     healthcheck: curl --fail --insecure https://localhost:23443/candlepin/status
+    health_startup_interval: 5s
     sdnotify: healthy
 
 - name: Run daemon reload to make Quadlet create the service files

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -27,6 +27,7 @@
     image: "{{ postgresql_container_image }}:{{ postgresql_container_tag }}"
     state: quadlet
     healthcheck: pg_isready
+    healthcheck_interval: 5s
     sdnotify: healthy
     network: host
     volumes:

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -27,6 +27,7 @@
     image: "{{ postgresql_container_image }}:{{ postgresql_container_tag }}"
     state: quadlet
     healthcheck: pg_isready
+    health_startup_interval: 5s
     sdnotify: healthy
     network: host
     volumes:

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -27,7 +27,9 @@
     image: "{{ postgresql_container_image }}:{{ postgresql_container_tag }}"
     state: quadlet
     healthcheck: pg_isready
+    health_startup_cmd: pg_isready
     health_startup_interval: 5s
+    health_on_failure: kill
     sdnotify: healthy
     network: host
     volumes:
@@ -44,6 +46,9 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
+        After=foreman.target
+        [Service]
+        TimeoutStartSec=300
   notify:
     - Restart postgresql
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Candlepin and PostgreSQL both use `sdnotify: healthy`, which holds systemd's READY signal
until Podman marks the container healthy. Without a fast startup health check, the first
health check fires at the default 30s regular interval — meaning the service could sit fully
ready for up to 30s before systemd considers it started, adding unnecessary time to every
deployment.

Podman's startup health check system (separate from the regular ongoing check) allows polling
at a faster rate during initialisation, but it is only engaged when `health_startup_cmd` is
explicitly set. Without it, `health_startup_interval` is silently ignored.

Additionally, PostgreSQL was missing `TimeoutStartSec=300` in its quadlet options. With
`sdnotify: healthy` holding systemd's READY signal until the health check passes, a slow
Postgres initialisation would cause systemd to abort the service under its default 90s timeout.

#### What are the changes introduced in this pull request?

* **`health_startup_cmd`** (Candlepin, PostgreSQL): Podman has two independent health check
  systems — a startup check that runs during initialisation, and a regular check that takes
  over once the container is healthy. The startup system is only engaged when
  `health_startup_cmd` is set; without it `health_startup_interval` is silently ignored and
  the container falls back to the regular 30s interval. Setting `health_startup_cmd` to the
  same command as `healthcheck` activates the fast 5s startup polling with no change in what
  is checked. ([podman-systemd.unit(5)](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html))

* **`health_on_failure: kill`** (Candlepin, PostgreSQL): When a container running under
  systemd becomes unhealthy post-startup, the `kill` action terminates the container and lets
  systemd's `Restart=` policy handle recovery. This is the integration Podman recommends over
  the container-internal `restart` action, which bypasses systemd's restart tracking and
  rate-limiting entirely. ([Podman at the edge: Keeping services alive with custom healthcheck actions](https://www.redhat.com/en/blog/podman-edge-healthcheck))

* **`TimeoutStartSec=300`** (PostgreSQL): With `sdnotify: healthy` (`Notify=healthy` in the
  quadlet), systemd holds the service in the `activating` state until Podman signals healthy.
  If that takes longer than systemd's default `TimeoutStartSec` of 90s, systemd kills the
  service and marks it failed — even if Postgres was still initialising normally. Setting
  `TimeoutStartSec=300` matches the existing Candlepin value and gives PostgreSQL the same
  headroom. ([containers/podman#27290](https://github.com/containers/podman/issues/27290))

#### How to test this pull request

Steps to reproduce:

* Deploy with `foremanctl install` and observe that Candlepin and PostgreSQL services reach
  the `active (running)` state faster than before (startup health checks fire every 5s rather
  than 30s).
* Confirm both services start cleanly: `systemctl status candlepin postgresql`
* Optionally, stop one of the containers mid-run (`podman stop postgresql`) and confirm
  systemd restarts the service automatically via the kill-on-failure path.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
