### PR TITLE
Remove candlepin events service and ssl config

### DIFF
--- a/development/roles/foreman_development/templates/katello.yaml.j2
+++ b/development/roles/foreman_development/templates/katello.yaml.j2
@@ -11,9 +11,4 @@
     :oauth_secret: {{ candlepin_oauth_secret }}
     :ca_cert_file: {{ foreman_development_cert_dir }}/proxy_ca.pem
 
-  :candlepin_events:
-    :ssl_cert_file: {{ foreman_development_cert_dir }}/client_cert.pem
-    :ssl_key_file: {{ foreman_development_cert_dir }}/client_key.pem
-    :ssl_ca_file: {{ foreman_development_cert_dir }}/proxy_ca.pem
-
   :katello_applicability: true

--- a/src/roles/foreman/templates/katello.yaml.j2
+++ b/src/roles/foreman/templates/katello.yaml.j2
@@ -8,11 +8,5 @@
     :oauth_secret: "{{ candlepin_oauth_secret }}"
     :ca_cert_file: /etc/foreman/katello-default-ca.crt
 
-  :candlepin_events:
-    :broker_host: localhost
-    :ssl_cert_file: /etc/foreman/client_cert.pem
-    :ssl_key_file: /etc/foreman/client_key.pem
-    :ssl_ca_file: /etc/foreman/katello-default-ca.crt
-
   :pulp:
     :ca_cert_file: /etc/foreman/katello-default-ca.crt

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -50,7 +50,7 @@ def test_foreman_status_cache(foreman_status):
     assert foreman_status['results']['foreman']['cache']['servers'][0]['status'] == 'ok'
 
 
-@pytest.mark.parametrize("katello_service", ['candlepin', 'candlepin_auth', 'candlepin_events', 'foreman_tasks', 'katello_events', 'pulp3', 'pulp3_content'])
+@pytest.mark.parametrize("katello_service", ['candlepin', 'candlepin_auth', 'foreman_tasks', 'katello_events', 'pulp3', 'pulp3_content'])
 def test_katello_services_status(foreman_status, katello_service):
     assert foreman_status['results']['katello']['services'][katello_service]['status'] == 'ok'
 


### PR DESCRIPTION
Since the `candlepin_events` service has been removed [here](https://github.com/theforeman/puppet-katello/pull/525), I am removing it from foremanctl as well, as it is no longer required.