### PR TITLE
Add --preserve-plugin-branches flag to deploy-dev

### DIFF
--- a/development/playbooks/deploy-dev/metadata.obsah.yaml
+++ b/development/playbooks/deploy-dev/metadata.obsah.yaml
@@ -29,6 +29,10 @@ variables:
   foreman_development_github_username:
     help: GitHub username to add as additional remote for git checkouts
     action: store
+  foreman_development_preserve_plugin_branches:
+    parameter: --preserve-plugin-branches
+    help: Skip git checkout for plugins, preserving local branches and changes.
+    type: Boolean
 
 include:
   - _flavor_features

--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -153,7 +153,9 @@
     foreman_development_plugin_name: "{{ foreman_development_plugin_config.name.split('/')[1] }}"
     foreman_development_plugin_org: "{{ foreman_development_plugin_config.name.split('/')[0] }}"
     foreman_development_plugin_repo_url: "https://github.com/{{ foreman_development_plugin_config.name }}.git"
-    foreman_development_plugin_manage_repo: "{{ foreman_development_plugin_config.manage_repo | default(true) }}"
+    foreman_development_plugin_manage_repo: >-
+      {{ false if foreman_development_preserve_plugin_branches | default(false)
+      else foreman_development_plugin_config.manage_repo | default(true) }}
     foreman_development_plugin_settings_template: "{{ foreman_development_plugin_config.settings_template | default('') }}"
     foreman_development_plugin_extra_gemfiles: "{{ foreman_development_plugin_config.extra_gemfiles | default([]) }}"
   loop: "{{ foreman_development_default_plugins + foreman_development_enabled_plugins }}"


### PR DESCRIPTION
## Summary
- Adds `--preserve-plugin-branches` flag to `forge deploy-dev`
- When passed, skips `git checkout` for all plugins, preserving local branches and uncommitted changes across deploy-dev runs
- Useful when developing on a plugin and re-running deploy-dev without losing your working branch

## Usage
```bash
forge deploy-dev --preserve-plugin-branches
```

## Test plan
- [ ] Run `forge deploy-dev` without the flag — plugins should be checked out to upstream HEAD as before
- [ ] Run `forge deploy-dev --preserve-plugin-branches` with a plugin on a local branch — branch should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)