### PR TITLE
Download CentOS Stream 10 Vagrant box directly from CentOS mirrors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,9 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "quadlet" do |override|
     override.vm.box = ENV.fetch("FOREMANCTL_BASE_BOX", "centos/stream9")
+    if override.vm.box == "centos/stream10"
+      override.vm.box_url = "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-libvirt.box"
+    end
     override.vm.hostname = "quadlet.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The version published in the Hashicorp portal is broken, see https://redhat.atlassian.net/browse/CS-3411 for details

#### What are the changes introduced in this pull request?

* Use a box url

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
