### PR TITLE
Add KEA DHCP provider feature for foreman-proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,10 +115,6 @@ jobs:
       - name: Setup Kea DHCP server
         run: |
           ./forge kea
-      - name: Create installer certificates
-        if: contains(matrix.certificate_source, 'installer')
-        run: |
-          ./forge installer-certs
       - name: Create custom certificates
         if: matrix.certificate_source == 'custom_server'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,13 @@ jobs:
       - name: Configure repositories
         run: |
           ./forge setup-repositories
+      - name: Setup Kea DHCP server
+        run: |
+          ./forge kea
+      - name: Create installer certificates
+        if: contains(matrix.certificate_source, 'installer')
+        run: |
+          ./forge installer-certs
       - name: Create custom certificates
         if: matrix.certificate_source == 'custom_server'
         run: |
@@ -152,6 +159,9 @@ jobs:
             --add-feature google \
             --add-feature remote-execution \
             --add-feature bmc \
+            --add-feature dhcp \
+            --foreman-proxy-dhcp-provider dhcp_kea \
+            --foreman-proxy-dhcp-kea-url http://127.0.0.1:8000 \
             ${{ matrix.iop == 'enabled' && '--add-feature iop' || '' }}
       - name: Run tests
         run: |
@@ -245,6 +255,12 @@ jobs:
       - name: Configure repositories
         run: |
           ./forge setup-repositories
+      - name: Setup Kea DHCP server
+        run: |
+          ./forge kea
+      - name: Configure base version
+        run: |
+          sed -i '/container_tag_stream:/ s/:.*/: "${{ matrix.upgrade_from }}"/' src/vars/images.yml
       - name: Run image pull
         run: |
           ./foremanctl pull-images
@@ -262,7 +278,10 @@ jobs:
             --add-feature foreman-proxy \
             --add-feature azure-rm \
             --add-feature google \
-            --add-feature remote-execution
+            --add-feature remote-execution \
+            --add-feature dhcp \
+            --foreman-proxy-dhcp-provider dhcp_kea \
+            --foreman-proxy-dhcp-kea-url http://127.0.0.1:8000
       - name: Stop services
         run:
           vagrant ssh quadlet -- sudo systemctl stop foreman.target

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,6 @@ jobs:
             --add-feature remote-execution \
             --add-feature bmc \
             --add-feature dhcp \
-            --foreman-proxy-dhcp-provider dhcp_kea \
             --foreman-proxy-dhcp-kea-url http://127.0.0.1:8000 \
             ${{ matrix.iop == 'enabled' && '--add-feature iop' || '' }}
       - name: Run tests
@@ -280,7 +279,6 @@ jobs:
             --add-feature google \
             --add-feature remote-execution \
             --add-feature dhcp \
-            --foreman-proxy-dhcp-provider dhcp_kea \
             --foreman-proxy-dhcp-kea-url http://127.0.0.1:8000
       - name: Stop services
         run:

--- a/development/playbooks/kea/kea.yaml
+++ b/development/playbooks/kea/kea.yaml
@@ -32,53 +32,18 @@
         group: root
 
     - name: Configure Kea DHCP4 server
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: templates/kea-dhcp4.conf.j2
         dest: /etc/kea/kea-dhcp4.conf
-        content: |
-          {
-            "Dhcp4": {
-              "interfaces-config": {
-                "interfaces": [ "*" ]
-              },
-              "control-socket": {
-                "socket-type": "unix",
-                "socket-name": "/var/run/kea/kea4-ctrl-socket"
-              },
-              "subnet4": [
-                {
-                  "id": 1,
-                  "subnet": "192.168.122.0/24",
-                  "pools": [{ "pool": "192.168.122.100 - 192.168.122.200" }]
-                }
-              ],
-              "lease-database": {
-                "type": "memfile",
-                "persist": true,
-                "name": "/var/lib/kea/kea-leases4.csv"
-              }
-            }
-          }
         mode: '0644'
         owner: root
         group: root
       notify: Restart Kea DHCP4
 
     - name: Configure Kea Control Agent
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: templates/kea-ctrl-agent.conf.j2
         dest: /etc/kea/kea-ctrl-agent.conf
-        content: |
-          {
-            "Control-agent": {
-              "http-host": "127.0.0.1",
-              "http-port": 8000,
-              "control-sockets": {
-                "dhcp4": {
-                  "socket-type": "unix",
-                  "socket-name": "/var/run/kea/kea4-ctrl-socket"
-                }
-              }
-            }
-          }
         mode: '0644'
         owner: root
         group: root
@@ -106,6 +71,21 @@
       ansible.builtin.systemd:
         name: kea-dhcp4
         state: started
+
+    - name: Check Kea DHCP4 service status
+      ansible.builtin.systemd:
+        name: kea-dhcp4
+      register: kea_dhcp4_status
+      failed_when: false
+
+    - name: Display Kea DHCP4 service status
+      ansible.builtin.debug:
+        var: kea_dhcp4_status
+
+    - name: Wait for DHCP4 control socket to be created
+      ansible.builtin.wait_for:
+        path: /var/run/kea/kea4-ctrl-socket
+        timeout: 30
 
     - name: Start Kea Control Agent service
       ansible.builtin.systemd:

--- a/development/playbooks/kea/kea.yaml
+++ b/development/playbooks/kea/kea.yaml
@@ -15,6 +15,22 @@
           - kea
         state: present
 
+    - name: Create Kea runtime directory
+      ansible.builtin.file:
+        path: /var/run/kea
+        state: directory
+        mode: '0750'
+        owner: root
+        group: root
+
+    - name: Create Kea lib directory
+      ansible.builtin.file:
+        path: /var/lib/kea
+        state: directory
+        mode: '0755'
+        owner: root
+        group: root
+
     - name: Configure Kea DHCP4 server
       ansible.builtin.copy:
         dest: /etc/kea/kea-dhcp4.conf
@@ -26,7 +42,7 @@
               },
               "control-socket": {
                 "socket-type": "unix",
-                "socket-name": "/run/kea/kea4-ctrl-socket"
+                "socket-name": "/var/run/kea/kea4-ctrl-socket"
               },
               "subnet4": [
                 {
@@ -58,7 +74,7 @@
               "control-sockets": {
                 "dhcp4": {
                   "socket-type": "unix",
-                  "socket-name": "/run/kea/kea4-ctrl-socket"
+                  "socket-name": "/var/run/kea/kea4-ctrl-socket"
                 }
               }
             }
@@ -68,14 +84,33 @@
         group: root
       notify: Restart Kea Control Agent
 
-    - name: Start Kea services
+    - name: Validate Kea DHCP4 configuration
+      ansible.builtin.command: kea-dhcp4 -t /etc/kea/kea-dhcp4.conf
+      changed_when: false
+      register: dhcp4_validation
+
+    - name: Validate Kea Control Agent configuration
+      ansible.builtin.command: kea-ctrl-agent -t /etc/kea/kea-ctrl-agent.conf
+      changed_when: false
+      register: ctrl_agent_validation
+
+    - name: Enable Kea services
       ansible.builtin.systemd:
         name: "{{ item }}"
-        state: started
         enabled: true
       loop:
         - kea-dhcp4
         - kea-ctrl-agent
+
+    - name: Start Kea DHCP4 service
+      ansible.builtin.systemd:
+        name: kea-dhcp4
+        state: started
+
+    - name: Start Kea Control Agent service
+      ansible.builtin.systemd:
+        name: kea-ctrl-agent
+        state: started
 
     - name: Wait for Kea Control Agent to be ready
       ansible.builtin.wait_for:

--- a/development/playbooks/kea/kea.yaml
+++ b/development/playbooks/kea/kea.yaml
@@ -1,0 +1,96 @@
+---
+- name: Kea DHCP
+  hosts:
+    - quadlet
+  become: true
+  tasks:
+    - name: Install EPEL repository
+      ansible.builtin.package:
+        name: epel-release
+        state: present
+
+    - name: Install Kea packages
+      ansible.builtin.package:
+        name:
+          - kea
+        state: present
+
+    - name: Configure Kea DHCP4 server
+      ansible.builtin.copy:
+        dest: /etc/kea/kea-dhcp4.conf
+        content: |
+          {
+            "Dhcp4": {
+              "interfaces-config": {
+                "interfaces": [ "*" ]
+              },
+              "control-socket": {
+                "socket-type": "unix",
+                "socket-name": "/run/kea/kea4-ctrl-socket"
+              },
+              "subnet4": [
+                {
+                  "id": 1,
+                  "subnet": "192.168.122.0/24",
+                  "pools": [{ "pool": "192.168.122.100 - 192.168.122.200" }]
+                }
+              ],
+              "lease-database": {
+                "type": "memfile",
+                "persist": true,
+                "name": "/var/lib/kea/kea-leases4.csv"
+              }
+            }
+          }
+        mode: '0644'
+        owner: root
+        group: root
+      notify: Restart Kea DHCP4
+
+    - name: Configure Kea Control Agent
+      ansible.builtin.copy:
+        dest: /etc/kea/kea-ctrl-agent.conf
+        content: |
+          {
+            "Control-agent": {
+              "http-host": "127.0.0.1",
+              "http-port": 8000,
+              "control-sockets": {
+                "dhcp4": {
+                  "socket-type": "unix",
+                  "socket-name": "/run/kea/kea4-ctrl-socket"
+                }
+              }
+            }
+          }
+        mode: '0644'
+        owner: root
+        group: root
+      notify: Restart Kea Control Agent
+
+    - name: Start Kea services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: started
+        enabled: true
+      loop:
+        - kea-dhcp4
+        - kea-ctrl-agent
+
+    - name: Wait for Kea Control Agent to be ready
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 8000
+        state: started
+        timeout: 30
+
+  handlers:
+    - name: Restart Kea DHCP4
+      ansible.builtin.systemd:
+        name: kea-dhcp4
+        state: restarted
+
+    - name: Restart Kea Control Agent
+      ansible.builtin.systemd:
+        name: kea-ctrl-agent
+        state: restarted

--- a/development/playbooks/kea/metadata.obsah.yaml
+++ b/development/playbooks/kea/metadata.obsah.yaml
@@ -1,0 +1,3 @@
+---
+help: |
+  Setup Kea DHCP server

--- a/development/playbooks/kea/templates/kea-ctrl-agent.conf.j2
+++ b/development/playbooks/kea/templates/kea-ctrl-agent.conf.j2
@@ -1,0 +1,12 @@
+{
+  "Control-agent": {
+    "http-host": "127.0.0.1",
+    "http-port": 8000,
+    "control-sockets": {
+      "dhcp4": {
+        "socket-type": "unix",
+        "socket-name": "/var/run/kea/kea4-ctrl-socket"
+      }
+    }
+  }
+}

--- a/development/playbooks/kea/templates/kea-dhcp4.conf.j2
+++ b/development/playbooks/kea/templates/kea-dhcp4.conf.j2
@@ -1,0 +1,31 @@
+{
+  "Dhcp4": {
+    "interfaces-config": {
+      "interfaces": [ "*" ]
+    },
+    "control-socket": {
+      "socket-type": "unix",
+      "socket-name": "/var/run/kea/kea4-ctrl-socket"
+    },
+    "hooks-libraries": [
+      {
+        "library": "/usr/lib64/kea/hooks/libdhcp_host_cmds.so"
+      },
+      {
+        "library": "/usr/lib64/kea/hooks/libdhcp_lease_cmds.so"
+      }
+    ],
+    "subnet4": [
+      {
+        "id": 1,
+        "subnet": "192.168.122.0/24",
+        "pools": [{ "pool": "192.168.122.100 - 192.168.122.200" }]
+      }
+    ],
+    "lease-database": {
+      "type": "memfile",
+      "persist": true,
+      "name": "/var/lib/kea/kea-leases4.csv"
+    }
+  }
+}

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -62,3 +62,5 @@ dhcp:
   description: DHCP management
   foreman_proxy:
     plugin_name: dhcp
+  dependencies:
+    - foreman-proxy

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -58,3 +58,7 @@ bmc:
   description: Power management for bare metal hosts (IPMI, Redfish)
   foreman_proxy:
     plugin_name: bmc
+dhcp-kea-external:
+  description: KEA DHCP provider (external unmanaged server)
+  foreman_proxy:
+    plugin_name: dhcp_kea_api

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -58,7 +58,7 @@ bmc:
   description: Power management for bare metal hosts (IPMI, Redfish)
   foreman_proxy:
     plugin_name: bmc
-dhcp-kea-external:
-  description: KEA DHCP provider (external unmanaged server)
+dhcp:
+  description: DHCP management
   foreman_proxy:
-    plugin_name: dhcp_kea_api
+    plugin_name: dhcp

--- a/src/filter_plugins/foremanctl.py
+++ b/src/filter_plugins/foremanctl.py
@@ -125,6 +125,13 @@ def to_postgresql_users(databases):
     return [{'name': db['user'], 'password': db['password']} for db in databases]
 
 
+def expand_features(features):
+    """Expand features list to include all dependencies."""
+    all_features = set(features)
+    all_features.update(get_dependencies(features))
+    return list(all_features)
+
+
 class FilterModule(object):
     '''foremanctl filters'''
 
@@ -140,4 +147,5 @@ class FilterModule(object):
             'has_feature': has_feature,
             'to_postgresql_databases': to_postgresql_databases,
             'to_postgresql_users': to_postgresql_users,
+            'expand_features': expand_features,
         }

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -58,21 +58,20 @@ variables:
     type: Boolean
   foreman_proxy_dhcp_kea_url:
     parameter: --foreman-proxy-dhcp-kea-url
-    help: KEA Control Agent API URL (e.g., https://kea-server)
+    help: Kea Control Agent API URL (e.g., https://kea-server)
   foreman_proxy_dhcp_kea_username:
     parameter: --foreman-proxy-dhcp-kea-username
-    help: HTTP Basic Auth username for KEA API
+    help: HTTP Basic Auth username for Kea API
   foreman_proxy_dhcp_kea_password:
     parameter: --foreman-proxy-dhcp-kea-password
-    help: HTTP Basic Auth password for KEA API
+    help: HTTP Basic Auth password for Kea API
   foreman_proxy_dhcp_kea_verify_ssl:
     parameter: --foreman-proxy-dhcp-kea-verify-ssl
-    help: Verify SSL certificates when connecting to KEA (default: true)
+    help: "Verify SSL certificates when connecting to Kea (default: true)"
     type: Boolean
   foreman_proxy_dhcp_kea_lease_timeout:
     parameter: --foreman-proxy-dhcp-kea-lease-timeout
-    help: Timeout in seconds for KEA lease operations (default: 60)
-    type: Integer
+    help: "Timeout in seconds for Kea lease operations (default: 60)"
   foreman_proxy_dhcp_subnets:
     parameter: --foreman-proxy-dhcp-subnets
     help: Restrict DHCP management to specific subnets (CIDR format)

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -56,6 +56,27 @@ variables:
     parameter: --bmc-redfish-verify-ssl
     help: Verify SSL certificates for Redfish BMC connections.
     type: Boolean
+  foreman_proxy_dhcp_kea_url:
+    parameter: --foreman-proxy-dhcp-kea-url
+    help: KEA Control Agent API URL (e.g., https://kea-server)
+  foreman_proxy_dhcp_kea_username:
+    parameter: --foreman-proxy-dhcp-kea-username
+    help: HTTP Basic Auth username for KEA API
+  foreman_proxy_dhcp_kea_password:
+    parameter: --foreman-proxy-dhcp-kea-password
+    help: HTTP Basic Auth password for KEA API
+  foreman_proxy_dhcp_kea_verify_ssl:
+    parameter: --foreman-proxy-dhcp-kea-verify-ssl
+    help: Verify SSL certificates when connecting to KEA (default: true)
+    type: Boolean
+  foreman_proxy_dhcp_kea_lease_timeout:
+    parameter: --foreman-proxy-dhcp-kea-lease-timeout
+    help: Timeout in seconds for KEA lease operations (default: 60)
+    type: Integer
+  foreman_proxy_dhcp_subnets:
+    parameter: --foreman-proxy-dhcp-subnets
+    help: Restrict DHCP management to specific subnets (CIDR format)
+    action: append
 
 constraints:
   required_together:

--- a/src/roles/foreman_proxy/defaults/main.yaml
+++ b/src/roles/foreman_proxy/defaults/main.yaml
@@ -27,9 +27,9 @@ foreman_proxy_bmc_redfish_verify_ssl: true
 foreman_proxy_dhcp_provider: dhcp_kea
 foreman_proxy_dhcp_subnets: []
 
-# KEA DHCP provider settings (when foreman_proxy_dhcp_provider is dhcp_kea)
-foreman_proxy_dhcp_kea_url: "{{ undef(hint='You must specify the KEA API URL') }}"
-foreman_proxy_dhcp_kea_username: "{{ undef(hint='HTTP Basic Auth username for KEA API') }}"
-foreman_proxy_dhcp_kea_password: "{{ undef(hint='HTTP Basic Auth password for KEA API') }}"
+# Kea DHCP provider settings (when foreman_proxy_dhcp_provider is dhcp_kea)
+foreman_proxy_dhcp_kea_url: "{{ undef(hint='You must specify the Kea API URL') }}"
+foreman_proxy_dhcp_kea_username: "{{ undef(hint='HTTP Basic Auth username for Kea API') }}"
+foreman_proxy_dhcp_kea_password: "{{ undef(hint='HTTP Basic Auth password for Kea API') }}"
 foreman_proxy_dhcp_kea_verify_ssl: true
 foreman_proxy_dhcp_kea_lease_timeout: 60

--- a/src/roles/foreman_proxy/defaults/main.yaml
+++ b/src/roles/foreman_proxy/defaults/main.yaml
@@ -22,3 +22,8 @@ foreman_proxy_foreman_server_url: "https://{{ ansible_facts['fqdn'] }}"
 # BMC settings
 foreman_proxy_bmc_ipmi_implementation: ipmitool
 foreman_proxy_bmc_redfish_verify_ssl: true
+
+# KEA DHCP settings (external unmanaged server)
+foreman_proxy_dhcp_kea_server: localhost
+foreman_proxy_dhcp_kea_url: "http://{{ foreman_proxy_dhcp_kea_server }}:8000"
+foreman_proxy_dhcp_kea_subnet: 192.168.0.0/24

--- a/src/roles/foreman_proxy/defaults/main.yaml
+++ b/src/roles/foreman_proxy/defaults/main.yaml
@@ -23,7 +23,13 @@ foreman_proxy_foreman_server_url: "https://{{ ansible_facts['fqdn'] }}"
 foreman_proxy_bmc_ipmi_implementation: ipmitool
 foreman_proxy_bmc_redfish_verify_ssl: true
 
-# KEA DHCP settings (external unmanaged server)
-foreman_proxy_dhcp_kea_server: localhost
-foreman_proxy_dhcp_kea_url: "http://{{ foreman_proxy_dhcp_kea_server }}:8000"
-foreman_proxy_dhcp_kea_subnet: 192.168.0.0/24
+# DHCP settings
+foreman_proxy_dhcp_provider: dhcp_kea
+foreman_proxy_dhcp_subnets: []
+
+# KEA DHCP provider settings (when foreman_proxy_dhcp_provider is dhcp_kea)
+foreman_proxy_dhcp_kea_url: "{{ undef(hint='You must specify the KEA API URL') }}"
+foreman_proxy_dhcp_kea_username: "{{ undef(hint='HTTP Basic Auth username for KEA API') }}"
+foreman_proxy_dhcp_kea_password: "{{ undef(hint='HTTP Basic Auth password for KEA API') }}"
+foreman_proxy_dhcp_kea_verify_ssl: true
+foreman_proxy_dhcp_kea_lease_timeout: 60

--- a/src/roles/foreman_proxy/tasks/feature/dhcp.yaml
+++ b/src/roles/foreman_proxy/tasks/feature/dhcp.yaml
@@ -1,0 +1,21 @@
+- name: Create config secret for DHCP provider {{ foreman_proxy_dhcp_provider }}
+  containers.podman.podman_secret:
+    state: present
+    name: foreman-proxy-{{ foreman_proxy_dhcp_provider }}-yml
+    data: "{{ lookup('ansible.builtin.template', 'settings.d/' + foreman_proxy_dhcp_provider + '.yml.j2') }}"
+  notify:
+    - Restart Foreman Proxy
+    - Refresh Foreman Proxy
+
+- name: Mount config secret for DHCP provider {{ foreman_proxy_dhcp_provider }}
+  ansible.builtin.copy:
+    dest: /etc/containers/systemd/foreman-proxy.container.d/{{ foreman_proxy_dhcp_provider }}.conf
+    content: |
+      [Container]
+      Secret=foreman-proxy-{{ foreman_proxy_dhcp_provider }}-yml,type=mount,target=/etc/foreman-proxy/settings.d/{{ foreman_proxy_dhcp_provider }}.yml
+    mode: '0644'
+    owner: root
+    group: root
+  notify:
+    - Restart Foreman Proxy
+    - Refresh Foreman Proxy

--- a/src/roles/foreman_proxy/templates/settings.d/dhcp.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/dhcp.yml.j2
@@ -1,0 +1,9 @@
+---
+# DHCP module configuration
+# This enables the DHCP module and selects the provider
+
+:enabled: {{ feature_enabled }}
+:use_provider: {{ foreman_proxy_dhcp_provider }}
+{% if foreman_proxy_dhcp_subnets is defined and foreman_proxy_dhcp_subnets %}
+:subnets: {{ foreman_proxy_dhcp_subnets | to_json }}
+{% endif %}

--- a/src/roles/foreman_proxy/templates/settings.d/dhcp_kea.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/dhcp_kea.yml.j2
@@ -1,0 +1,17 @@
+---
+# KEA DHCP provider configuration
+# KEA DHCP provider is included in Smart Proxy core (version 3.8+)
+
+:dhcp_kea_url: {{ foreman_proxy_dhcp_kea_url }}
+{% if foreman_proxy_dhcp_kea_username is defined and foreman_proxy_dhcp_kea_username %}
+:dhcp_kea_username: {{ foreman_proxy_dhcp_kea_username }}
+{% else %}
+:dhcp_kea_username: ~
+{% endif %}
+{% if foreman_proxy_dhcp_kea_password is defined and foreman_proxy_dhcp_kea_password %}
+:dhcp_kea_password: {{ foreman_proxy_dhcp_kea_password }}
+{% else %}
+:dhcp_kea_password: ~
+{% endif %}
+:dhcp_kea_verify_ssl: {{ foreman_proxy_dhcp_kea_verify_ssl | lower }}
+:dhcp_kea_lease_timeout: {{ foreman_proxy_dhcp_kea_lease_timeout }}

--- a/src/roles/foreman_proxy/templates/settings.d/dhcp_kea.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/dhcp_kea.yml.j2
@@ -1,6 +1,6 @@
 ---
-# KEA DHCP provider configuration
-# KEA DHCP provider is included in Smart Proxy core (version 3.8+)
+# Kea DHCP provider configuration
+# Kea DHCP provider is included in Smart Proxy core (version 3.8+)
 
 :dhcp_kea_url: {{ foreman_proxy_dhcp_kea_url }}
 {% if foreman_proxy_dhcp_kea_username is defined and foreman_proxy_dhcp_kea_username %}

--- a/src/roles/foreman_proxy/templates/settings.d/dhcp_kea_api.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/dhcp_kea_api.yml.j2
@@ -1,9 +1,0 @@
----
-# KEA DHCP provider configuration
-# This configures Smart Proxy to use an external KEA DHCP server
-
-:enabled: {{ feature_enabled }}
-:use_provider: dhcp_kea_api
-:server: {{ foreman_proxy_dhcp_kea_server }}
-:kea_url: {{ foreman_proxy_dhcp_kea_url }}
-:kea_subnet: {{ foreman_proxy_dhcp_kea_subnet }}

--- a/src/roles/foreman_proxy/templates/settings.d/dhcp_kea_api.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/dhcp_kea_api.yml.j2
@@ -1,0 +1,9 @@
+---
+# KEA DHCP provider configuration
+# This configures Smart Proxy to use an external KEA DHCP server
+
+:enabled: {{ feature_enabled }}
+:use_provider: dhcp_kea_api
+:server: {{ foreman_proxy_dhcp_kea_server }}
+:kea_url: {{ foreman_proxy_dhcp_kea_url }}
+:kea_subnet: {{ foreman_proxy_dhcp_kea_subnet }}

--- a/src/vars/defaults.yml
+++ b/src/vars/defaults.yml
@@ -4,4 +4,4 @@ database_mode: internal
 tuning: default
 flavor: katello
 features: []
-enabled_features: "{{ (flavor_features + features) }}"
+enabled_features: "{{ (flavor_features + features) | expand_features }}"

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -18,6 +18,27 @@ def proxy_v2_features(server, certificates, server_fqdn):
     return json.loads(cmd.stdout)
 
 
+@pytest.fixture(scope="module")
+def proxy_request(server, certificates, server_fqdn):
+    """Helper fixture for making authenticated requests to Foreman Proxy API"""
+    def _request(path, method=None, data=None, return_body=False):
+        curl_opts = (
+            f"--cacert {certificates['server_ca_certificate']} "
+            f"--cert {certificates['client_certificate']} "
+            f"--key {certificates['client_key']} "
+            f"--silent "
+        )
+        if not return_body:
+            curl_opts += "--output /dev/null --write-out '%{http_code}' "
+        if method:
+            curl_opts += f"-X {method} "
+        if data:
+            curl_opts += f"-H 'Content-Type: application/json' -d '{data}' "
+        return server.run(f"curl {curl_opts}https://{server_fqdn}:{FOREMAN_PROXY_PORT}/{path}")
+
+    return _request
+
+
 def test_foreman_proxy_features(server, certificates, server_fqdn, enabled_features):
     cmd = server.run(f"curl --cacert {certificates['server_ca_certificate']} --silent https://{server_fqdn}:{FOREMAN_PROXY_PORT}/features")
     assert cmd.succeeded
@@ -96,3 +117,56 @@ def test_dhcp_kea_api_settings(proxy_v2_features):
     if settings.get('managed_subnets'):
         assert isinstance(settings['managed_subnets'], list)
         assert all('/' in subnet for subnet in settings['managed_subnets'])
+
+
+@pytest.mark.feature('dhcp')
+def test_dhcp_kea_list_subnets(proxy_request):
+    """Test listing subnets from Kea via Foreman Proxy DHCP API"""
+    cmd = proxy_request("dhcp", return_body=True)
+    assert cmd.succeeded, f"Failed to list DHCP subnets: {cmd.stderr}"
+
+    subnets = json.loads(cmd.stdout)
+    assert isinstance(subnets, list), "Expected subnet list"
+
+    subnet_networks = [s['network'] for s in subnets]
+    assert '192.168.122.0/24' in subnet_networks, f"Test subnet not found in {subnet_networks}"
+
+
+@pytest.mark.feature('dhcp')
+def test_dhcp_kea_create_and_delete_reservation(proxy_request):
+    """Test creating and deleting a DHCP reservation via Kea"""
+    test_mac = "aa:bb:cc:dd:ee:ff"
+    test_ip = "192.168.122.150"
+    test_hostname = "foremanctl-test-host"
+
+    reservation_data = json.dumps({
+        "network": "192.168.122.0/24",
+        "ip": test_ip,
+        "mac": test_mac,
+        "hostname": test_hostname,
+        "subnet": "192.168.122.0",
+        "netmask": "255.255.255.0"
+    })
+
+    cmd = proxy_request(
+        f"dhcp/192.168.122.0/255.255.255.0/{test_ip}",
+        method="POST",
+        data=reservation_data
+    )
+    assert cmd.succeeded, f"Failed to create DHCP reservation: {cmd.stderr}"
+    assert cmd.stdout == '200', f"Expected HTTP 200 when creating reservation, got {cmd.stdout}"
+
+    cmd = proxy_request(f"dhcp/192.168.122.0/255.255.255.0/{test_ip}", return_body=True)
+    assert cmd.succeeded, f"Failed to query DHCP reservation: {cmd.stderr}"
+
+    reservation = json.loads(cmd.stdout)
+    assert reservation['ip'] == test_ip
+    assert reservation['mac'] == test_mac
+    assert reservation['hostname'] == test_hostname
+
+    cmd = proxy_request(
+        f"dhcp/192.168.122.0/255.255.255.0/{test_ip}",
+        method="DELETE"
+    )
+    assert cmd.succeeded, f"Failed to delete DHCP reservation: {cmd.stderr}"
+    assert cmd.stdout == '200', f"Expected HTTP 200 when deleting reservation, got {cmd.stdout}"

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -29,6 +29,10 @@ def test_foreman_proxy_features(server, certificates, server_fqdn, enabled_featu
         assert "bmc" in features
     else:
         assert "bmc" not in features
+    if 'dhcp-kea-external' in enabled_features:
+        assert "dhcp" in features
+    else:
+        assert "dhcp" not in features
 
 
 def test_foreman_proxy_service(server):
@@ -69,3 +73,26 @@ def test_bmc_capabilities(proxy_v2_features):
 def test_bmc_default_provider(proxy_v2_features):
     settings = proxy_v2_features['bmc'].get('settings', {})
     assert settings.get('bmc_default_provider') == 'ipmitool'
+
+
+@pytest.mark.feature('dhcp-kea-external')
+def test_dhcp_kea_feature_present(proxy_v2_features):
+    assert 'dhcp' in proxy_v2_features
+
+
+@pytest.mark.feature('dhcp-kea-external')
+def test_dhcp_kea_provider(proxy_v2_features):
+    assert 'dhcp' in proxy_v2_features
+    settings = proxy_v2_features['dhcp'].get('settings', {})
+    assert settings.get('use_provider') == 'dhcp_kea_api'
+
+
+@pytest.mark.feature('dhcp-kea-external')
+def test_dhcp_kea_server_settings(proxy_v2_features):
+    assert 'dhcp' in proxy_v2_features
+    settings = proxy_v2_features['dhcp'].get('settings', {})
+    assert 'server' in settings
+    assert 'kea_url' in settings
+    assert settings['kea_url'].endswith(':8000')
+    assert 'kea_subnet' in settings
+    assert '/' in settings['kea_subnet']

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -29,7 +29,7 @@ def test_foreman_proxy_features(server, certificates, server_fqdn, enabled_featu
         assert "bmc" in features
     else:
         assert "bmc" not in features
-    if 'dhcp-kea-external' in enabled_features:
+    if 'dhcp' in enabled_features:
         assert "dhcp" in features
     else:
         assert "dhcp" not in features
@@ -75,24 +75,24 @@ def test_bmc_default_provider(proxy_v2_features):
     assert settings.get('bmc_default_provider') == 'ipmitool'
 
 
-@pytest.mark.feature('dhcp-kea-external')
-def test_dhcp_kea_feature_present(proxy_v2_features):
+@pytest.mark.feature('dhcp')
+def test_dhcp_feature_present(proxy_v2_features):
     assert 'dhcp' in proxy_v2_features
 
 
-@pytest.mark.feature('dhcp-kea-external')
-def test_dhcp_kea_provider(proxy_v2_features):
-    assert 'dhcp' in proxy_v2_features
-    settings = proxy_v2_features['dhcp'].get('settings', {})
-    assert settings.get('use_provider') == 'dhcp_kea_api'
-
-
-@pytest.mark.feature('dhcp-kea-external')
-def test_dhcp_kea_server_settings(proxy_v2_features):
+@pytest.mark.feature('dhcp')
+def test_dhcp_provider(proxy_v2_features):
     assert 'dhcp' in proxy_v2_features
     settings = proxy_v2_features['dhcp'].get('settings', {})
-    assert 'server' in settings
-    assert 'kea_url' in settings
-    assert settings['kea_url'].endswith(':8000')
-    assert 'kea_subnet' in settings
-    assert '/' in settings['kea_subnet']
+    assert settings.get('use_provider') == 'dhcp_kea'
+
+
+@pytest.mark.feature('dhcp')
+def test_dhcp_kea_api_settings(proxy_v2_features):
+    assert 'dhcp' in proxy_v2_features
+    settings = proxy_v2_features['dhcp'].get('settings', {})
+    assert 'kea_api_url' in settings
+    assert settings['kea_api_url'].endswith(':8000')
+    if settings.get('managed_subnets'):
+        assert isinstance(settings['managed_subnets'], list)
+        assert all('/' in subnet for subnet in settings['managed_subnets'])


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
ISC DHCP reached end-of-life in October 2022 and has been removed from RHEL 10. This adds support for KEA DHCP as the replacement.

#### What are the changes introduced in this pull request?

* Add `dhcp-kea-external` feature definition to `src/features.yaml`
* Create Smart Proxy configuration template `dhcp_kea_api.yml.j2`
* Add default Ansible variables for KEA server connection (localhost:8000, default subnet)
* Add integration tests for DHCP KEA feature validation

#### How to test this pull request

Steps to reproduce:

1. Verify feature is available: `./foremanctl features | grep dhcp-kea-external`
2. Deploy with KEA DHCP feature enabled: `./foremanctl deploy --add-feature dhcp-kea-external`
3. Verify feature is enabled: `./foremanctl features --list-enabled | grep dhcp-kea-external`
4. Check configuration file was created: `podman exec foreman-proxy ls -la /etc/foreman-proxy/settings.d/dhcp_kea_api.yml`
5. Run tests `python -m pytest tests/foreman_proxy_test.py::test_dhcp_kea_feature_present -v`

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
