### PR TITLE
TFTP feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,9 @@ jobs:
         if: matrix.security != 'none'
         run: |
           ./forge security --mode ${{ matrix.security }}
+      - name: Setup TFTP server
+        run: |
+          ./forge tftp
       - name: Apply fapolicyd workarounds
         # https://access.redhat.com/solutions/7072618 / https://issues.redhat.com/browse/RHEL-37912
         # https://github.com/theforeman/foreman-fapolicyd/blob/develop/15-foreman-container.rules
@@ -152,6 +155,8 @@ jobs:
             --add-feature google \
             --add-feature remote-execution \
             --add-feature bmc \
+            --add-feature tftp \
+            --tftp-servername 127.0.0.1 \
             ${{ matrix.iop == 'enabled' && '--add-feature iop' || '' }}
       - name: Run tests
         run: |

--- a/development/playbooks/tftp/metadata.obsah.yaml
+++ b/development/playbooks/tftp/metadata.obsah.yaml
@@ -1,0 +1,3 @@
+---
+help: |
+  Setup TFTP server

--- a/development/playbooks/tftp/tftp.yaml
+++ b/development/playbooks/tftp/tftp.yaml
@@ -1,0 +1,21 @@
+---
+- name: TFTP
+  hosts:
+    - quadlet
+  become: true
+  tasks:
+    - name: Install packages
+      ansible.builtin.package:
+        name:
+          - tftp-server
+          - tftp
+        state: present
+
+    - name: Start TFTP services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: started
+        enabled: true
+      with_items:
+        - tftp.socket
+        - tftp.service

--- a/development/playbooks/tftp/tftp.yaml
+++ b/development/playbooks/tftp/tftp.yaml
@@ -17,5 +17,4 @@
         state: started
         enabled: true
       with_items:
-        - tftp.socket
         - tftp.service

--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -112,6 +112,15 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--add-feature bmc` | Enable BMC feature | `--foreman-proxy-bmc` |
 | `--bmc-ipmi-implementation` | IPMI implementation to use for BMC | `--foreman-proxy-bmc-default-provider` |
 | `--bmc-redfish-verify-ssl` | Verify SSL certificates for Redfish BMC connections | `--foreman-proxy-bmc-redfish-verify-ssl` |
+| `--add-feature tftp` | Enable TFTP feature | `--foreman-proxy-tftp` |
+| `--tftp-servername` | IP address of the TFTP server (required when enabling TFTP) | `--foreman-proxy-tftp-servername` |
+| `--tftp-root` | Directory to serve TFTP files from | `--foreman-proxy-tftp-root` |
+
+### Unmapped
+
+| foreman-installer Parameter | Description | Reason |
+| --------------------------- | ----------- | ------ |
+| `--foreman-proxy-tftp-managed` | Installer managed TFTP | not supported |
 
 ### Undetermined
 
@@ -144,10 +153,6 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--foreman-proxy-plugin-dns-route53-aws-access-key` | | foreman_proxy::plugin::dns_route53 | aws_access_key |
 | `--foreman-proxy-plugin-dns-route53-aws-secret-key` | | foreman_proxy::plugin::dns_route53 | aws_secret_key |
 | `--foreman-proxy-httpboot` | | foreman_proxy | httpboot |
-| `--foreman-proxy-tftp` | | foreman_proxy | tftp |
-| `--foreman-proxy-tftp-servername` | | foreman_proxy | tftp_servername |
-| `--foreman-proxy-tftp-managed` | | foreman_proxy | tftp_managed |
-| `--foreman-proxy-tftp-root` | | foreman_proxy | tftp_root |
 | `--foreman-proxy-plugin-dhcp-remote-isc-dhcp-config` | | foreman_proxy::plugin::dhcp_remote_isc | config |
 | `--foreman-proxy-plugin-dhcp-remote-isc-dhcp-leases` | | foreman_proxy::plugin::dhcp_remote_isc | dhcp_config |
 | `--foreman-proxy-plugin-dhcp-remote-isc-key-name` | | foreman_proxy::plugin::dhcp_remote_isc | key_name |

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -58,3 +58,7 @@ bmc:
   description: Power management for bare metal hosts (IPMI, Redfish)
   foreman_proxy:
     plugin_name: bmc
+tftp:
+  description: Enable TFTP feature on Foreman Proxy
+  foreman_proxy:
+    plugin_name: tftp

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -56,10 +56,21 @@ variables:
     parameter: --bmc-redfish-verify-ssl
     help: Verify SSL certificates for Redfish BMC connections.
     type: Boolean
+  foreman_proxy_tftp_root:
+    parameter: --tftp-root
+    help: Directory to serve TFTP files from.
+    type: AbsolutePath
+  foreman_proxy_tftp_servername:
+    parameter: --tftp-servername
+    help: Server name or IP address for TFTP. TFTP clients typically do not have DNS available, so an IP address is recommended.
 
 constraints:
   required_together:
     - [certificates_custom_server_certificate, certificates_custom_server_key, certificates_custom_server_ca_certificate]
+  forbidden_if:
+    - [certificates_source, installer, [certificates_custom_server_certificate, certificates_custom_server_key, certificates_custom_server_ca_certificate]]
+  required_in_list:
+    - [[[features, tftp]], [foreman_proxy_tftp_servername]]
 
 include:
   - _certificate_source

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -58,7 +58,7 @@ variables:
     type: Boolean
   foreman_proxy_tftp_root:
     parameter: --tftp-root
-    help: Directory to serve TFTP files from.
+    help: Directory to serve TFTP files from, defaults to /var/lib/tftpboot if not specified.
     type: AbsolutePath
   foreman_proxy_tftp_servername:
     parameter: --tftp-servername

--- a/src/plugins/modules/migrate_answers.py
+++ b/src/plugins/modules/migrate_answers.py
@@ -32,6 +32,11 @@ PARAMETER_MAP = {
     ('foreman', 'server_ssl_key'): 'IGNORE',
     ('foreman', 'server_ssl_ca'): 'IGNORE',
 
+    # Foreman Proxy TFTP
+    ('foreman_proxy', 'tftp_managed'): 'IGNORE',
+    ('foreman_proxy', 'tftp_root'): 'foreman_proxy_tftp_root',
+    ('foreman_proxy', 'tftp_servername'): 'foreman_proxy_tftp_servername',
+
     # TODO: Add more mappings as discovered
 }
 

--- a/src/roles/foreman_proxy/defaults/main.yaml
+++ b/src/roles/foreman_proxy/defaults/main.yaml
@@ -22,3 +22,7 @@ foreman_proxy_foreman_server_url: "https://{{ ansible_facts['fqdn'] }}"
 # BMC settings
 foreman_proxy_bmc_ipmi_implementation: ipmitool
 foreman_proxy_bmc_redfish_verify_ssl: true
+
+# TFTP settings
+foreman_proxy_tftp_root: /var/lib/tftpboot
+foreman_proxy_tftp_servername: "{{ undef(hint='You must specify a TFTP servername') }}"

--- a/src/roles/foreman_proxy/tasks/feature/tftp.yaml
+++ b/src/roles/foreman_proxy/tasks/feature/tftp.yaml
@@ -1,0 +1,21 @@
+---
+- name: TFTP root directory
+  notify:
+    - Restart Foreman Proxy
+    - Refresh Foreman Proxy
+  block:
+    - name: Create TFTP root directory
+      ansible.builtin.file:
+        path: "{{ foreman_proxy_tftp_root }}"
+        state: directory
+        mode: "0777"
+
+    - name: Mount the directory into foreman-proxy container
+      ansible.builtin.copy:
+        dest: /etc/containers/systemd/foreman-proxy.container.d/tftp-root.conf
+        content: |
+          [Container]
+          Volume={{ foreman_proxy_tftp_root }}:/var/lib/tftpboot:rw
+        mode: '0644'
+        owner: root
+        group: root

--- a/src/roles/foreman_proxy/tasks/feature/tftp.yaml
+++ b/src/roles/foreman_proxy/tasks/feature/tftp.yaml
@@ -8,7 +8,9 @@
       ansible.builtin.file:
         path: "{{ foreman_proxy_tftp_root }}"
         state: directory
-        mode: "0777"
+        mode: "0755"
+        owner: 998
+        group: 998
 
     - name: Mount the directory into foreman-proxy container
       ansible.builtin.copy:

--- a/src/roles/foreman_proxy/tasks/main.yaml
+++ b/src/roles/foreman_proxy/tasks/main.yaml
@@ -16,6 +16,8 @@
     sdnotify: true
     network: host
     hostname: "{{ ansible_facts['hostname'] }}.local"
+    security_opt:
+      - "label=disable"
     secrets:
       - 'foreman-proxy-settings-yml,type=mount,target=/etc/foreman-proxy/settings.yml'
       - 'foreman-proxy-ssl-ca,type=mount,target=/etc/foreman-proxy/ssl_ca.pem'

--- a/src/roles/foreman_proxy/templates/settings.d/tftp.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/tftp.yml.j2
@@ -1,0 +1,4 @@
+---
+:enabled: {{ feature_enabled }}
+:tftproot: /var/lib/tftpboot
+:tftp_servername: {{ foreman_proxy_tftp_servername }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from requests.adapters import HTTPAdapter
 SSH_CONFIG = './.tmp/ssh-config'
 OBSAH_STATE = os.environ.get('OBSAH_STATE', '.var/lib/foremanctl')
 PARAMETERS_FILE = os.path.join(OBSAH_STATE, 'parameters.yaml')
+FOREMAN_PROXY_PORT = 8443
 
 
 class UserParameters:
@@ -269,6 +270,26 @@ class ResolveAdapter(HTTPAdapter):
         conn.host = self.target_ip
 
         return conn
+
+
+@pytest.fixture(scope="module")
+def proxy_request(server, certificates, server_fqdn):
+    def _request(path, method=None, data=None, return_body=False):
+        curl_opts = (
+            f"--cacert {certificates['server_ca_certificate']} "
+            f"--cert {certificates['client_certificate']} "
+            f"--key {certificates['client_key']} "
+            f"--silent "
+        )
+        if not return_body:
+            curl_opts += "--output /dev/null --write-out '%{http_code}' "
+        if method:
+            curl_opts += f"-X {method} "
+        if data:
+            curl_opts += f"-d '{data}' "
+        return server.run(f"curl {curl_opts}https://{server_fqdn}:{FOREMAN_PROXY_PORT}/{path}")
+
+    return _request
 
 
 @pytest.fixture(scope="module")

--- a/tests/foreman_proxy_test.py
+++ b/tests/foreman_proxy_test.py
@@ -3,23 +3,18 @@ import json
 
 import pytest
 
-FOREMAN_PROXY_PORT = 8443
+from tests.conftest import FOREMAN_PROXY_PORT
 
 
 @pytest.fixture(scope="module")
-def proxy_v2_features(server, certificates, server_fqdn):
-    cmd = server.run(
-        f"curl --cacert {certificates['server_ca_certificate']} "
-        f"--cert {certificates['client_certificate']} "
-        f"--key {certificates['client_key']} "
-        f"--silent https://{server_fqdn}:{FOREMAN_PROXY_PORT}/v2/features"
-    )
+def proxy_v2_features(proxy_request):
+    cmd = proxy_request("v2/features", return_body=True)
     assert cmd.succeeded, f"Failed to query /v2/features: {cmd.stderr}"
     return json.loads(cmd.stdout)
 
 
-def test_foreman_proxy_features(server, certificates, server_fqdn, enabled_features):
-    cmd = server.run(f"curl --cacert {certificates['server_ca_certificate']} --silent https://{server_fqdn}:{FOREMAN_PROXY_PORT}/features")
+def test_foreman_proxy_features(proxy_request, enabled_features):
+    cmd = proxy_request("features", return_body=True)
     assert cmd.succeeded
     features = json.loads(cmd.stdout)
     assert "logs" in features
@@ -29,6 +24,10 @@ def test_foreman_proxy_features(server, certificates, server_fqdn, enabled_featu
         assert "bmc" in features
     else:
         assert "bmc" not in features
+    if 'tftp' in enabled_features:
+        assert "tftp" in features
+    else:
+        assert "tftp" not in features
 
 
 def test_foreman_proxy_service(server):
@@ -54,6 +53,18 @@ def test_foreman_proxy_client_auth_to_foreman(server, certificates, server_fqdn)
     )
     assert cmd.succeeded
     assert cmd.stdout == '201'
+
+
+@pytest.mark.feature('tftp')
+def test_tftp_write_and_fetch(proxy_request, server):
+    test_mac = "aa:bb:cc:dd:ee:ff"
+    cmd = proxy_request(f"tftp/{test_mac}", data="syslinux_config=foremanctl+test+probe")
+    assert cmd.succeeded
+    assert cmd.stdout == '200', f"Expected HTTP 200 when creating TFTP PXE config, got {cmd.stdout}"
+
+    cmd = server.run("tftp 127.0.0.1 -c get pxelinux.cfg/01-aa-bb-cc-dd-ee-ff /tmp/foremanctl_tftp_test_download")
+    assert cmd.succeeded, f"TFTP get failed: {cmd.stdout}"
+    assert server.file("/tmp/foremanctl_tftp_test_download").content_string == "foremanctl test probe"
 
 
 @pytest.mark.feature('bmc')


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Support the TFTP Smart Proxy feature.

#### What are the changes introduced in this pull request?

* `foremanctl deploy ---add-feature tftp`

#### How to test this pull request



```shell
./foremanctl deploy --help

  --tftp-root FOREMAN_PROXY_TFTP_ROOT
                        Directory to serve TFTP files from. (persisted)
  --tftp-servername FOREMAN_PROXY_TFTP_SERVERNAME
                        Server name to use for TFTP. (persisted)
```

```shell
./foremanctl deploy --add-feature foreman-proxy --add-feature tftp \
  --tftp-root /var/lib/foreman-custom-tftp \
  --tftp-servername something-else.example.com \
```
Go to https://quadlet.example.com/smart_proxies/2-quadlet-example-com, TFTP should be enabled.

```
vagrant ssh quadlet
sudo podman exec -it foreman-proxy /bin/bash
```

```shell
cat /etc/foreman-proxy/settings.d/tftp.yml
```

```yaml
---
:enabled: false
:tftproot: /var/lib/foreman-custom-tftp
:tftp_servername: something-else.example.com
:tftp_connect_timeout: 10
:verify_server_cert: true
```

```
./foremanctl deploy --remove-feature tftp
./foremanctl features
=>

tftp                      available    Enable TFTP feature on Foreman Proxy
```

`cat /etc/foreman-proxy/settings.d/tftp.yml`
```yaml
---
:enabled: false
:tftproot: /var/lib/foreman-custom-tftp
:tftp_servername: something-else.example.com
:tftp_connect_timeout: 10
:verify_server_cert: true
```

Go to https://quadlet.example.com/smart_proxies/2-quadlet-example-com, TFTP should be disabled.

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
