### PR TITLE
allow downstream product overrides for features

### DIFF
--- a/foremanctl
+++ b/foremanctl
@@ -6,7 +6,9 @@ OBSAH_DATA=${OBSAH_BASE}/src
 OBSAH_INVENTORY=${OBSAH_BASE}/inventories
 OBSAH_STATE=${OBSAH_BASE}/.var/lib/foremanctl
 OBSAH_PERSIST_PARAMS=true
-OBSAH_ALLOW_EXTRA_VARS=false
+# Let downstream wrappers pass extra obsah vars when needed
+# (default stays strict; opt-in via OBSAH_ALLOW_EXTRA_VARS=true in env).
+OBSAH_ALLOW_EXTRA_VARS=${OBSAH_ALLOW_EXTRA_VARS:-false}
 export OBSAH_NAME OBSAH_DATA OBSAH_INVENTORY OBSAH_STATE OBSAH_PERSIST_PARAMS OBSAH_ALLOW_EXTRA_VARS
 
 ANSIBLE_LOG_PATH=${OBSAH_BASE}/.var/lib/foremanctl/foremanctl.log

--- a/src/filter_plugins/foremanctl.py
+++ b/src/filter_plugins/foremanctl.py
@@ -10,9 +10,18 @@ import yaml
 
 BASE_FEATURES = ['hammer', 'foreman-proxy', 'foreman']
 
-features_yaml = pathlib.Path(__file__).parent.parent / 'features.yaml'
+_SRC_ROOT = pathlib.Path(__file__).parent.parent
+features_yaml = _SRC_ROOT / 'features.yaml'
 with features_yaml.open() as features_file:
     FEATURE_MAP = yaml.safe_load(features_file)
+
+# load additional feature files under features.d  
+_features_d = _SRC_ROOT / 'features.d'
+if _features_d.is_dir():
+    for _overlay in sorted(_features_d.glob('*.yaml')):
+        with _overlay.open() as _overlay_file:
+            _extra = yaml.safe_load(_overlay_file) or {}
+        FEATURE_MAP.update(_extra)
 
 
 def compact_list(items):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
This allows downstream products to extend foremanctl without touching the actual files (features.yaml,  foremanctl) As of now adding features  requires patching the checkout

#### What are the changes introduced in this pull request?

* `foremanctl.py`: load `src/features.d/*.yaml` if the directory exists

#### How to test this pull request

Steps to test:

* Without creating overlays, test foremanctl, there is no change to the current behavior
* Write `features.d/whatever.yaml` with `feature: { description: my_great_feature }` and try `foremanctl features list`
* use `OBSAH_ALLOW_EXTRA_VARS=true` and set extra vars (-e var=value) and see if they are accepted

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
