### PR TITLE
[CP] Fixes #560 - Add systemctl wants to foreman.target for httpd

### DIFF
--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -103,12 +103,10 @@
     dest: /etc/systemd/system/httpd.service.d/foreman-target.conf
     mode: "0644"
     content: |
+      [Install]
+      WantedBy=default.target foreman.target
       [Unit]
       PartOf=foreman.target
-
-      [Install]
-      WantedBy=foreman.target
-  notify: Restart httpd
 
 - name: Reload systemd daemon
   ansible.builtin.systemd:

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -140,9 +140,13 @@ def test_httpd_headers_use_dashes(server):
     assert cmd.stdout.strip() == '', f"HTTP header names should use dashes, not underscores:\n{cmd.stdout}"
 
 
-def test_httpd_foreman_target_drop_in(server):
+def test_httpd_foreman_target_config(server):
     drop_in = server.file("/etc/systemd/system/httpd.service.d/foreman-target.conf")
     assert drop_in.exists
     assert drop_in.is_file
     assert drop_in.contains("PartOf=foreman.target")
-    assert drop_in.contains("WantedBy=foreman.target")
+    assert drop_in.contains(r"WantedBy=default\.target foreman\.target")
+
+    wants_link = server.file("/etc/systemd/system/foreman.target.wants/httpd.service")
+    assert wants_link.exists
+    assert wants_link.is_symlink


### PR DESCRIPTION
Cherry pick of https://github.com/theforeman/foremanctl/pull/561 to the 2.y branch. The other commit which added httpd to foreman.target needs these changes applied to function 100% correctly (`systemctl start foreman.target` does not function).
