### PR TITLE
Refs #226 - Gate deploy roles on enabled_features and add foreman-proxy flavor

### DIFF
--- a/src/playbooks/_flavor_features/metadata.obsah.yaml
+++ b/src/playbooks/_flavor_features/metadata.obsah.yaml
@@ -4,6 +4,7 @@ variables:
     help: Base flavor to use in this deployment.
     choices:
       - katello
+      - foreman-proxy
   features:
     parameter: --add-feature
     help: Additional features to enable in this deployment.

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -27,11 +27,15 @@
     - role: postgresql
       when:
         - database_mode == 'internal'
-    - redis
-    - candlepin
+    - role: redis
+      when: "'foreman' in enabled_features or 'katello' in enabled_features"
+    - role: candlepin
+      when: "'katello' in enabled_features"
     - httpd
-    - pulp
-    - foreman
+    - role: pulp
+      when: "'katello' in enabled_features"
+    - role: foreman
+      when: "'foreman' in enabled_features"
     - role: systemd_target
     - role: iop_core
       when:

--- a/src/vars/flavors/foreman-proxy.yml
+++ b/src/vars/flavors/foreman-proxy.yml
@@ -1,0 +1,3 @@
+---
+flavor_features:
+  - foreman-proxy


### PR DESCRIPTION
## Summary

- Gate `redis`, `candlepin`, `pulp`, and `foreman` roles on `enabled_features` in `deploy.yaml` so non-server flavors skip server-only services
- Add a `foreman-proxy` flavor (`flavor_features: [foreman-proxy]`) for standalone smart proxy deployments
- Register `foreman-proxy` as a valid `--flavor` choice in the metadata

## Motivation

This is the foundational change needed for smart proxy support (issue #226). By making deploy roles conditional, future flavors (like `foreman-proxy-content` from #571) can deploy subsets of services without running the full server stack.

The existing `katello` flavor includes both `foreman` and `katello` in its `flavor_features`, so all role conditions evaluate to true for existing deployments — this is fully backward-compatible.

## Relationship to existing PRs

This extracts the deploy.yaml gating pattern from #527 (which has merge conflicts) as a standalone, mergeable change. The `foreman-proxy-content` flavor from #571 builds on this foundation but is left for that PR to handle since it involves additional proxy registration and content mirroring work.

## How to test

### Existing katello flavor (no regression)

```bash
foremanctl deploy --initial-admin-password=changeme --tuning default
# All services should start as before
```

### New foreman-proxy flavor

```bash
foremanctl deploy --flavor foreman-proxy --initial-admin-password=changeme
# Only httpd + foreman-proxy should start
# redis, candlepin, pulp, foreman should be skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)