### PR TITLE
Enable ansible-lint var-naming to enforce scoped role variables

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 ---
+enable_list:
+  - var-naming[no-role-prefix]
 exclude_paths:
   - .ansible/
   - .github/


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

To help enforce role names being scoped per role.

#### What are the changes introduced in this pull request?

* Enables the var-naming ansible-lint rule explciitly

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
