### PR TITLE
Fixes #560 - Add systemctl wants to foreman.target for httpd

### DIFF
--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -103,12 +103,10 @@
     dest: /etc/systemd/system/httpd.service.d/foreman-target.conf
     mode: "0644"
     content: |
+      [Install]
+      WantedBy=default.target foreman.target
       [Unit]
       PartOf=foreman.target
-
-      [Install]
-      WantedBy=foreman.target
-  notify: Restart httpd
 
 - name: Reload systemd daemon
   ansible.builtin.systemd:

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -140,9 +140,13 @@ def test_httpd_headers_use_dashes(server):
     assert cmd.stdout.strip() == '', f"HTTP header names should use dashes, not underscores:\n{cmd.stdout}"
 
 
-def test_httpd_foreman_target_drop_in(server):
+def test_httpd_foreman_target_config(server):
     drop_in = server.file("/etc/systemd/system/httpd.service.d/foreman-target.conf")
     assert drop_in.exists
     assert drop_in.is_file
     assert drop_in.contains("PartOf=foreman.target")
-    assert drop_in.contains("WantedBy=foreman.target")
+    assert drop_in.contains(r"WantedBy=default\.target foreman\.target")
+
+    wants_link = server.file("/etc/systemd/system/foreman.target.wants/httpd.service")
+    assert wants_link.exists
+    assert wants_link.is_symlink


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
When running systemctl start foreman.target, Apache (httpd) does not start on it's own. I attempted to include this as a part of the fix in https://github.com/theforeman/foremanctl/pull/536 but biffed the implementation.

#### What are the changes introduced in this pull request?

* Corrects `foreman.target`'s wants to properly include httpd. The old add-wants block was skipped by systemctl due to httpd being in the `multi-user.target` (higher prio). This was fine unless the user manually wanted to run `systemctl stop foreman.target` and `systemctl start foreman.target`, which might sometimes be the case.

#### How to test this pull request

Steps to reproduce:
1. Pull changes and rebuild the VMs.
2. Run `vagrant ssh quadlet` after VM boot.
3. Wait for services to spin up, then run `systemctl list-dependencies foreman.target` to verify httpd made the list.
4. Run `systemctl stop foreman.target` and `systemctl status httpd` to ensure it stopped.
5. Run `systemctl start foreman.target` and `systemctl status httpd` to ensure it is running.
6. Validate unit test changes.

#### Checklist
* [X] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable) N/A
