### PR TITLE
Use different foremanctl versions when testing upgrades

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,12 +222,13 @@ jobs:
       fail-fast: false
       matrix:
         upgrade_from:
-          - '3.18'
-        upgrade_to:
-          - 'nightly'
+          - '2.y-stable'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.upgrade_from }}
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -244,9 +245,6 @@ jobs:
       - name: Configure repositories
         run: |
           ./forge setup-repositories
-      - name: Configure base version
-        run: |
-          sed -i '/container_tag_stream:/ s/:.*/: "${{ matrix.upgrade_from }}"/' src/vars/images.yml
       - name: Run image pull
         run: |
           ./foremanctl pull-images
@@ -268,9 +266,10 @@ jobs:
       - name: Stop services
         run:
           vagrant ssh quadlet -- sudo systemctl stop foreman.target
-      - name: Configure upgrade version
+      - name: Switch foremanctl version
         run: |
-          sed -i '/container_tag_stream:/ s/:.*/: "${{ matrix.upgrade_to }}"/' src/vars/images.yml
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD
       - name: Run image pull
         run: |
           ./foremanctl pull-images


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Instead of testing different container images using the same foremanctl version, actually deploy an older foremanctl version (and the images it is configured for), then upgrade to the "latest"

#### What are the changes introduced in this pull request?

* check out `2.y-stable` branch, use that for the initial deployment, then switch to the PR/main branch

#### How to test this pull request

Steps to reproduce:

* CI

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
