### PR TITLE
Fixes #562 - Remove dead code from health subcommand

### DIFF
--- a/src/playbooks/health/health.yaml
+++ b/src/playbooks/health/health.yaml
@@ -8,7 +8,6 @@
     - "../../vars/flavors/{{ flavor }}.yml"
     - "../../vars/base.yaml"
     - "../../vars/database.yml"
-    - "../../vars/health.yml"
   tasks:
     - name: Execute health checks
       ansible.builtin.include_role:

--- a/src/roles/check_duplicate_permissions/tasks/main.yaml
+++ b/src/roles/check_duplicate_permissions/tasks/main.yaml
@@ -15,7 +15,6 @@
   changed_when: false
 
 - name: Check for duplicate permissions
-  when: not (health_fix | default(false) | bool)
   ansible.builtin.assert:
     that:
       - check_duplicate_permissions_result.rowcount == 0


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Ian pointed out two areas of dead code in https://github.com/theforeman/foremanctl/pull/521 after merge.

#### What are the changes introduced in this pull request?
* Removes the dead code.

#### How to test this pull request

Steps to reproduce:
1. Verify that both removals in source are dead code.
2. Ensure `foremanctl health` still runs as normal.

#### Checklist
* [ ] Tests added/updated (if applicable) N/A
* [ ] Documentation updated (if applicable) N/A
