### PR TITLE
Rename --foreman-initial-* options to --initial-* in foremanctl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
             --certificate-source=${{ matrix.certificate_source }} \
             ${{ matrix.database == 'external' && '--database-mode=external --database-host=database.example.com --database-ssl-ca $(pwd)/.var/lib/foremanctl/db-ca.crt --database-ssl-mode verify-full' || '' }} \
             ${{ matrix.certificate_source == 'custom_server' && '--certificate-server-certificate /root/custom-certificates/certs/quadlet.example.com.crt --certificate-server-key /root/custom-certificates/private/quadlet.example.com.key --certificate-server-ca-certificate /root/custom-certificates/certs/server-ca.crt' || '' }} \
-            --foreman-initial-admin-password=changeme \
+            --initial-admin-password=changeme \
             --initial-organization "Foreman CI" \
             --initial-location "Internet" \
             --tuning development
@@ -239,7 +239,7 @@ jobs:
       - name: Run deployment
         run: |
           ./foremanctl deploy \
-            --foreman-initial-admin-password=changeme \
+            --initial-admin-password=changeme \
             --initial-organization "Foreman CI" \
             --initial-location "Internet" \
             --tuning development

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,7 +36,7 @@ This setup uses Vagrant to create a basic VM for running the deployment on:
 ./setup-environment
 source .venv/bin/activate
 ./forge vms start
-./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development --initial-organization "Foreman CI" --initial-location "Internet"
+./foremanctl deploy --initial-admin-password=changeme --tuning development --initial-organization "Foreman CI" --initial-location "Internet"
 ```
 
 ### Deploy hammer (optional)

--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -47,8 +47,8 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--pulp-database-name` | Name of the Pulp database | `--foreman-proxy-content-pulpcore-postgresql-db-name` |
 | `--pulp-database-user` | Owner of the Pulp database | `--foreman-proxy-content-pulpcore-postgresql-user` |
 | `--pulp-database-password` | Password for Pulp database | `--foreman-proxy-content-pulpcore-postgresql-password` |
-| `--foreman-initial-admin-username` | Initial username for the admin user | `--foreman-initial-admin-username` |
-| `--foreman-initial-admin-password` | Initial password for the admin user | `--foreman-initial-admin-password` |
+| `--initial-admin-username` | Initial username for the admin user | `--foreman-initial-admin-username` |
+| `--initial-admin-password` | Initial password for the admin user | `--foreman-initial-admin-password` |
 | `--initial-organization` | Name of an initial organization | `--foreman-initial-organization` |
 | `--initial-location` | Name of an initial location | `--foreman-initial-location` |
 | `--foreman-puma-workers` | Number of workers for Puma | `--foreman-foreman-service-puma-workers` |

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -5,8 +5,10 @@ help: |
 variables:
   foreman_initial_admin_username:
     help: Initial username for the admin user.
+    parameter: --initial-admin-username
   foreman_initial_admin_password:
     help: Initial password for the admin user.
+    parameter: --initial-admin-password
   foreman_initial_organization:
     help: Name of an initial organization.
     parameter: --initial-organization


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

#### What are the changes introduced in this pull request?

The current CLI uses --foreman-initial-* parameters, where the foreman prefix is an internal implementation detail inherited from the old installer. This detail is not relevant to end users and adds unnecessary verbosity.

To improve usability and align with user expectations, the CLI should expose these parameters as --initial-*.

#### How to test this pull request

Steps to reproduce:

- Renamed all --foreman-initial-* CLI options to --initial-*
- Updated corresponding argument handling and references in the codebase
- Ensured consistency across all initial parameter options

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
