### PR TITLE
ensure we use the right hostname when testing repo URLs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,16 @@
+import os
 import uuid
+import yaml
 
 import apypie
 import paramiko
 import py.path
 import pytest
+import requests
 import testinfra
-import yaml
-import os
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from requests.adapters import HTTPAdapter
 
 
 SSH_CONFIG='./.tmp/ssh-config'
@@ -220,3 +222,27 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "iop" in item.keywords:
             item.add_marker(skip_iop)
+
+
+class ResolveAdapter(HTTPAdapter):
+    def __init__(self, target_ip, *args, **kwargs):
+        self.target_ip = target_ip
+        super().__init__(*args, **kwargs)
+
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        conn = super().get_connection_with_tls_context(request, verify, proxies, cert)
+
+        # Override the host to point to your target IP
+        # This forces the socket to open to target_ip instead of the URL's domain
+        conn.host = self.target_ip
+
+        return conn
+
+
+@pytest.fixture(scope="module")
+def local_request(ssh_config, server_fqdn):
+    session = requests.Session()
+    adapter = ResolveAdapter(target_ip=ssh_config["hostname"])
+    session.mount(f"http://{server_fqdn}", adapter)
+    session.mount(f"https://{server_fqdn}", adapter)
+    return session

--- a/tests/foreman_api_test.py
+++ b/tests/foreman_api_test.py
@@ -1,34 +1,27 @@
-import urllib.parse
-
-import requests
-
-
-def _repo_url(repo, ssh_config):
-    return urllib.parse.urlunparse(urllib.parse.urlparse(repo['full_path'])._replace(netloc=ssh_config['hostname']))
-
-
 def test_foreman_organization(organization):
     assert organization
+
 
 def test_foreman_product(product):
     assert product
 
-def test_foreman_yum_repository(yum_repository, foremanapi, ssh_config):
+
+def test_foreman_yum_repository(yum_repository, foremanapi, local_request):
     assert yum_repository
     foremanapi.resource_action('repositories', 'sync', {'id': yum_repository['id']})
-    repo_url = _repo_url(yum_repository, ssh_config)
-    assert requests.get(f'{repo_url}/repodata/repomd.xml', verify=False)
-    assert requests.get(f'{repo_url}/Packages/b/bear-4.1-1.noarch.rpm', verify=False)
+    repo_url = yum_repository['full_path']
+    assert local_request.get(f'{repo_url}/repodata/repomd.xml', verify=False)
+    assert local_request.get(f'{repo_url}/Packages/b/bear-4.1-1.noarch.rpm', verify=False)
 
 
-def test_foreman_file_repository(file_repository, foremanapi, ssh_config):
+def test_foreman_file_repository(file_repository, foremanapi, local_request):
     assert file_repository
     foremanapi.resource_action('repositories', 'sync', {'id': file_repository['id']})
-    repo_url = _repo_url(file_repository, ssh_config)
-    assert requests.get(f'{repo_url}/1.iso', verify=False)
+    repo_url = file_repository['full_path']
+    assert local_request.get(f'{repo_url}/1.iso', verify=False)
 
 
-def test_foreman_container_repository(container_repository, foremanapi, ssh_config):
+def test_foreman_container_repository(container_repository, foremanapi):
     assert container_repository
     foremanapi.resource_action('repositories', 'sync', {'id': container_repository['id']})
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The application generates links and we should assert that the generated links are valid.
However, as the FQDN of the application might not be reachable from the place the tests run from, we used to override the "host" (netloc) part of the URL with the IP address we know from the SSH config.
That means that if the application generates a link with the wrong host, we don't notice it, as we override it.

Related:
- #482 
- #471 

#### What are the changes introduced in this pull request?

* Instead of overriding the host in the URL, only override it at the connection level, ensuring the right hostname is tested in the URL.

#### How to test this pull request

Steps to reproduce:

* Tests should cover this

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
