### PR TITLE
Include CA bundle in the bundle

### DIFF
--- a/src/playbooks/certificate-bundle/certificate-bundle.yaml
+++ b/src/playbooks/certificate-bundle/certificate-bundle.yaml
@@ -22,6 +22,7 @@
     - role: certificate_bundle
       vars:
         certificate_bundle_hostname: "{{ hostname }}"
+        certificate_bundle_ca_bundle: "{{ ca_bundle }}"
         certificate_bundle_ca_certificate: "{{ ca_certificate }}"
         certificate_bundle_server_ca_certificate: "{{ server_ca_certificate }}"
         certificate_bundle_server_certificate: "{{ certificates_ca_directory }}/hosts/{{ hostname }}/certs/{{ hostname }}.crt"

--- a/src/roles/certificate_bundle/tasks/main.yml
+++ b/src/roles/certificate_bundle/tasks/main.yml
@@ -42,6 +42,13 @@
         remote_src: true
         mode: '0444'
 
+    - name: Copy CA bundle
+      ansible.builtin.copy:
+        src: "{{ certificate_bundle_ca_bundle }}"
+        dest: "{{ certificate_bundle_build_directory.path }}/certs/certs/ca-bundle.crt"
+        remote_src: true
+        mode: '0444'
+
     - name: Copy server certificate
       ansible.builtin.copy:
         src: "{{ certificate_bundle_server_certificate }}"

--- a/tests/certificate_bundle_test.py
+++ b/tests/certificate_bundle_test.py
@@ -8,6 +8,7 @@ TARBALL = f'/var/lib/foremanctl/certs/bundles/{HOSTNAME}.tar.gz'
 EXPECTED_CA_FILES = [
     'certs/certs/ca.crt',
     'certs/certs/server-ca.crt',
+    'certs/certs/ca-bundle.crt',
 ]
 
 EXPECTED_SERVER_FILES = [


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

We need the "ca-bundle" file when interacting with the Foreman system.
Either generated or copied. Copied seems easier.

#### What are the changes introduced in this pull request?

* Copy the ca-bundle file

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
