### PR TITLE
Add apache config support for /pypi

### DIFF
--- a/src/roles/httpd/defaults/main.yml
+++ b/src/roles/httpd/defaults/main.yml
@@ -3,6 +3,7 @@ httpd_pulp_api_backend: http://localhost:24817
 httpd_pulp_content_backend: http://localhost:24816
 httpd_foreman_backend: http://localhost:3000
 httpd_pub_dir: /var/www/html/pub
+httpd_enabled_pulp_snippets: []
 
 # MPM event module defaults
 httpd_server_limit: 25

--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -68,6 +68,10 @@
     ProxyPassReverse {{ httpd_pulp_content_backend }}/pulp/content
   </Location>
 
+{% for httpd_pulp_snippet in httpd_enabled_pulp_snippets %}
+{% include httpd_pulp_snippet+'.j2' %}
+{% endfor %}
+
   <Location "/pulp/api/v3">
     RequestHeader unset REMOTE_USER
     RequestHeader unset REMOTE-USER

--- a/src/roles/httpd/templates/pypi.j2
+++ b/src/roles/httpd/templates/pypi.j2
@@ -1,0 +1,7 @@
+  <Location "/pypi">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    RequestHeader set X-FORWARDED-PROTO expr=%{REQUEST_SCHEME}
+    ProxyPass {{ httpd_pulp_api_backend }}/pypi timeout=600
+    ProxyPassReverse {{ httpd_pulp_api_backend }}/pypi
+  </Location>

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -26,6 +26,7 @@ httpd_server_ca_certificate: "{{ server_ca_certificate }}"
 httpd_client_ca_certificate: "{{ client_ca_certificate }}"
 httpd_server_certificate: "{{ server_certificate }}"
 httpd_server_key: "{{ server_key }}"
+httpd_enabled_pulp_snippets: "{{ ['pypi'] if 'pulp_python' in pulp_plugins else [] }}"
 
 pulp_content_origin: "https://{{ ansible_facts['fqdn'] }}"
 pulp_pulp_url: "https://{{ ansible_facts['fqdn'] }}"

--- a/src/vars/flavors/katello.yml
+++ b/src/vars/flavors/katello.yml
@@ -5,4 +5,5 @@ flavor_features:
   - content/ansible
   - content/container
   - content/deb
+  - content/python
   - content/rpm

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -63,6 +63,14 @@ def test_https_pulp_auth(server, certificates, server_fqdn):
     assert cmd.stdout == '200'
 
 
+def test_https_pypi_endpoint(server, certificates, server_fqdn):
+    cmd = server.run(f"curl --cacert {certificates['server_ca_certificate']} https://{server_fqdn}/pypi/test/")
+    assert cmd.succeeded
+    # Verify route proxies to Pulp's Python plugin by checking for PythonDistribution in response
+    # (Rails or unconfigured routes would return different errors)
+    assert "PythonDistribution" in cmd.stdout
+
+
 def test_pub_directory_exists(server):
     pub_dir = server.file(HTTPD_PUB_DIR)
     assert pub_dir.exists


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Add Apache config support for /pypi in foremanctl

Fixes [SAT-44475](https://redhat.atlassian.net/browse/SAT-44475)

#### What are the changes introduced in this pull request?

* Added `<Location "/pypi">` block in `foreman-ssl-vhost.conf.j2` to proxy requests to Pulp API backend
* Configured required headers: X-CLIENT-CERT, X-FORWARDED-PROTO
* Set timeout to 600 seconds (matching other Pulp API routes)

#### How to test this pull request

Steps to reproduce:

* Deploy the changes
* SSH into the VM
* Verify the Apache configuration was generated:
   `grep -A 6 'Location "/pypi"' /etc/httpd/conf.d/foreman-ssl.conf`
* Expected: Should show the /pypi Location block with correct headers and proxy settings

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
