### PR TITLE
Expand ruff coverage to all project Python files and fix violations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           pip install --upgrade pip
           pip install ruff
       - name: Run ruff
-        run: ruff check --output-format=github tests/
+        run: ruff check --output-format=github tests/ src/ development/scripts/ inventories/
 
   tests:
     strategy:

--- a/development/scripts/vagrant.py
+++ b/development/scripts/vagrant.py
@@ -5,9 +5,9 @@ import argparse
 import json
 import subprocess
 import sys
-import yaml
-
 from collections import defaultdict
+
+import yaml
 
 
 def parse_args():

--- a/inventories/broker.py
+++ b/inventories/broker.py
@@ -2,11 +2,10 @@
 
 import argparse
 import json
-import yaml
-import os
 import subprocess
 import sys
-from io import StringIO
+
+import yaml
 
 
 def parse_args():

--- a/src/callback_plugins/foremanctl.py
+++ b/src/callback_plugins/foremanctl.py
@@ -14,6 +14,7 @@ DOCUMENTATION = """
       - set as stdout in configuration
 """
 
+
 class CallbackModule(DefaultCallbackModule):
     """Foremanctl callback."""
 

--- a/src/filter_plugins/foremanctl.py
+++ b/src/filter_plugins/foremanctl.py
@@ -1,7 +1,11 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 __metaclass__ = type
 
 import pathlib
+
 import yaml
 
 BASE_FEATURES = ['hammer', 'foreman-proxy', 'foreman']
@@ -55,6 +59,7 @@ def available_foreman_plugins(_value):
     plugins = [FEATURE_MAP.get(feature).get('foreman', {}).get('plugin_name') for feature in FEATURE_MAP.keys()]
     return compact_list(plugins)
 
+
 def list_all_features(enabled_features, only_enabled=False):
     enabled_list = []
     available_list = []
@@ -73,9 +78,11 @@ def list_all_features(enabled_features, only_enabled=False):
 
     return "\n".join(output)
 
+
 def invalid_features(features):
     """Return a list of unknown features not defined in features.yaml."""
     return [feature for feature in features if feature not in FEATURE_MAP]
+
 
 def hammer_plugins(value):
     dependencies = list(get_dependencies(filter_features(value)))

--- a/src/plugins/modules/migrate_answers.py
+++ b/src/plugins/modules/migrate_answers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import os
-import sys
+
 import yaml
 from ansible.module_utils.basic import AnsibleModule
 
@@ -48,7 +48,7 @@ def resolve_answer_file_from_scenario(scenario_file='/etc/foreman-installer/scen
 
             answer_file = scenario_data.get(':answer_file')
             if not answer_file:
-                raise ValueError(f"Scenario file does not contain :answer_file: key")
+                raise ValueError("Scenario file does not contain :answer_file: key")
 
             return answer_file
         except yaml.YAMLError as e:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Ruff was recently added as a CI lint check but only targeted `tests/`. The remaining Python files in the project (`src/`, `development/scripts/`, `inventories/`) were not covered, leaving lint violations undetected.

#### What are the changes introduced in this pull request?

* Extend the ruff CI step to also check `src/`, `development/scripts/`, and `inventories/`
* Fix all 13 violations found: import ordering, unused imports (`os`, `sys`, `io.StringIO`), missing blank lines between top-level definitions (E302), and a spurious `f`-string prefix

#### How to test this pull request

Steps to reproduce:

* Run `ruff check tests/ src/ development/scripts/ inventories/` — should report no errors

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)