### PR TITLE
Fix IOP tests to properly validate service endpoints

### DIFF
--- a/tests/iop/conftest.py
+++ b/tests/iop/conftest.py
@@ -5,6 +5,8 @@ ROLE_MAP = {
     "iop-ingress": "iop_ingress",
     "iop-inventory": "iop_inventory",
     "iop-advisor": "iop_advisor",
+    "iop-gateway": "iop_gateway",
+    "iop-remediation": "iop_remediation",
 }
 
 

--- a/tests/iop/test_advisor.py
+++ b/tests/iop/test_advisor.py
@@ -138,5 +138,5 @@ def test_advisor_fdw_permissions_on_view(server):
 
 
 def test_advisor_api_endpoint(server, iop_image):
-    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-advisor')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-service-advisor-backend-api:8000/ 2>/dev/null || echo '000'")
-    assert result.stdout.strip() != "000"
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-advisor')} curl --fail -s -o /dev/null http://iop-service-advisor-backend-api:8000/api/insights/v1/status/live/")
+    assert result.succeeded

--- a/tests/iop/test_ingress.py
+++ b/tests/iop/test_ingress.py
@@ -10,6 +10,5 @@ def test_ingress_service(server):
 
 
 def test_ingress_http_endpoint(server, iop_image):
-    result = server.run(f"podman run --rm {iop_image('iop-ingress')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-ingress:8080/")
-    if result.succeeded:
-        assert "200" in result.stdout
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-ingress')} curl --fail -s -o /dev/null http://iop-core-ingress:8080/")
+    assert result.succeeded

--- a/tests/iop/test_integration.py
+++ b/tests/iop/test_integration.py
@@ -17,9 +17,9 @@ def test_iop_core_ingress_service(server):
         assert service.is_enabled
 
 
-def test_iop_ingress_endpoint(server):
-    result = server.run("curl -f http://localhost:8080/ 2>/dev/null || echo 'Ingress not yet responding'")
-    assert result.rc == 0
+def test_iop_ingress_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-core-ingress:8080/")
+    assert result.succeeded
 
 
 def test_iop_core_puptoo_service(server):
@@ -30,9 +30,9 @@ def test_iop_core_puptoo_service(server):
         assert service.is_enabled
 
 
-def test_iop_puptoo_metrics_endpoint(server):
-    result = server.run("curl -f http://localhost:8000/metrics 2>/dev/null || echo 'Puptoo not yet responding'")
-    assert result.rc == 0
+def test_iop_puptoo_metrics_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-core-puptoo:8000/metrics")
+    assert result.succeeded
 
 
 def test_iop_core_yuptoo_service(server):
@@ -43,9 +43,9 @@ def test_iop_core_yuptoo_service(server):
         assert service.is_enabled
 
 
-def test_iop_yuptoo_endpoint(server):
-    result = server.run("curl -f http://localhost:5005/ 2>/dev/null || echo 'Yuptoo not yet responding'")
-    assert result.rc == 0
+def test_iop_yuptoo_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-core-yuptoo:5005/")
+    assert result.succeeded
 
 
 def test_iop_core_engine_service(server):
@@ -64,19 +64,14 @@ def test_iop_core_gateway_service(server):
         assert service.is_enabled
 
 
-def test_iop_gateway_endpoint(server):
-    result = server.run("curl -f http://localhost:24443/ 2>/dev/null || echo 'Gateway not yet responding'")
-    assert result.rc == 0
-
-
-def test_iop_gateway_api_ingress_endpoint(server):
-    result = server.run("curl -f http://localhost:24443/api/ingress 2>/dev/null || echo 'Gateway API ingress not yet responding'")
-    assert result.rc == 0
+def test_iop_gateway_endpoint(server, certificates):
+    result = server.run(f"curl --fail -s -o /dev/null https://localhost:24443/ --cert {certificates['iop_gateway_client_certificate']} --key {certificates['iop_gateway_client_key']} --cacert {certificates['iop_gateway_client_ca_certificate']}")
+    assert result.succeeded
 
 
 def test_iop_gateway_https_cert_auth(server, certificates):
-    result = server.run(f"curl -s -o /dev/null -w '%{{http_code}}' https://localhost:24443/ --cert {certificates['iop_gateway_client_certificate']} --key {certificates['iop_gateway_client_key']} --cacert {certificates['iop_gateway_client_ca_certificate']} 2>/dev/null || echo '000'")
-    assert "200" in result.stdout
+    result = server.run(f"curl --fail -s -o /dev/null https://localhost:24443/ --cert {certificates['iop_gateway_client_certificate']} --key {certificates['iop_gateway_client_key']} --cacert {certificates['iop_gateway_client_ca_certificate']}")
+    assert result.succeeded
 
 
 def test_iop_core_host_inventory_api_service(server):
@@ -88,13 +83,13 @@ def test_iop_core_host_inventory_api_service(server):
 
 
 def test_iop_inventory_mq_endpoint(server, iop_image):
-    result = server.run(f"podman run --network=iop-core-network {iop_image('iop-inventory')} curl http://iop-core-host-inventory:9126/ 2>/dev/null || echo 'Host inventory MQ not yet responding'")
-    assert result.rc == 0
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-core-host-inventory:9126/")
+    assert result.succeeded
 
 
 def test_iop_inventory_api_health_endpoint(server, iop_image):
-    result = server.run(f"podman run --network=iop-core-network {iop_image('iop-inventory')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-host-inventory-api:8081/health 2>/dev/null || echo '000'")
-    assert "200" in result.stdout
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-core-host-inventory-api:8081/health")
+    assert result.succeeded
 
 
 def test_iop_service_advisor_backend_api_service(server):
@@ -114,8 +109,8 @@ def test_iop_service_advisor_backend_service(server):
 
 
 def test_iop_advisor_api_endpoint(server, iop_image):
-    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-advisor')} curl -f http://iop-service-advisor-backend-api:8000/ 2>/dev/null || echo 'Advisor API not yet responding'")
-    assert result.rc == 0
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-service-advisor-backend-api:8000/api/insights/v1/status/live/")
+    assert result.succeeded
 
 
 def test_iop_service_remediations_api_service(server):
@@ -126,6 +121,6 @@ def test_iop_service_remediations_api_service(server):
         assert service.is_enabled
 
 
-def test_iop_remediations_api_endpoint(server):
-    result = server.run("curl -f http://localhost:9002/ 2>/dev/null || echo 'Remediations API not yet responding'")
-    assert result.rc == 0
+def test_iop_remediations_api_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-gateway')} curl --fail -s -o /dev/null http://iop-service-remediations-api:9002/health")
+    assert result.succeeded

--- a/tests/iop/test_inventory.py
+++ b/tests/iop/test_inventory.py
@@ -27,15 +27,8 @@ def test_inventory_service_dependencies(server):
 
 
 def test_inventory_api_endpoint(server, iop_image):
-    result = server.run(f"podman run --rm {iop_image('iop-inventory')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-host-inventory-api:8081/health")
-    if result.succeeded:
-        assert "200" in result.stdout
-
-
-def test_inventory_hosts_endpoint(server, iop_image):
-    result = server.run(f"podman run --rm {iop_image('iop-inventory')} curl -s -o /dev/null -w '%{{http_code}}' http://iop-core-host-inventory-api:8081/api/inventory/v1/hosts")
-    if result.succeeded:
-        assert "200" in result.stdout
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-inventory')} curl --fail -s -o /dev/null http://iop-core-host-inventory-api:8081/health")
+    assert result.succeeded
 
 
 def test_inventory_cleanup_service(server):

--- a/tests/iop/test_remediation.py
+++ b/tests/iop/test_remediation.py
@@ -24,6 +24,6 @@ def test_remediation_api_environment_variables(server):
     assert "DB_SSL_ENABLED=false" in result.stdout
 
 
-def test_remediation_api_endpoint(server):
-    result = server.run("curl -s -o /dev/null -w '%{http_code}' http://localhost:9002/ 2>/dev/null || echo '000'")
-    assert result.stdout.strip() != "000"
+def test_remediation_api_endpoint(server, iop_image):
+    result = server.run(f"podman run --network=iop-core-network --rm {iop_image('iop-remediation')} curl --fail -s -o /dev/null http://iop-service-remediations-api:9002/health")
+    assert result.succeeded


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The IOP HTTP endpoint tests had several issues that prevented them from actually validating services:
- Tests curled `localhost` for ports not published to the host (only the gateway publishes 24443)
- `|| echo` fallbacks made `rc` always 0, so tests passed whether services were up or down
- `if result.succeeded` guards silently skipped assertions when `podman run` failed due to missing `--network`
- Endpoint paths didn't match the actual health/liveness endpoints exposed by the services

#### What are the changes introduced in this pull request?

* Add `--network=iop-core-network` to all `podman run` curl commands so container DNS resolves
* Remove all `|| echo` fallbacks and `if result.succeeded` guards so failures surface
* Use correct service endpoints from puppet-iop acceptance specs: `/api/insights/v1/status/live/` for advisor, `/health` for remediations

#### How to test this pull request

Steps to reproduce:

* Deploy IOP with `./foremanctl deploy`
* Run IOP tests: `./forge test --pytest_args="tests/iop/"`
* Verify all HTTP endpoint tests actually reach services and assert real status codes

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
