### PR TITLE
Update smart-proxy name configuration for development

### DIFF
--- a/development/roles/foreman_development/tasks/smart-proxy/main.yml
+++ b/development/roles/foreman_development/tasks/smart-proxy/main.yml
@@ -138,7 +138,7 @@
 
 - name: Configure smart-proxy for development
   theforeman.foreman.smart_proxy:
-    name: "{{ ansible_facts['fqdn'] }}-dev"
+    name: "{{ ansible_facts['fqdn'] }}"
     url: "https://{{ ansible_facts['fqdn'] }}:8443"
     server_url: "{{ foreman_development_url }}"
     username: "{{ foreman_development_admin_user }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

This change makes "internal" capsule naming consistent with downstream which in turn makes robottelo easier to use against dev environment

#### What are the changes introduced in this pull request?

* proxy name from hostname-dev to hostname


