### PR TITLE
Fix broker inventory parsing of ruamel YAML tags

### DIFF
--- a/inventories/broker.py
+++ b/inventories/broker.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 
@@ -16,16 +17,29 @@ def parse_args():
     return parser.parse_args()
 
 
+def parse_broker_inventory(output):
+    # Broker emits ruamel-specific tags (e.g. !NetworkType) that safe_load rejects.
+    output = re.sub(r'!\w+\s+', '', output)
+    inventory = yaml.safe_load(output)
+    if not inventory:
+        return
+    return inventory.values()
+
+
 def get_running_hosts():
     cmd = ["broker", "inventory", "--details"]
 
     try:
-        output = subprocess.check_output(cmd, universal_newlines=True).rstrip()
-    except FileNotFoundError:
+        output = subprocess.check_output(
+            cmd, universal_newlines=True, stderr=subprocess.DEVNULL
+        ).rstrip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
         return
 
-    hosts = yaml.safe_load(output)
-    return hosts.values()
+    try:
+        return parse_broker_inventory(output)
+    except yaml.YAMLError:
+        return
 
 
 def list_running_hosts():
@@ -65,8 +79,8 @@ def main():
     if args.list:
         json.dump(hosts, sys.stdout)
     elif args.host:
-        details = hosts['_meta']['hostvars']
-        json.dump(details[args.host], sys.stdout)
+        details = hosts['_meta']['hostvars'].get(args.host, {})
+        json.dump(details, sys.stdout)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

`inventories/broker.py` uses `yaml.safe_load()` to parse the output of `broker inventory --details`. When Broker returns YAML containing ruamel-specific tags such as `!NetworkType`, parsing fails with a `ConstructorError`, causing the inventory script to exit with a non-zero status.

As a result, Ansible reports inventory parse failures for `broker.py` on every `forge` / `foremanctl` run, even in workflows that do not depend on Broker hosts, such as local Vagrant-based development environments.

Fixes https://github.com/theforeman/foremanctl/issues/545

Related: https://github.com/SatelliteQE/broker

#### What are the changes introduced in this pull request?

* Add `parse_broker_inventory()` to strip ruamel-specific YAML tags before `safe_load()`
* Handle `subprocess.CalledProcessError` and `yaml.YAMLError` and return an empty inventory when broker is missing or fails
* Suppress broker stderr during inventory collection to avoid noise in Ansible output
* Return `{}` for unknown `--host` lookups instead of raising `KeyError`

#### How to test this pull request

Steps to reproduce:

1. Install and configure Broker (`pip install broker`).
2. Check out a host whose inventory contains tagged values (for example, `!NetworkType`).
3. On `master`, run:

   ```bash
   python3 inventories/broker.py --list
   ```

   Verify it fails with:

   ```text
   yaml.constructor.ConstructorError: could not determine a constructor for the tag '!NetworkType'
   ```

4. On this branch, run the same command and verify it exits 0 and prints valid JSON inventory.
5. Run a command that triggers inventory loading, such as:

   ```bash
   ./forge vms start
   ```

   or

   ```bash
   ./foremanctl deploy
   ```

   Verify that Ansible does not report broker inventory parse failures.
6. With broker not installed, run `python3 inventories/broker.py --list` and verify it exits 0 with an empty inventory (`"hosts": []`).

#### Checklist

* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
