### PR TITLE
Load boxes.yaml

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 10240
       libvirt.cpus = 4
-      libvirt.machine_virtual_size = 30
+      libvirt.machine_virtual_size = 50
     end
   end
 
@@ -45,6 +45,23 @@ Vagrant.configure("2") do |config|
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 2048
+    end
+  end
+
+  # Load user-local box definitions from boxes.yaml (gitignored)
+  boxes_yaml = File.join(__dir__, 'boxes.yaml')
+  if File.exist?(boxes_yaml)
+    user_boxes = YAML.safe_load(File.read(boxes_yaml)) || {}
+    user_boxes.compact.each do |name, settings|
+      config.vm.define name do |override|
+        override.vm.box = settings.fetch('box') { ENV.fetch('FOREMANCTL_BASE_BOX', 'centos/stream9') }
+
+        override.vm.provider "libvirt" do |libvirt, _provider|
+          libvirt.memory = settings.fetch('memory', 3072)
+          libvirt.cpus = settings.fetch('cpus', 1)
+          libvirt.machine_virtual_size = settings.fetch('disk_size', 50)
+        end
+      end
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,12 @@
+require 'yaml'
+
 Vagrant.configure("2") do |config|
+  if Vagrant.has_plugin?('vagrant-hostmanager')
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+    config.hostmanager.include_offline = true
+  end
   config.vm.synced_folder ".", "/vagrant"
 
   config.vm.provision("etc_hosts", type: 'ansible') do |ansible|
@@ -17,7 +25,7 @@ Vagrant.configure("2") do |config|
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 10240
       libvirt.cpus = 4
-      libvirt.machine_virtual_size = 30
+      libvirt.machine_virtual_size = 50
     end
   end
 
@@ -36,6 +44,25 @@ Vagrant.configure("2") do |config|
 
     override.vm.provider "libvirt" do |libvirt, provider|
       libvirt.memory = 2048
+    end
+  end
+
+  # Load user-local box definitions from boxes.yaml (gitignored)
+  boxes_yaml = File.join(__dir__, 'boxes.yaml')
+  if File.exist?(boxes_yaml)
+    user_boxes = YAML.safe_load(File.read(boxes_yaml)) || {}
+    user_boxes.each do |name, settings|
+      next if settings.nil?
+      config.vm.define name do |override|
+        override.vm.box = ENV.fetch("FOREMANCTL_BASE_BOX", settings.fetch('box', 'centos/stream9'))
+        override.vm.hostname = settings.fetch('hostname', "#{name}.example.com")
+
+        override.vm.provider "libvirt" do |libvirt, _provider|
+          libvirt.memory = settings.fetch('memory', 4096)
+          libvirt.cpus = settings.fetch('cpus', 1)
+          libvirt.machine_virtual_size = settings['disk_size'] if settings.key?('disk_size')
+        end
+      end
     end
   end
 end

--- a/docs/developer/development-environment.md
+++ b/docs/developer/development-environment.md
@@ -48,6 +48,25 @@ You can deploy directly to a remote host using the `--target-host` parameter:
 ./forge deploy-dev --target-host=192.168.1.100
 ```
 
+### Defining New Hosts
+
+You can define custom hosts in boxes.yaml:
+
+```
+---
+# User-local box definitions (this file is gitignored)
+# Each entry becomes a vagrant box. Available settings:
+#   box:       base box (default: centos/stream9)
+#   memory:    RAM in MB (default: 3072)
+#   cpus:      CPU count (default: 1)
+#   disk_size: disk in GB (default: 50)
+
+katello-production:
+  memory: 12288
+  cpus: 4
+  disk_size: 50
+```
+
 ### SSH Authentication
 
 When deploying to remote hosts that require SSH password authentication:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

#### What are the changes introduced in this pull request?

* Adds hostmanager config, mainly so that the hypervisor's `/etc/hosts` is updated along with the VMs' hosts files.
* Increases the dev box disk size to 50 to allow more space for long-lasting logs and Pulp.
* Allows users to create a boxes.yaml file to add to the default box list in the Vagrantfile.

#### How to test this pull request

Steps to reproduce:

* Try to create a boxes.yaml like

```yaml
---
# User-local box definitions (this file is gitignored)
# Each entry becomes a vagrant box. Available settings:
#   box:       base box (default: centos/stream9)
#   hostname:  FQDN (default: <name>.example.com)
#   memory:    RAM in MB (default: 2048)
#   cpus:      CPU count (default: 1)
#   disk_size: disk in GB (default: unset)

katello-production:
  memory: 12288
  cpus: 4
  disk_size: 50
```

* Try `vagrant-hostmanager` and ensure the hypervisor's hosts file is updated.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
