### PR TITLE
Enable http for foreman proxy

### DIFF
--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -109,6 +109,7 @@ There are multiple use cases from the users perspective that dictate what parame
 
 | Parameter | Description | foreman-installer Parameters |
 | --------- | ----------- | ---------------------------- |
+| `--foreman-proxy-http` | Enable plain text HTTP on Foreman Proxy | `--foreman-proxy-http` |
 | `--bmc-ipmi-implementation` | IPMI implementation to use for BMC | `--foreman-proxy-bmc-default-provider` |
 | `--bmc-redfish-verify-ssl` | Verify SSL certificates for Redfish BMC connections | `--foreman-proxy-bmc-redfish-verify-ssl` |
 
@@ -162,7 +163,6 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--foreman-proxy-plugin-openscap-ansible-module` | | foreman_proxy::plugin::openscap | ansible_module |
 | `--foreman-proxy-plugin-openscap-puppet-module` | | foreman_proxy::plugin::openscap | puppet_module |
 | `--foreman-proxy-content-enable-ostree` | | | |
-| `--foreman-proxy-http` | | | |
 | `--foreman-proxy-log` | | | |
 | `--foreman-proxy-log-level` | | | |
 | `--foreman-proxy-plugin-ansible-working-dir` | | | |

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -46,6 +46,10 @@ variables:
     type: AbsolutePath
     parameter: --certificate-server-ca-certificate
     persist: false
+  foreman_proxy_http:
+    parameter: --foreman-proxy-http
+    help: Enable plain text HTTP on Foreman Proxy
+    type: Boolean
   foreman_proxy_bmc_ipmi_implementation:
     parameter: --bmc-ipmi-implementation
     help: IPMI implementation to use for BMC.

--- a/src/roles/foreman_proxy/defaults/main.yaml
+++ b/src/roles/foreman_proxy/defaults/main.yaml
@@ -4,6 +4,8 @@ foreman_proxy_container_tag: "nightly"
 foreman_proxy_registry_auth_file: /etc/foreman/registry-auth.json
 
 foreman_proxy_name: "{{ ansible_facts['fqdn'] }}"
+foreman_proxy_http: false
+foreman_proxy_http_port: 8000
 foreman_proxy_https_port: 8443
 foreman_proxy_url: "https://{{ foreman_proxy_name }}:{{ foreman_proxy_https_port }}"
 

--- a/src/roles/foreman_proxy/templates/settings.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.yml.j2
@@ -4,6 +4,9 @@
 :trusted_hosts: {{ foreman_proxy_trusted_hosts }}
 
 :https_port: {{ foreman_proxy_https_port }}
+{% if foreman_proxy_http | bool %}
+:http_port: {{ foreman_proxy_http_port }}
+{% endif %}
 :ssl_ca_file: /etc/foreman-proxy/ssl_ca.pem
 :ssl_certificate: /etc/foreman-proxy/ssl_cert.pem
 :ssl_private_key: /etc/foreman-proxy/ssl_key.pem


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Enable proxy to run on http
#### What are the changes introduced in this pull request?

* foreman proxy can run on http

#### How to test this pull request
* Run `foremanctl deploy --foreman-proxy-http true`

Steps to reproduce:


#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
