### PR TITLE
Swap development to use oauth to register smart_proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
           ./forge setup-repositories
       - name: Run deployment
         run: |
-          ./forge deploy-dev --foreman-development-enabled-plugin foreman_ansible
+          ./forge deploy-dev --foreman-development-enabled-plugin foreman_ansible --add-feature foreman-proxy --add-feature hammer
       - name: Setup upterm session
         if: ${{ failure() }}
         uses: owenthereal/action-upterm@v1

--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -39,6 +39,10 @@
     - role: httpd
     - role: pulp
     - role: foreman_development
+      vars:
+        foreman_development_oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
+        foreman_development_oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"
+        foreman_development_candlepin_oauth_secret: "{{ candlepin_oauth_secret }}"
   post_tasks:
     - name: Display development environment information
       ansible.builtin.debug:

--- a/development/requirements.yml
+++ b/development/requirements.yml
@@ -9,4 +9,5 @@ collections:
   - name: https://github.com/theforeman/forklift
     type: git
   - name: theforeman.foreman
+    version: ">=5.11.0"
   - name: theforeman.operations

--- a/development/roles/foreman_development/defaults/main.yaml
+++ b/development/roles/foreman_development/defaults/main.yaml
@@ -14,6 +14,8 @@ foreman_development_client_key: "{{ foreman_client_key }}"
 foreman_development_admin_user: "admin"
 foreman_development_admin_password: "changeme"
 
+foreman_development_candlepin_url: "https://localhost:23443/candlepin"
+
 foreman_development_git_repo: "https://github.com/theforeman/foreman.git"
 foreman_development_git_revision: "develop"
 foreman_development_github_username: ""

--- a/development/roles/foreman_development/tasks/smart-proxy/main.yml
+++ b/development/roles/foreman_development/tasks/smart-proxy/main.yml
@@ -141,8 +141,8 @@
     name: "{{ ansible_facts['fqdn'] }}-dev"
     url: "https://{{ ansible_facts['fqdn'] }}:8443"
     server_url: "{{ foreman_development_url }}"
-    username: "{{ foreman_development_admin_user }}"
-    password: "{{ foreman_development_admin_password }}"
+    oauth1_consumer_key: "{{ foreman_development_oauth_consumer_key }}"
+    oauth1_consumer_secret: "{{ foreman_development_oauth_consumer_secret }}"
     ca_path: "{{ foreman_development_ca_certificate }}"
 
 - name: Stop development services after smart proxy registration

--- a/development/roles/foreman_development/templates/katello.yaml.j2
+++ b/development/roles/foreman_development/templates/katello.yaml.j2
@@ -6,9 +6,9 @@
   :katello_applicability: true
 
   :candlepin:
-    :url: {{ candlepin_url | default('https://localhost:23443/candlepin') }}
-    :oauth_key: katello
-    :oauth_secret: {{ candlepin_oauth_secret }}
+    :url: {{ foreman_development_candlepin_url }}
+    :oauth_key: {{ foreman_development_oauth_consumer_key }}
+    :oauth_secret: {{ foreman_development_candlepin_oauth_secret }}
     :ca_cert_file: {{ foreman_development_cert_dir }}/proxy_ca.pem
 
   :candlepin_events:

--- a/development/roles/foreman_development/templates/katello.yaml.j2
+++ b/development/roles/foreman_development/templates/katello.yaml.j2
@@ -7,7 +7,7 @@
 
   :candlepin:
     :url: {{ foreman_development_candlepin_url }}
-    :oauth_key: {{ foreman_development_oauth_consumer_key }}
+    :oauth_key: katello
     :oauth_secret: {{ foreman_development_candlepin_oauth_secret }}
     :ca_cert_file: {{ foreman_development_cert_dir }}/proxy_ca.pem
 

--- a/development/roles/foreman_development/templates/settings.yaml.j2
+++ b/development/roles/foreman_development/templates/settings.yaml.j2
@@ -9,9 +9,9 @@
 
 # The following values are used for providing default settings during db migrate
 :oauth_active: true
-:oauth_map_users: true
-:oauth_consumer_key: {{ candlepin_oauth_key | default('katello') }}
-:oauth_consumer_secret: {{ candlepin_oauth_secret }}
+:oauth_map_users: false
+:oauth_consumer_key: {{ foreman_development_oauth_consumer_key }}
+:oauth_consumer_secret: {{ foreman_development_oauth_consumer_secret }}
 
 # SSL settings
 :ssl_ca_file: {{ foreman_development_cert_dir }}/proxy_ca.pem


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The production deployment swapped to registering smart-proxies with oauth. This moves development to follow the same model.

#### What are the changes introduced in this pull request?

* smart-proxy registration in development deployment will now use oauth

#### How to test this pull request

Steps to reproduce:

* Deploy a foremanctl development environment
* No errors

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
