### PR TITLE
Add Ansible integration feature

### DIFF
--- a/src/features.yaml
+++ b/src/features.yaml
@@ -20,6 +20,15 @@ azure-rm:
   hammer: foreman_azure_rm
   foreman:
     plugin_name: foreman_azure_rm
+ansible:
+  description: Ansible integration plugin for Foreman
+  foreman:
+    plugin_name: foreman_ansible
+  foreman_proxy:
+    plugin_name: ansible
+  hammer: foreman_ansible
+  dependencies:
+    - remote-execution
 remote-execution:
   description: Remote Execution plugin for Foreman
   foreman:

--- a/src/roles/foreman_proxy/templates/settings.d/ansible.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/ansible.yml.j2
@@ -1,0 +1,2 @@
+---
+:enabled: {{ feature_enabled }}

--- a/src/vars/flavors/katello.yml
+++ b/src/vars/flavors/katello.yml
@@ -2,6 +2,7 @@
 flavor_features:
   - foreman
   - katello
+  - ansible
   - content/ansible
   - content/container
   - content/deb

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -17,3 +17,12 @@ def test_foreman_rex(client_environment, activation_key, organization, foremanap
     task = foremanapi.wait_for_task(job['task'])
     assert task['result'] == 'success'
     foremanapi.delete('hosts', {'id': client_fqdn})
+
+def test_foreman_ansible_rex(client_environment, activation_key, organization, foremanapi, client, client_fqdn):
+    client.run('dnf install -y subscription-manager')
+    rcmd = foremanapi.create('registration_commands', {'organization_id': organization['id'], 'insecure': True, 'activation_keys': [activation_key['name']], 'force': True})
+    client.run_test(rcmd['registration_command'])
+    job = foremanapi.create('job_invocations', {'job_template': 'Run Command - Ansible Default', 'inputs': {'command': 'uptime'}, 'search_query': f'name = {client_fqdn}', 'targeting_type': 'static_query'})
+    task = foremanapi.wait_for_task(job['task'])
+    assert task['result'] == 'success'
+    foremanapi.delete('hosts', {'id': client_fqdn})

--- a/tests/features_test.py
+++ b/tests/features_test.py
@@ -9,7 +9,7 @@ def test_foremanctl_features():
     for noise in ['PLAY [', 'TASK [', 'ok:', 'changed:', 'PLAY RECAP']:
         assert noise not in result.stdout, f"Ansible output not suppressed: found '{noise}'"
 
-    for feature in ['foreman', 'foreman-proxy', 'azure-rm']:
+    for feature in ['foreman', 'foreman-proxy', 'azure-rm', 'ansible']:
         assert feature in result.stdout, f"Expected feature '{feature}' in output"
 
 def test_foremanctl_features_list_enabled():

--- a/tests/foreman_plugins_test.py
+++ b/tests/foreman_plugins_test.py
@@ -1,6 +1,10 @@
 import pytest
 
-@pytest.mark.parametrize("foreman_plugin", ['foreman_azure_rm', 'foreman_google'])
-def test_foreman_compute_resources(foremanapi, foreman_plugin):
+@pytest.mark.parametrize("foreman_plugin", ['foreman_ansible', 'foreman_azure_rm', 'foreman_google'])
+def test_foreman_plugin_loaded(foremanapi, foreman_plugin):
     plugins = [plugin['name'] for plugin in foremanapi.list('plugins')]
     assert foreman_plugin in plugins
+
+def test_ansible_default_job_template(foremanapi):
+    templates = foremanapi.list('job_templates', search='name="Run Command - Ansible Default"')
+    assert len(templates) > 0

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -11,6 +11,7 @@ def test_foreman_proxy_features(server, certificates, server_fqdn):
     assert "logs" in features
     assert "script" in features
     assert "dynflow" in features
+    assert "ansible" in features
 
 def test_foreman_proxy_service(server):
     foreman_proxy = server.service("foreman-proxy")


### PR DESCRIPTION
## Summary
- Register `ansible` feature in `features.yaml` with foreman_ansible (Foreman),
  ansible (proxy), and foreman_ansible (Hammer CLI) plugins
- Add smart proxy settings template for the ansible plugin
- Enable ansible by default in the katello flavor
- Depends on remote-execution (which transitively enables dynflow)
- Rename `test_foreman_compute_resources` to `test_foreman_plugin_loaded` since
  the parametrized list now includes non-compute plugins

### Scope

Ansible is enabled by default in the **katello flavor only**, matching how other
plugins (katello, remote-execution, rh-cloud) are scoped. Vanilla Foreman installs
can opt in via `--add-feature=ansible`.

### Assumptions

This PR registers the plugin and enables it in the container images. It assumes:
- The Foreman and Smart Proxy container images already ship `foreman_ansible` and
  `smart_proxy_ansible` gems
- `ansible-core` is present in the proxy container image
- SSH key distribution and inventory are handled by REX (dependency)

## Test plan
- [x] `foreman_ansible` plugin loaded in Foreman (API check)
- [x] `ansible` feature exposed on smart proxy `/features` endpoint
- [x] "Run Command - Ansible Default" job template seeded
- [x] `ansible` listed in `foremanctl features`
- [x] Ansible-based REX job execution against a registered host

🤖 Generated with [Claude Code](https://claude.com/claude-code)