### PR TITLE
Rewrite compute resources test to not require Hammer

### DIFF
--- a/tests/foreman_compute_resources_test.py
+++ b/tests/foreman_compute_resources_test.py
@@ -1,11 +1,9 @@
 import pytest
 
-FOREMAN_HOST = 'localhost'
-FOREMAN_PORT = 3000
-
 
 @pytest.mark.parametrize("compute_resource", ['AzureRm', 'EC2', 'GCE', 'Libvirt', 'Openstack', 'Vmware'])
-def test_foreman_compute_resources(server, compute_resource):
-    hammer = server.run("hammer compute-resource create --help | grep provider")
-    assert hammer.succeeded
-    assert compute_resource in hammer.stdout
+def test_foreman_compute_resources(foremanapi, compute_resource):
+    create = foremanapi.resource('compute_resources').action('create')
+    compute_resource_param = [param for param in create.params if param.name == 'compute_resource'][0]
+    provider = [param for param in compute_resource_param.params if param.name == 'provider'][0]
+    assert compute_resource in provider.description


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Hammer is an optional feature that may not be deployed. It's also faster to query the API directly. @ehelms also ran into this with https://github.com/theforeman/foremanctl/pull/485/changes#diff-b8717c3b94dcdcb21359fefd8fc5b4ae1d84b9a1806547228b6c8f7e855891ed and here it doesn't bring value to use Hammer.

#### What are the changes introduced in this pull request?

This uses the API directly to extract the right information. It would be a lot easier if there was an API endpoint to query this programatically.

#### How to test this pull request

Steps to reproduce:

* Let CI run
* Verify it's green

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)