### PR TITLE
Add allowed content checksums to pulp settings

### DIFF
--- a/src/roles/pulp/defaults/main.yaml
+++ b/src/roles/pulp/defaults/main.yaml
@@ -66,6 +66,8 @@ pulp_settings_other_env:
   PULP_CONTENT_WORKERS: "{{ pulp_content_service_worker_count }}"
   PULP_TOKEN_AUTH_DISABLED: "true"
   PULP_FLATPAK_INDEX: "true"
+  PULP_ALLOWED_CONTENT_CHECKSUMS: >-
+    ['sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
 pulp_settings_env: "{{ pulp_settings_database_env | ansible.builtin.combine(pulp_settings_other_env) }}"
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Adding allowed content checksums to pulp settings.
#### What are the changes introduced in this pull request?

* Add ALLOWED_CONTENT_CHECKSUMS

#### How to test this pull request

Steps to reproduce:

* Run a ./forge deploy-dev .. to get a running katello instance.
The /etc/containers/systemd/pulp-api.container should contain the allowed content checksum values allowed.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
