### PR TITLE
Use namespace for stage images

### DIFF
--- a/docs/developer/container-image-builds.md
+++ b/docs/developer/container-image-builds.md
@@ -9,9 +9,9 @@ There will be three flavors of Foreman containers:
   * Foreman + Katello
   * Foreman + all plugins
 
-Stage versions of containers will have stage in the name and be published in the Foreman's quay repository:
+Stage versions of containers will have stage in the namespace and be published in the Foreman's quay repository:
 
-  * `quay.io/foreman/$service-stage:$tag`
+  * `quay.io/foreman/stage/$service:$tag`
 
 The base image will be `quay.io/centos/centos:stream9`.
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

This will simplify the process for stage vs. production by keeping the image name consistent and only changing the namespace. This will also allow using registry overrides to switch between stage and production. See https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#remapping-and-mirroring-registries

#### What are the changes introduced in this pull request?

* Change to using stage namespace

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [x] Documentation updated (if applicable)
