### PR TITLE
Move default certificate path to /var/lib/foremanctl/certs

### DIFF
--- a/docs/user/certificates.md
+++ b/docs/user/certificates.md
@@ -42,9 +42,9 @@ foremanctl deploy --certificate-source=installer
 After deployment, certificates are available at:
 
 **Default Source:**
-- CA Certificate: `/root/certificates/certs/ca.crt`
-- Server Certificate: `/root/certificates/certs/<hostname>.crt`
-- Client Certificate: `/root/certificates/certs/<hostname>-client.crt`
+- CA Certificate: `/var/lib/foremanctl/certs/certs/ca.crt`
+- Server Certificate: `/var/lib/foremanctl/certs/certs/<hostname>.crt`
+- Client Certificate: `/var/lib/foremanctl/certs/certs/<hostname>-client.crt`
 
 **Installer Source:**
 - CA Certificate: `/root/ssl-build/katello-default-ca.crt`
@@ -156,7 +156,7 @@ The `certificate_checks` role uses `foreman-certificate-check` binary to validat
 
 **Directory Structure:**
 ```
-/root/certificates/
+/var/lib/foremanctl/certs/
 ├── certs/           # Public certificates
 ├── private/         # Private keys and passwords
 └── requests/        # Certificate signing requests

--- a/docs/user/certificates.md
+++ b/docs/user/certificates.md
@@ -71,9 +71,9 @@ foremanctl deploy --certificate-source=installer
 After deployment, certificates are available at:
 
 **Default Source:**
-- CA Certificate: `/root/certificates/certs/ca.crt`
-- Server Certificate: `/root/certificates/certs/<hostname>.crt`
-- Client Certificate: `/root/certificates/certs/<hostname>-client.crt`
+- CA Certificate: `/var/lib/foremanctl/certs/certs/ca.crt`
+- Server Certificate: `/var/lib/foremanctl/certs/certs/<hostname>.crt`
+- Client Certificate: `/var/lib/foremanctl/certs/certs/<hostname>-client.crt`
 
 **Custom Server Source:**
 - CA Certificate: `/root/certificates/certs/ca.crt` (internal CA)
@@ -234,10 +234,10 @@ The `certificate_checks` role uses `foreman-certificate-check` binary to validat
 
 **Directory Structure:**
 ```
-/root/certificates/
-├── certs/           # Public certificates (ca.crt, server-ca.crt, ca-bundle.crt, *.crt)
-├── private/         # Private keys and passwords (ca.key, ca.pwd, *.key)
-└── requests/        # Certificate signing requests (*.csr)
+/var/lib/foremanctl/certs/
+├── certs/           # Public certificates
+├── private/         # Private keys and passwords
+└── requests/        # Certificate signing requests
 ```
 
 **SANs and CNAMEs:**

--- a/src/roles/certificates/defaults/main.yml
+++ b/src/roles/certificates/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 certificates_ca: true
-certificates_ca_directory: /root/certificates # Change this to /var/lib?
+certificates_ca_directory: /var/lib/foremanctl/certs
 certificates_ca_directory_keys: "{{ certificates_ca_directory }}/private"
 certificates_ca_directory_certs: "{{ certificates_ca_directory }}/certs"
 certificates_ca_directory_requests: "{{ certificates_ca_directory }}/requests"

--- a/src/roles/certificates/defaults/main.yml
+++ b/src/roles/certificates/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 certificates_source: default
 certificates_ca: true
-certificates_ca_directory: /root/certificates # Change this to /var/lib?
+certificates_ca_directory: /var/lib/foremanctl/certs
 certificates_ca_directory_keys: "{{ certificates_ca_directory }}/private"
 certificates_ca_directory_certs: "{{ certificates_ca_directory }}/certs"
 certificates_ca_directory_requests: "{{ certificates_ca_directory }}/requests"

--- a/src/vars/default_certificates.yml
+++ b/src/vars/default_certificates.yml
@@ -1,5 +1,5 @@
 ---
-certificates_ca_directory: /root/certificates
+certificates_ca_directory: /var/lib/foremanctl/certs
 ca_key_password: "{{ certificates_ca_directory }}/private/ca.pwd"
 ca_certificate: "{{ certificates_ca_directory }}/certs/ca.crt"
 ca_key: "{{ certificates_ca_directory }}/private/ca.key"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def certificates(pytestconfig, server_fqdn):
     source = pytestconfig.getoption("certificate_source")
     env = Environment(loader=FileSystemLoader("."), autoescape=select_autoescape())
     template = env.get_template(f"./src/vars/{source}_certificates.yml")
-    context = {'certificates_ca_directory': '/root/certificates',
+    context = {'certificates_ca_directory': '/var/lib/foremanctl/certs',
                'ansible_facts': {'fqdn': server_fqdn}}
     return yaml.safe_load(template.render(context))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,8 @@ def client_fqdn(client_hostname):
 def certificates(certificate_source, server_fqdn):
     env = Environment(loader=FileSystemLoader("."), autoescape=select_autoescape())
     template = env.get_template(f"./src/vars/{certificate_source}_certificates.yml")
-    context = {'ansible_facts': {'fqdn': server_fqdn}}
+    context = {'certificates_ca_directory': '/var/lib/foremanctl/certs',
+               'ansible_facts': {'fqdn': server_fqdn}}
     # we have vars that refer to other vars, so load them once and then re-render the template
     context.update(yaml.safe_load(template.render(context)))
     return yaml.safe_load(template.render(context))


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Certificates that are generated and managed by `foremanctl` should live in an appropriate location on the file system that indicates to the admin. In `foreman-installer`, these certificates lived in `/root/ssl-build` which was always seen as a non-standard location. These certificates should not be touched by the user, and thus `/var` is the best location to store and indicate this to the user.

#### What are the changes introduced in this pull request?

* Moves certificate generation and management from `/root/certificates` to `/var/lib/foremanctl/certs`.

#### How to test this pull request

Steps to reproduce:

* `./foremanctl deploy`
* Check that certificates are present in `/var/lib/foremanctl/certs`

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
