### PR TITLE
Restart PostgreSQL when quadlet env vars change

### DIFF
--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -43,6 +43,8 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
+  notify:
+    - Restart postgresql
 
 - name: Configure SSL certificates
   when:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The Deploy PostgreSQL container task updates the quadlet file with tuning-specific env vars (POSTGRESQL_MAX_CONNECTIONS, POSTGRESQL_SHARED_BUFFERS, POSTGRESQL_EFFECTIVE_CACHE_SIZE) but does not notify the Restart postgresql handler. As a result, switching tuning profiles (e.g. medium to default) updates the quadlet file and triggers daemon_reload, but PostgreSQL keeps running with stale env vars from the previous profile.

#### What are the changes introduced in this pull request?

* Adding `notify: Restart postgresql` to the container task ensures the handler fires whenever the quadlet content changes, restarting the service with the updated env vars.

#### How to test this pull request

Steps to reproduce:

* Run `foremanctl deploy --tuning medium`
* Check the postgresql tuning values
* Run  `foremanctl deploy --reset-tuning`
* Check the postgresql tuning values again
* The tuning values will be for the medium profile

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
