### PR TITLE
Add --manage-repos parameter for forge deploy-dev

### DIFF
--- a/development/playbooks/deploy-dev/metadata.obsah.yaml
+++ b/development/playbooks/deploy-dev/metadata.obsah.yaml
@@ -29,6 +29,10 @@ variables:
   foreman_development_github_username:
     help: GitHub username to add as additional remote for git checkouts
     action: store
+  foreman_development_manage_repos:
+    parameter: --manage-repos
+    help: Manage git repositories for Foreman and plugins. Set to false to skip cloning and checking out repositories.
+    type: Boolean
 
 include:
   - _flavor_features

--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -95,6 +95,7 @@
     git_repository_repository_name: "foreman"
     git_repository_revision: "{{ foreman_development_git_revision }}"
     git_repository_secondary_remote_owner: "{{ foreman_development_github_username }}"
+  when: foreman_development_manage_repos | default(true)
 
 - name: Create database configuration
   ansible.builtin.template:
@@ -153,7 +154,9 @@
     foreman_development_plugin_name: "{{ foreman_development_plugin_config.name.split('/')[1] }}"
     foreman_development_plugin_org: "{{ foreman_development_plugin_config.name.split('/')[0] }}"
     foreman_development_plugin_repo_url: "https://github.com/{{ foreman_development_plugin_config.name }}.git"
-    foreman_development_plugin_manage_repo: "{{ foreman_development_plugin_config.manage_repo | default(true) }}"
+    foreman_development_plugin_manage_repo: >-
+      {{ (foreman_development_manage_repos | default(true))
+      and (foreman_development_plugin_config.manage_repo | default(true)) }}
     foreman_development_plugin_settings_template: "{{ foreman_development_plugin_config.settings_template | default('') }}"
     foreman_development_plugin_extra_gemfiles: "{{ foreman_development_plugin_config.extra_gemfiles | default([]) }}"
   loop: "{{ foreman_development_default_plugins + foreman_development_enabled_plugins }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

When iterating on Foreman or plugin code during development, `forge deploy-dev` clones and checks out the default branch for each repository, discarding any local branches or changes. There is no way to disable this behavior for subsequent deploys.

#### What are the changes introduced in this pull request?

* Add `--manage-repos` CLI parameter for `forge deploy-dev` that controls whether git repositories are cloned and checked out. Set to `false` to skip repository management for both Foreman and plugins.
* When `--manage-repos=false`, the global setting takes precedence but individual plugin `manage_repo` config is still respected when the global flag is not set.

#### How to test this pull request

Steps to reproduce:

* Run `forge deploy-dev` to do an initial deploy
* Check out a custom branch in Foreman or a plugin directory
* Run `forge deploy-dev --manage-repos=false` and verify repositories are not touched

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)