### PR TITLE
Fixes #535 - Add httpd to foreman.target

### DIFF
--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -92,6 +92,28 @@
   notify:
     - Restart httpd
 
+- name: Create systemd drop-in directory for httpd
+  ansible.builtin.file:
+    path: /etc/systemd/system/httpd.service.d
+    state: directory
+    mode: "0755"
+
+- name: Add httpd to foreman.target
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/httpd.service.d/foreman-target.conf
+    mode: "0644"
+    content: |
+      [Unit]
+      PartOf=foreman.target
+
+      [Install]
+      WantedBy=foreman.target
+  notify: Restart httpd
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+
 - name: Flush handlers to restart services
   ansible.builtin.meta: flush_handlers
 

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -138,3 +138,11 @@ def test_httpd_config_syntax(server):
 def test_httpd_headers_use_dashes(server):
     cmd = server.run("grep -rPn 'RequestHeader\\s+set\\s+\\S*_\\S*\\s' /etc/httpd/conf.d/foreman.conf /etc/httpd/conf.d/foreman-ssl.conf /etc/httpd/conf.d/05-foreman.d/ /etc/httpd/conf.d/05-foreman-ssl.d/ 2>/dev/null")
     assert cmd.stdout.strip() == '', f"HTTP header names should use dashes, not underscores:\n{cmd.stdout}"
+
+
+def test_httpd_foreman_target_drop_in(server):
+    drop_in = server.file("/etc/systemd/system/httpd.service.d/foreman-target.conf")
+    assert drop_in.exists
+    assert drop_in.is_file
+    assert drop_in.contains("PartOf=foreman.target")
+    assert drop_in.contains("WantedBy=foreman.target")


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Apache was not a part of the foreman.target systemd target, leading to more difficult server administration and testing.

#### What are the changes introduced in this pull request?
- Added httpd to the foreman.target.
- Created a unit test to verify httpd is wanted by and part of the foreman.target.

#### How to test this pull request

Steps to reproduce:
1. Run `./forge vms start`.
2. Run `vagrant ssh quadlet` after VM boot.
3. Wait for services to spin up, then run `systemctl list-dependencies foreman.target` to verify httpd made the list.
4. Validate the unit test and source for quality.

#### Checklist
* [X] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable) <- Nothing to document imho
