### PR TITLE
Use role defaults for container images in IOP tests

### DIFF
--- a/tests/iop/conftest.py
+++ b/tests/iop/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+import yaml
+
+ROLE_MAP = {
+    "iop-ingress": "iop_ingress",
+    "iop-inventory": "iop_inventory",
+    "iop-advisor": "iop_advisor",
+}
+
+
+def _load_role_image(role_name):
+    with open(f"src/roles/{role_name}/defaults/main.yaml") as f:
+        defaults = yaml.safe_load(f)
+    image = defaults[f"{role_name}_container_image"]
+    tag = defaults[f"{role_name}_container_tag"]
+    return f"{image}:{tag}"
+
+
+@pytest.fixture(scope="module")
+def iop_image():
+    cache = {}
+
+    def _get(name):
+        if name not in cache:
+            cache[name] = _load_role_image(ROLE_MAP[name])
+        return cache[name]
+
+    return _get

--- a/tests/iop/test_advisor.py
+++ b/tests/iop/test_advisor.py
@@ -137,6 +137,6 @@ def test_advisor_fdw_permissions_on_view(server):
     assert "SELECT" in result.stdout
 
 
-def test_advisor_api_endpoint(server):
-    result = server.run("podman run --network=iop-core-network --rm quay.io/iop/advisor-backend:latest curl -s -o /dev/null -w '%{http_code}' http://iop-service-advisor-backend-api:8000/ 2>/dev/null || echo '000'")
+def test_advisor_api_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-advisor')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-service-advisor-backend-api:8000/ 2>/dev/null || echo '000'")
     assert result.stdout.strip() != "000"

--- a/tests/iop/test_ingress.py
+++ b/tests/iop/test_ingress.py
@@ -9,7 +9,7 @@ def test_ingress_service(server):
     assert service.is_enabled
 
 
-def test_ingress_http_endpoint(server):
-    result = server.run("podman run --rm quay.io/iop/ingress:latest curl -s -o /dev/null -w '%{http_code}' http://iop-core-ingress:8080/")
+def test_ingress_http_endpoint(server, iop_image):
+    result = server.run(f"podman run --rm {iop_image('iop-ingress')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-ingress:8080/")
     if result.succeeded:
         assert "200" in result.stdout

--- a/tests/iop/test_integration.py
+++ b/tests/iop/test_integration.py
@@ -87,13 +87,13 @@ def test_iop_core_host_inventory_api_service(server):
         assert service.is_enabled
 
 
-def test_iop_inventory_mq_endpoint(server):
-    result = server.run("podman run --network=iop-core-network quay.io/iop/host-inventory:latest curl http://iop-core-host-inventory:9126/ 2>/dev/null || echo 'Host inventory MQ not yet responding'")
+def test_iop_inventory_mq_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network {iop_image('iop-inventory')} curl http://iop-core-host-inventory:9126/ 2>/dev/null || echo 'Host inventory MQ not yet responding'")
     assert result.rc == 0
 
 
-def test_iop_inventory_api_health_endpoint(server):
-    result = server.run("podman run --network=iop-core-network quay.io/iop/host-inventory curl -s -o /dev/null -w '%{http_code}' http://iop-core-host-inventory-api:8081/health 2>/dev/null || echo '000'")
+def test_iop_inventory_api_health_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network {iop_image('iop-inventory')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-host-inventory-api:8081/health 2>/dev/null || echo '000'")
     assert "200" in result.stdout
 
 
@@ -113,8 +113,8 @@ def test_iop_service_advisor_backend_service(server):
         assert service.is_enabled
 
 
-def test_iop_advisor_api_endpoint(server):
-    result = server.run("podman run --network=iop-core-network --rm quay.io/iop/advisor-backend:latest curl -f http://iop-service-advisor-backend-api:8000/ 2>/dev/null || echo 'Advisor API not yet responding'")
+def test_iop_advisor_api_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-advisor')} curl -f http://iop-service-advisor-backend-api:8000/ 2>/dev/null || echo 'Advisor API not yet responding'")
     assert result.rc == 0
 
 

--- a/tests/iop/test_inventory.py
+++ b/tests/iop/test_inventory.py
@@ -26,14 +26,14 @@ def test_inventory_service_dependencies(server):
     assert "iop-core-host-inventory-migrate.service" in result.stdout
 
 
-def test_inventory_api_endpoint(server):
-    result = server.run("podman run --rm quay.io/iop/host-inventory:latest curl -s -o /dev/null -w '%{http_code}' http://iop-core-host-inventory-api:8081/health")
+def test_inventory_api_endpoint(server, iop_image):
+    result = server.run(f"podman run --rm {iop_image('iop-inventory')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-host-inventory-api:8081/health")
     if result.succeeded:
         assert "200" in result.stdout
 
 
-def test_inventory_hosts_endpoint(server):
-    result = server.run("podman run --rm quay.io/iop/host-inventory:latest curl -s -o /dev/null -w '%{http_code}' http://iop-core-host-inventory-api:8081/api/inventory/v1/hosts")
+def test_inventory_hosts_endpoint(server, iop_image):
+    result = server.run(f"podman run --rm {iop_image('iop-inventory')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-host-inventory-api:8081/api/inventory/v1/hosts")
     if result.succeeded:
         assert "200" in result.stdout
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

IOP tests hardcoded container image references (e.g. `quay.io/iop/host-inventory:latest`), which meant they could drift out of sync with the actual images configured in role defaults. If the image or tag changed in deployment configuration, the tests would still use the old values.

#### What are the changes introduced in this pull request?

* Add a shared `iop_image` pytest fixture in `tests/iop/conftest.py` that reads `container_image` and `container_tag` from each role's `defaults/main.yaml`
* Replace all hardcoded `quay.io/iop/*` image references across `test_advisor.py`, `test_ingress.py`, `test_integration.py`, and `test_inventory.py` with calls to the `iop_image` fixture

#### How to test this pull request

Steps to reproduce:

* Deploy an IOP environment and run the IOP test suite: `python -m pytest tests/iop/ -vv`
* Verify that the container images used in test `podman run` commands match the values from the corresponding role defaults under `src/roles/`

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
