### PR TITLE
Don't leak PostgreSQL credentials when looping over DBs

### DIFF
--- a/src/roles/backup/tasks/database_dumps.yaml
+++ b/src/roles/backup/tasks/database_dumps.yaml
@@ -12,6 +12,7 @@
   environment:
     PGPASSWORD: "{{ item.password }}"
   loop: "{{ backup_databases_config }}"
+  no_log: true
   loop_control:
     label: "{{ item.name }}"
   changed_when: true

--- a/src/roles/backup/tasks/preflight.yaml
+++ b/src/roles/backup/tasks/preflight.yaml
@@ -93,4 +93,5 @@
   vars:
     check_database_index_database: "{{ item.database }}"
   loop: "{{ backup_databases }}"
+  no_log: true
   when: backup_database_mode == 'internal'

--- a/src/roles/checks/tasks/main.yml
+++ b/src/roles/checks/tasks/main.yml
@@ -13,6 +13,7 @@
   vars:
     check_database_index_database: "{{ item.database }}"
   loop: "{{ checks_databases }}"
+  no_log: true
   when: database_mode == 'internal'
 
 - name: Report status of checks


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The list we're looping over includes credentials, so we should not log any of that.

Fixes: ba1f1a500901f6f8c7347a63969e9e66c33438fb

#### What are the changes introduced in this pull request?

* set no_log

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
