### PR TITLE
Require SSL in devel

### DIFF
--- a/development/roles/foreman_development/templates/settings.yaml.j2
+++ b/development/roles/foreman_development/templates/settings.yaml.j2
@@ -3,7 +3,7 @@
 #:puppet_server: puppet
 :unattended: true
 :login: true
-:require_ssl: false
+:require_ssl: true
 :locations_enabled: true
 :organizations_enabled: true
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

I want to understand why `require_ssl` defaults to false in development. It seems the devel settings.yaml was copied from puppet-katello_devel which has defaulted to `false` since the very beginning of the repo in 2014.

#### What are the changes introduced in this pull request?

* Requires SSL in development environments

#### How to test this pull request

TBD

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
