### PR TITLE
use role-specific vars for url and oauth in foreman_proxy and hammer

### DIFF
--- a/src/roles/foreman_proxy/defaults/main.yaml
+++ b/src/roles/foreman_proxy/defaults/main.yaml
@@ -17,3 +17,5 @@ foreman_proxy_plugins: []
 foreman_proxy_features: "{{ foreman_proxy_base_features + foreman_proxy_plugins }}"
 foreman_proxy_available_features: "{{ [] | available_foreman_proxy_plugins }}"
 foreman_proxy_disabled_features: "{{ foreman_proxy_available_features | difference(foreman_proxy_features) }}"
+
+foreman_proxy_foreman_server_url: "https://{{ ansible_facts['fqdn'] }}"

--- a/src/roles/foreman_proxy/handlers/main.yml
+++ b/src/roles/foreman_proxy/handlers/main.yml
@@ -7,7 +7,7 @@
 - name: Refresh Foreman Proxy
   theforeman.foreman.smart_proxy_refresh:
     smart_proxy: "{{ foreman_proxy_name }}"
-    server_url: "{{ foreman_url }}"
-    oauth1_consumer_key: "{{ foreman_oauth_consumer_key }}"
-    oauth1_consumer_secret: "{{ foreman_oauth_consumer_secret }}"
+    server_url: "{{ foreman_proxy_foreman_server_url }}"
+    oauth1_consumer_key: "{{ foreman_proxy_oauth_consumer_key }}"
+    oauth1_consumer_secret: "{{ foreman_proxy_oauth_consumer_secret }}"
     validate_certs: false

--- a/src/roles/foreman_proxy/tasks/main.yaml
+++ b/src/roles/foreman_proxy/tasks/main.yaml
@@ -74,9 +74,9 @@
   theforeman.foreman.smart_proxy:
     name: "{{ foreman_proxy_name }}"
     url: "{{ foreman_proxy_url }}"
-    server_url: "{{ foreman_url }}"
-    oauth1_consumer_key: "{{ foreman_oauth_consumer_key }}"
-    oauth1_consumer_secret: "{{ foreman_oauth_consumer_secret }}"
+    server_url: "{{ foreman_proxy_foreman_server_url }}"
+    oauth1_consumer_key: "{{ foreman_proxy_oauth_consumer_key }}"
+    oauth1_consumer_secret: "{{ foreman_proxy_oauth_consumer_secret }}"
     validate_certs: false
 
 - name: Flush handlers to restart services

--- a/src/roles/foreman_proxy/templates/settings.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.yml.j2
@@ -1,6 +1,6 @@
 :settings_directory: /etc/foreman-proxy/settings.d
 
-:foreman_url: {{ foreman_url }}
+:foreman_url: {{ foreman_proxy_foreman_server_url }}
 :trusted_hosts: {{ foreman_proxy_trusted_hosts }}
 
 :https_port: {{ foreman_proxy_https_port }}

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -32,5 +32,9 @@ pulp_plugins: "{{ enabled_features | select('contains', 'content/') | map('repla
 
 hammer_ca_certificate: "{{ server_ca_certificate }}"
 hammer_plugins: "{{ enabled_features | features_to_hammer_plugins }}"
+hammer_foreman_server_url: "{{ foreman_url }}"
 
 foreman_proxy_plugins: "{{ enabled_features | features_to_foreman_proxy_plugins }}"
+foreman_proxy_foreman_server_url: "{{ foreman_url }}"
+foreman_proxy_oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
+foreman_proxy_oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

we forgot to use role-specific vars for accessing foreman inside the hammer and foreman_proxy roles

#### What are the changes introduced in this pull request?

* introduce and use those vars

#### How to test this pull request

CI

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
