### PR TITLE
Remove the duplicate HTTPS entry

### DIFF
--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -84,7 +84,7 @@
           Foreman development environment deployed successfully!
 
           Access URLs:
-            - Foreman UI: https://{{ foreman_development_url }}
+            - Foreman UI: {{ foreman_development_url }}
             - Direct Rails: http://localhost:3000 (when running)
 
           Credentials:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The development environment info message displayed after a successful forge deploy-dev shows a malformed URL for the Foreman UI. The variable foreman_development_url is defined in **`development/roles/foreman_development/defaults/main.yaml as:`**

**main.yaml**
**`foreman_development_url: "http://{{ ansible_facts['fqdn'] }}:{{ foreman_development_rails_port }}`** 
This variable already includes the **`http://`** scheme. However, the info message template in **`deploy-dev.yaml`** was incorrectly prepending https:// in front of it:

- **`Foreman UI: https://{{ foreman_development_url }}`**
This produced a double-scheme URL like https://http://foremanctl.example.com:3000, which is invalid and confusing for users.

#### What are the changes introduced in this pull request?
A single-line fix in **`development/playbooks/deploy-dev/deploy-dev.yaml:`** remove the hardcoded **`https://`** prefix from the Foreman UI URL in the post-deploy info message, so the variable foreman_development_url is used directly (which already contains the correct http:// scheme).

Before:
- Foreman UI: https://{{ foreman_development_url }}

After:
- Foreman UI: {{ foreman_development_url }}
This produces the correct URL: http://<fqdn>:3000.

#### How to test this pull request
Steps to reproduce:
Deploy the development environment:

1. **`./forge deploy-dev`**

2. Access URLs:

  - Foreman UI: http://<your-fqdn>:3000
Confirm the URL is not displayed as https://http://<fqdn>:3000.

Fixes https://github.com/theforeman/foremanctl/issues/454

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)