### PR TITLE
Add httpd MPM event module configuration

### DIFF
--- a/src/roles/httpd/defaults/main.yml
+++ b/src/roles/httpd/defaults/main.yml
@@ -4,6 +4,15 @@ httpd_pulp_content_backend: http://localhost:24816
 httpd_foreman_backend: http://localhost:3000
 httpd_pub_dir: /var/www/html/pub
 
+# MPM event module defaults
+httpd_server_limit: 25
+httpd_start_servers: 2
+httpd_min_spare_threads: 16
+httpd_max_spare_threads: 32
+httpd_threads_per_child: 16
+httpd_thread_limit: 64
+httpd_listen_backlog: 511
+
 # External authentication configuration
 httpd_external_authentication: "{{ external_authentication | default(None) }}"
 httpd_ipa_manage_sssd: true

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -60,6 +60,14 @@
     remote_src: true
     mode: "0644"
 
+- name: Configure MPM event module
+  ansible.builtin.template:
+    src: event.conf.j2
+    dest: /etc/httpd/conf.modules.d/event.conf
+    mode: "0644"
+  notify:
+    - Restart httpd
+
 - name: Configure external authentication
   ansible.builtin.include_tasks: "external_auth/{{ httpd_external_authentication }}.yml"
   when: httpd_external_authentication in ['ipa', 'ipa_with_api']

--- a/src/roles/httpd/templates/event.conf.j2
+++ b/src/roles/httpd/templates/event.conf.j2
@@ -1,0 +1,12 @@
+<IfModule mpm_event_module>
+  ServerLimit            {{ httpd_server_limit }}
+  StartServers           {{ httpd_start_servers }}
+{% if httpd_max_request_workers is defined %}
+  MaxRequestWorkers      {{ httpd_max_request_workers }}
+{% endif %}
+  MinSpareThreads        {{ httpd_min_spare_threads }}
+  MaxSpareThreads        {{ httpd_max_spare_threads }}
+  ThreadsPerChild        {{ httpd_threads_per_child }}
+  ThreadLimit            {{ httpd_thread_limit }}
+  ListenBacklog          {{ httpd_listen_backlog }}
+</IfModule>

--- a/src/vars/tuning/extra-extra-large.yml
+++ b/src/vars/tuning/extra-extra-large.yml
@@ -2,6 +2,9 @@
 min_cpu_cores: 48
 min_ram_mb: 262144
 
+httpd_server_limit: 64
+httpd_max_request_workers: 1024
+
 postgresql_max_connections: 1000
 postgresql_shared_buffers: 32GB
 postgresql_effective_cache_size: 64GB

--- a/src/vars/tuning/extra-large.yml
+++ b/src/vars/tuning/extra-large.yml
@@ -2,6 +2,9 @@
 min_cpu_cores: 32
 min_ram_mb: 131072
 
+httpd_server_limit: 64
+httpd_max_request_workers: 1024
+
 postgresql_max_connections: 1000
 postgresql_shared_buffers: 16GB
 postgresql_effective_cache_size: 32GB

--- a/src/vars/tuning/large.yml
+++ b/src/vars/tuning/large.yml
@@ -2,6 +2,9 @@
 min_cpu_cores: 16
 min_ram_mb: 65536
 
+httpd_server_limit: 64
+httpd_max_request_workers: 1024
+
 postgresql_max_connections: 1000
 postgresql_shared_buffers: 8GB
 postgresql_effective_cache_size: 16GB

--- a/src/vars/tuning/medium.yml
+++ b/src/vars/tuning/medium.yml
@@ -2,6 +2,9 @@
 min_cpu_cores: 8
 min_ram_mb: 32768
 
+httpd_server_limit: 64
+httpd_max_request_workers: 1024
+
 postgresql_max_connections: 1000
 postgresql_shared_buffers: 4GB
 postgresql_effective_cache_size: 8GB

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -87,3 +87,20 @@ def test_https_foreman_login(server, certificates, server_fqdn):
     cmd = server.run(f"{CURL_CMD} --cacert {certificates['ca_certificate']} --write-out '%{{http_code}}' https://{server_fqdn}/users/login")
     assert cmd.succeeded
     assert cmd.stdout == '200'
+
+def test_httpd_event_conf_exists(server):
+    event_conf = server.file("/etc/httpd/conf.modules.d/event.conf")
+    assert event_conf.exists
+    assert event_conf.is_file
+
+def test_httpd_event_conf_contains_server_limit(server):
+    event_conf = server.file("/etc/httpd/conf.modules.d/event.conf")
+    assert event_conf.contains("ServerLimit")
+
+def test_httpd_event_conf_contains_threads_per_child(server):
+    event_conf = server.file("/etc/httpd/conf.modules.d/event.conf")
+    assert event_conf.contains("ThreadsPerChild")
+
+def test_httpd_config_syntax(server):
+    cmd = server.run("httpd -t")
+    assert cmd.succeeded


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

foremanctl does not manage the Apache MPM event module configuration.
Without an explicit `event.conf`, httpd uses its compiled-in defaults:
`ServerLimit=16`, `ThreadsPerChild=25`, `MaxRequestWorkers=400`.

In foreman-installer deployments, puppet-apache sets base defaults of
`ServerLimit=25` and `ThreadsPerChild=16` (with MaxRequestWorkers
derived automatically as ServerLimit * ThreadsPerChild). The tuning
profiles then override these to `ServerLimit=64` and
`MaxRequestWorkers=1024` via custom-hiera. foremanctl has no equivalent,
leaving the system severely under-provisioned for concurrent workloads
such as bulk host registration.

With only 400 MaxRequestWorkers, httpd begins rejecting connections once
concurrent requests exceed this limit, causing registration failures that
are entirely avoidable with proper MPM configuration.

#### What are the changes introduced in this pull request?

* Add `event.conf.j2` template to the httpd role with configurable MPM
  event parameters (ServerLimit, MaxRequestWorkers, ListenBacklog, etc.)
* Add role defaults matching puppet-apache base values (ServerLimit=25,
  MaxRequestWorkers not set — Apache derives it automatically)
* Add per-profile tuning overrides for medium, large, extra-large, and
  extra-extra-large matching the foreman-installer custom-hiera values
  (ServerLimit=64, MaxRequestWorkers=1024)
* Add task to deploy `event.conf` to `/etc/httpd/conf.modules.d/`

#### How to test this pull request

Steps to reproduce:

* Deploy with `foremanctl deploy`
* Verify `/etc/httpd/conf.modules.d/event.conf` exists with
  `ServerLimit 25` and no explicit `MaxRequestWorkers`
* Deploy with `foremanctl deploy --tuning large`
* Verify `/etc/httpd/conf.modules.d/event.conf` now has
  `ServerLimit 64` and `MaxRequestWorkers 1024`
* Run `httpd -t` to confirm syntax
* Run `hammer ping` to confirm all services operational
* Register hosts concurrently — should not hit httpd connection limits

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
