### PR TITLE
don't load template if feature is disabled

### DIFF
--- a/src/roles/foreman_proxy/tasks/feature.yaml
+++ b/src/roles/foreman_proxy/tasks/feature.yaml
@@ -3,7 +3,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-proxy-{{ feature_name }}-yml
-    data: "{{ lookup('ansible.builtin.template', 'settings.d/' + feature_name + '.yml.j2') }}"
+    data: "{{ lookup('ansible.builtin.template', 'settings.d/' + feature_name + '.yml.j2') if feature_enabled != 'false' else ':enabled: false' }}"
   notify:
     - Restart Foreman Proxy
     - Refresh Foreman Proxy


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The feature template might have variables that are undefined when the feature is disabled.

#### What are the changes introduced in this pull request?

* use a trivial "enabled: false" string instead

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
