### PR TITLE
Support controller node and target node backup and add tests for backup

### DIFF
--- a/src/playbooks/backup/backup.yaml
+++ b/src/playbooks/backup/backup.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Backup databases and configuration
-  hosts: quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   become: true
   gather_facts: true
   vars_files:

--- a/src/playbooks/backup/metadata.obsah.yaml
+++ b/src/playbooks/backup/metadata.obsah.yaml
@@ -9,6 +9,11 @@ variables:
     type: AbsolutePath
     persist: false
 
+
+  target_host:
+    help: Target host to backup (defaults to quadlet)
+    persist: false
+
   skip_pulp_content:
     help: Skip Pulp content directory backup
     action: store_true

--- a/src/roles/backup/tasks/main.yaml
+++ b/src/roles/backup/tasks/main.yaml
@@ -86,37 +86,30 @@
 
     - name: Build database names list for display
       ansible.builtin.set_fact:
-        backup_databases_to_backup: "{{ backup_databases | map(attribute='database') | list }}"
+        backup_databases_to_backup: "{{ backup_databases | map(attribute='name') | list }}"
 
     - name: Dump databases
       ansible.builtin.include_tasks:
         file: database_dumps.yaml
 
-    - name: Create temporary directory on controller
-      ansible.builtin.tempfile:
-        state: directory
-        suffix: foremanctl-backup
-      delegate_to: localhost
-      become: false
-      register: backup_temp_dir
-
     - name: Archive foremanctl state on controller
       community.general.archive:
         path: "{{ obsah_state_path }}"
-        dest: "{{ backup_temp_dir.path }}/foremanctl-state.tar.gz"
+        dest: "{{ obsah_state_path }}/foremanctl-state.tar.gz"
         format: gz
+        mode: '0644'
       delegate_to: localhost
       become: false
 
     - name: Copy foremanctl state archive to target
       ansible.builtin.copy:
-        src: "{{ backup_temp_dir.path }}/foremanctl-state.tar.gz"
+        src: "{{ obsah_state_path }}/foremanctl-state.tar.gz"
         dest: "{{ backup_dir_full }}/foremanctl-state.tar.gz"
         mode: '0644'
 
-    - name: Clean up temporary directory on controller
+    - name: Clean up foremanctl state archive on controller
       ansible.builtin.file:
-        path: "{{ backup_temp_dir.path }}"
+        path: "{{ obsah_state_path }}/foremanctl-state.tar.gz"
         state: absent
       delegate_to: localhost
       become: false

--- a/src/roles/backup/tasks/main.yaml
+++ b/src/roles/backup/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set backup timestamp
   ansible.builtin.set_fact:
-    backup_timestamp: "{{ ansible_date_time.iso8601_basic_short }}"
+    backup_timestamp: "{{ ansible_facts['date_time']['iso8601_basic_short'] }}"
 
 - name: Set full backup directory path
   ansible.builtin.set_fact:
@@ -49,7 +49,7 @@
       ansible.builtin.systemd:
         name: postgresql.service
       register: backup_postgres_status
-      until: backup_postgres_status.status.ActiveState == 'inactive'
+      until: backup_postgres_status.status.ActiveState in ['inactive', 'failed']
       retries: "{{ backup_postgresql_stop_retries }}"
       delay: "{{ backup_postgresql_stop_delay }}"
       when: backup_database_mode == 'internal'

--- a/src/roles/backup/tasks/main.yaml
+++ b/src/roles/backup/tasks/main.yaml
@@ -92,12 +92,34 @@
       ansible.builtin.include_tasks:
         file: database_dumps.yaml
 
-    - name: Backup foremanctl state directory
+    - name: Create temporary directory on controller
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: foremanctl-backup
+      delegate_to: localhost
+      become: false
+      register: backup_temp_dir
+
+    - name: Archive foremanctl state on controller
       community.general.archive:
         path: "{{ obsah_state_path }}"
-        dest: "{{ backup_dir_full }}/foremanctl-state.tar.gz"
+        dest: "{{ backup_temp_dir.path }}/foremanctl-state.tar.gz"
         format: gz
+      delegate_to: localhost
+      become: false
+
+    - name: Copy foremanctl state archive to target
+      ansible.builtin.copy:
+        src: "{{ backup_temp_dir.path }}/foremanctl-state.tar.gz"
+        dest: "{{ backup_dir_full }}/foremanctl-state.tar.gz"
         mode: '0644'
+
+    - name: Clean up temporary directory on controller
+      ansible.builtin.file:
+        path: "{{ backup_temp_dir.path }}"
+        state: absent
+      delegate_to: localhost
+      become: false
 
     - name: Backup pulp content
       ansible.builtin.include_tasks:

--- a/src/roles/backup/tasks/metadata.yaml
+++ b/src/roles/backup/tasks/metadata.yaml
@@ -36,8 +36,8 @@
     mode: '0644'
   vars:
     backup_metadata:
-      hostname: "{{ ansible_fqdn }}"
-      os_version: "{{ ansible_distribution }} {{ ansible_distribution_version }}"
+      hostname: "{{ ansible_facts['fqdn'] }}"
+      os_version: "{{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
       foremanctl_version: "{{ ansible_facts.packages['foremanctl'][0].version | default('unknown') if 'foremanctl' in ansible_facts.packages else 'unknown' }}"
       type: offline
       incremental: false

--- a/src/roles/backup/tasks/preflight.yaml
+++ b/src/roles/backup/tasks/preflight.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Check for running Foreman tasks
   theforeman.foreman.resource_info:
-    server_url: "https://{{ ansible_fqdn }}"
+    server_url: "https://{{ ansible_facts['fqdn'] }}"
     oauth1_consumer_key: "{{ backup_foreman_oauth_consumer_key }}"
     oauth1_consumer_secret: "{{ backup_foreman_oauth_consumer_secret }}"
     ca_path: "{{ backup_foreman_ca_certificate }}"
@@ -18,7 +18,7 @@
 
 - name: Wait for Foreman tasks to complete (if --wait-for-tasks)
   theforeman.foreman.wait_for_task:
-    server_url: "https://{{ ansible_fqdn }}"
+    server_url: "https://{{ ansible_facts['fqdn'] }}"
     oauth1_consumer_key: "{{ backup_foreman_oauth_consumer_key }}"
     oauth1_consumer_secret: "{{ backup_foreman_oauth_consumer_secret }}"
     ca_path: "{{ backup_foreman_ca_certificate }}"
@@ -42,7 +42,7 @@
 
 - name: Check for running Pulp tasks
   ansible.builtin.uri:
-    url: "https://{{ ansible_fqdn }}/pulp/api/v3/tasks/?state__in=running,waiting"
+    url: "https://{{ ansible_facts['fqdn'] }}/pulp/api/v3/tasks/?state__in=running,waiting"
     method: GET
     client_cert: "{{ backup_foreman_client_certificate }}"
     client_key: "{{ backup_foreman_client_key }}"
@@ -61,7 +61,7 @@
 
 - name: Wait for Pulp tasks to complete (if --wait-for-tasks)
   ansible.builtin.uri:
-    url: "https://{{ ansible_fqdn }}/pulp/api/v3/tasks/?state__in=running,waiting"
+    url: "https://{{ ansible_facts['fqdn'] }}/pulp/api/v3/tasks/?state__in=running,waiting"
     method: GET
     client_cert: "{{ backup_foreman_client_certificate }}"
     client_key: "{{ backup_foreman_client_key }}"

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 
 import pytest
 import yaml
@@ -13,20 +14,26 @@ def backup_result(server):
     result = server.run(f"mkdir -p {BACKUP_DIR}")
     assert result.rc == 0, f"Failed to create backup directory on VM: {result.stderr}"
 
-    result = server.run(f"./foremanctl backup {BACKUP_DIR}")
+    result = subprocess.run(
+        ['./foremanctl', 'backup', BACKUP_DIR],
+        capture_output=True, text=True,
+    )
+    returncode = result.returncode
 
     find_result = server.run(f"ls -1 {BACKUP_DIR}")
     assert find_result.rc == 0, f"Backup directory should exist on VM. ls output: {find_result.stderr}"
 
     backup_dirs = [d for d in find_result.stdout.split('\n') if d.startswith('foreman-backup-')]
     assert len(backup_dirs) > 0, \
-        f"Should have created a timestamped backup directory. Command rc={result.rc}, stdout={result.stdout}, stderr={result.stderr}, ls output={find_result.stdout}"
+        f"Should have created a timestamped backup directory. Command rc={returncode}, stdout={result.stdout}, stderr={result.stderr}, ls output={find_result.stdout}"
 
     backup_dir_name = backup_dirs[0]
     full_backup_path = f"{BACKUP_DIR}/{backup_dir_name}"
 
     return {
-        'result': result,
+        'returncode': returncode,
+        'stdout': result.stdout,
+        'stderr': result.stderr,
         'backup_dir': full_backup_path,
         'backup_dir_name': backup_dir_name,
     }
@@ -59,8 +66,10 @@ def test_backup_directory_created(server, backup_result):
 
 def test_backup_command_succeeded(backup_result):
     """Test that backup command completed successfully"""
-    result = backup_result['result']
-    assert result.rc == 0, f"Backup command should succeed, got rc={result.rc}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    returncode = backup_result['returncode']
+    stdout = backup_result['stdout']
+    stderr = backup_result['stderr']
+    assert returncode == 0, f"Backup command should succeed, got rc={returncode}\nstdout: {stdout}\nstderr: {stderr}"
 
 
 def test_database_dumps_created(server, backup_result):
@@ -116,40 +125,24 @@ def test_foremanctl_state_archived(server, backup_result):
     """
     Test that foremanctl state directory is archived.
 
-    NOTE: This test is conditional because foremanctl-state.tar.gz is only
-    created in production deployments where Foreman and foremanctl run on
-    the same machine (ansible_connection=local).
+    The backup role handles both deployment modes:
+    - Local deployment: archives state directory directly from target
+    - Remote deployment: syncs state from controller to target, then archives
 
-    In VM-based development and CI environments:
-    - foremanctl runs on the HOST
-    - Foreman runs on a separate VM
-    - obsah_state_path points to the host's .var/lib/foremanctl/
-    - The backup playbook runs on the VM where this path doesn't exist
-    - Therefore, foremanctl-state.tar.gz is NOT created
-
-    This is expected and not a bug. The backup feature is designed for
-    production deployments where everything runs on the same server.
+    This ensures foremanctl state is always backed up regardless of whether
+    foremanctl runs on the same machine as Foreman or on a separate controller.
     """
     backup_dir = backup_result['backup_dir']
     state_archive = f"{backup_dir}/foremanctl-state.tar.gz"
 
     file_check = server.file(state_archive)
+    assert file_check.exists, "foremanctl-state.tar.gz should exist"
+    assert file_check.is_file, "foremanctl-state.tar.gz should be a file"
+    assert file_check.size > 0, "foremanctl-state.tar.gz should not be empty"
+    assert file_check.mode & 0o400, "foremanctl-state.tar.gz should be readable by owner"
 
-    if file_check.exists:
-        # Production deployment - verify the archive
-        assert file_check.is_file, "foremanctl-state.tar.gz should be a file"
-        assert file_check.size > 0, "foremanctl-state.tar.gz should not be empty"
-        assert file_check.mode & 0o400, "foremanctl-state.tar.gz should be readable by owner"
-
-        result = server.run(f"tar -tzf {state_archive} | head -5")
-        assert result.rc == 0, "foremanctl-state.tar.gz should be a valid tar.gz archive"
-    else:
-        pytest.skip(
-            "foremanctl-state.tar.gz not created in VM-based testing. "
-            "This is expected - the state directory exists on the host, "
-            "but the backup playbook runs on the VM. "
-            "In production (ansible_connection=local), this file is created."
-        )
+    result = server.run(f"tar -tzf {state_archive} | head -5")
+    assert result.rc == 0, "foremanctl-state.tar.gz should be a valid tar.gz archive"
 
 
 def test_pulp_content_archived(server, backup_result):
@@ -249,5 +242,5 @@ def test_metadata_timestamp_valid(backup_result, backup_metadata):
 
 def test_health_check_passes_after_backup(server, backup_result):
     """Verify system is healthy after backup using foremanctl health check"""
-    result = server.run("./foremanctl health")
-    assert result.rc == 0, f"Health check should pass after backup. Output:\n{result.stdout}\n{result.stderr}"
+    result = subprocess.run(['./foremanctl', 'health'], capture_output=True, text=True)
+    assert result.returncode == 0, f"Health check should pass after backup. Output:\n{result.stdout}\n{result.stderr}"

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -8,14 +8,46 @@ BACKUP_DIR = "/tmp/foremanctl-backup-test"
 
 
 @pytest.fixture(scope="module")
-def backup_result(server):
+def expected_databases(enabled_features, flavor):
+    """
+    Determine expected databases based on flavor and enabled features.
+
+    Note: These names correspond to the 'name' field in backup_databases,
+    which is used for the dump filename (e.g., 'foreman.dump'), not the
+    actual database name.
+    """
+    databases = []
+
+    # Katello flavor has foreman, candlepin, and pulp
+    if flavor == 'katello':
+        databases = ['foreman', 'candlepin', 'pulp']
+
+    # Foreman-proxy-content flavor only has pulp
+    elif flavor == 'foreman-proxy-content':
+        databases = ['pulp']
+
+    # Add IOP databases if IOP feature is enabled
+    if 'iop' in enabled_features:
+        databases.extend([
+            'iop_advisor',
+            'iop_inventory',
+            'iop_remediation',
+            'iop_vmaas',
+            'iop_vulnerability',
+        ])
+
+    return databases
+
+
+@pytest.fixture(scope="module")
+def backup_result(server, server_hostname):
     server.run(f"rm -rf {BACKUP_DIR}")
 
     result = server.run(f"mkdir -p {BACKUP_DIR}")
     assert result.rc == 0, f"Failed to create backup directory on VM: {result.stderr}"
 
     result = subprocess.run(
-        ['./foremanctl', 'backup', BACKUP_DIR],
+        ['./foremanctl', 'backup', BACKUP_DIR, '--target-host', server_hostname],
         capture_output=True, text=True,
     )
     returncode = result.returncode
@@ -72,13 +104,12 @@ def test_backup_command_succeeded(backup_result):
     assert returncode == 0, f"Backup command should succeed, got rc={returncode}\nstdout: {stdout}\nstderr: {stderr}"
 
 
-def test_database_dumps_created(server, backup_result):
+def test_database_dumps_created(server, backup_result, expected_databases):
     """Test that all database dump files are created and valid"""
     backup_dir = backup_result['backup_dir']
 
-    expected_dumps = ['foreman.dump', 'candlepin.dump', 'pulp.dump']
-
-    for dump_file in expected_dumps:
+    for database_name in expected_databases:
+        dump_file = f"{database_name}.dump"
         dump_path = f"{backup_dir}/{dump_file}"
         file_check = server.file(dump_path)
         assert file_check.exists, f"Database dump {dump_file} should exist at {dump_path}"
@@ -125,12 +156,11 @@ def test_foremanctl_state_archived(server, backup_result):
     """
     Test that foremanctl state directory is archived.
 
-    The backup role handles both deployment modes:
-    - Local deployment: archives state directory directly from target
-    - Remote deployment: syncs state from controller to target, then archives
-
-    This ensures foremanctl state is always backed up regardless of whether
-    foremanctl runs on the same machine as Foreman or on a separate controller.
+    The backup role archives the controller's obsah_state_path to capture
+    deployment state including secrets and configuration. This works for:
+    - Local deployment: controller and target are the same machine
+    - Quadlet deployment: controller has the state, archive transferred to target
+    - Proxy deployment: similar to quadlet
     """
     backup_dir = backup_result['backup_dir']
     state_archive = f"{backup_dir}/foremanctl-state.tar.gz"
@@ -143,6 +173,25 @@ def test_foremanctl_state_archived(server, backup_result):
 
     result = server.run(f"tar -tzf {state_archive} | head -5")
     assert result.rc == 0, "foremanctl-state.tar.gz should be a valid tar.gz archive"
+
+
+def test_foremanctl_state_archive_contents(server, backup_result):
+    """Test that foremanctl state archive contains expected deployment files"""
+    backup_dir = backup_result['backup_dir']
+    state_archive = f"{backup_dir}/foremanctl-state.tar.gz"
+
+    # Get archive contents
+    result = server.run(f"tar -tzf {state_archive}")
+    assert result.rc == 0, "Should be able to list archive contents"
+
+    archive_contents = result.stdout
+    file_list = [f for f in archive_contents.split('\n') if f and not f.endswith('/')]
+
+    assert len(file_list) > 0, "Archive should contain at least one file"
+
+    # Check for certificates-ca-password which should be present in all deployments
+    assert 'certificates-ca-password' in archive_contents, \
+        "Archive should contain certificates-ca-password (generated during deployment)"
 
 
 def test_pulp_content_archived(server, backup_result):
@@ -186,7 +235,7 @@ def test_metadata_file_exists(server, backup_result):
     assert file_check.mode & 0o400, "metadata.yml should be readable by owner"
 
 
-def test_metadata_structure(backup_metadata):
+def test_metadata_structure(backup_metadata, expected_databases):
     required_fields = ['hostname', 'os_version', 'type', 'timestamp', 'databases', 'database_mode']
     for field in required_fields:
         assert field in backup_metadata, f"Metadata should contain '{field}' field"
@@ -195,11 +244,11 @@ def test_metadata_structure(backup_metadata):
     assert backup_metadata['incremental'] is False, "Backup should not be incremental"
     assert backup_metadata['database_mode'] in ['internal', 'external'], "Database mode should be 'internal' or 'external'"
 
-    # Core databases should always be present
-    core_databases = {'foreman', 'candlepin', 'pulp'}
+    # Verify expected databases are present
+    expected_db_set = set(expected_databases)
     actual_databases = set(backup_metadata['databases'])
-    assert core_databases.issubset(actual_databases), \
-        f"Core databases {core_databases} should be present, got {actual_databases}"
+    assert expected_db_set == actual_databases, \
+        f"Expected databases {expected_db_set} should match actual {actual_databases}"
 
 
 def test_metadata_backed_up_components(backup_metadata):
@@ -213,23 +262,27 @@ def test_metadata_backed_up_components(backup_metadata):
 
 
 @pytest.mark.feature("iop")
-def test_metadata_includes_iop_databases(backup_metadata):
+def test_metadata_includes_iop_databases(backup_metadata, expected_databases):
     assert 'databases' in backup_metadata, "Metadata should contain 'databases' field"
 
-    expected_databases = {'foreman', 'candlepin', 'pulp'}
-    expected_iop_databases = {
-        'advisor_db',
-        'inventory_db',
-        'remediations_db',
-        'vmaas_db',
-        'vulnerability_db',
-    }
-
-    all_expected = expected_databases | expected_iop_databases
+    # With IOP enabled, expected_databases fixture should include IOP databases
+    expected_db_set = set(expected_databases)
     actual_databases = set(backup_metadata['databases'])
 
-    assert all_expected == actual_databases, \
-        f"With IOP enabled, databases should be {all_expected}, got {actual_databases}"
+    # Verify IOP databases are present
+    # Note: These are the 'name' values from database.yml, not the actual PostgreSQL database names
+    expected_iop_databases = {
+        'iop_advisor',
+        'iop_inventory',
+        'iop_remediation',
+        'iop_vmaas',
+        'iop_vulnerability',
+    }
+    assert expected_iop_databases.issubset(actual_databases), \
+        f"With IOP enabled, databases should include {expected_iop_databases}, got {actual_databases}"
+
+    assert expected_db_set == actual_databases, \
+        f"Expected databases {expected_db_set} should match actual {actual_databases}"
 
 
 def test_metadata_timestamp_valid(backup_result, backup_metadata):

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -1,0 +1,253 @@
+import re
+
+import pytest
+import yaml
+
+BACKUP_DIR = "/tmp/foremanctl-backup-test"
+
+
+@pytest.fixture(scope="module")
+def backup_result(server):
+    server.run(f"rm -rf {BACKUP_DIR}")
+
+    result = server.run(f"mkdir -p {BACKUP_DIR}")
+    assert result.rc == 0, f"Failed to create backup directory on VM: {result.stderr}"
+
+    result = server.run(f"./foremanctl backup {BACKUP_DIR}")
+
+    find_result = server.run(f"ls -1 {BACKUP_DIR}")
+    assert find_result.rc == 0, f"Backup directory should exist on VM. ls output: {find_result.stderr}"
+
+    backup_dirs = [d for d in find_result.stdout.split('\n') if d.startswith('foreman-backup-')]
+    assert len(backup_dirs) > 0, \
+        f"Should have created a timestamped backup directory. Command rc={result.rc}, stdout={result.stdout}, stderr={result.stderr}, ls output={find_result.stdout}"
+
+    backup_dir_name = backup_dirs[0]
+    full_backup_path = f"{BACKUP_DIR}/{backup_dir_name}"
+
+    return {
+        'result': result,
+        'backup_dir': full_backup_path,
+        'backup_dir_name': backup_dir_name,
+    }
+
+
+@pytest.fixture(scope="module")
+def backup_metadata(server, backup_result):
+    """Load and parse the backup metadata.yml file"""
+    backup_dir = backup_result['backup_dir']
+    metadata_file = f"{backup_dir}/metadata.yml"
+    content = server.file(metadata_file).content_string
+    return yaml.safe_load(content)
+
+
+def test_backup_directory_created(server, backup_result):
+    """Test that backup creates a timestamped directory with correct permissions"""
+    backup_dir_name = backup_result['backup_dir_name']
+    backup_dir = backup_result['backup_dir']
+
+    timestamp_pattern = r'foreman-backup-\d{8}T\d{6}'
+    assert re.match(timestamp_pattern, backup_dir_name), \
+        f"Backup directory should match pattern foreman-backup-YYYYMMDDTHHMMSS, got: {backup_dir_name}"
+
+    # Check directory permissions
+    dir_check = server.file(backup_dir)
+    assert dir_check.is_directory
+    assert dir_check.mode == 0o770 or dir_check.mode == 0o40770, \
+        f"Backup directory should have mode 0770, got {oct(dir_check.mode)}"
+
+
+def test_backup_command_succeeded(backup_result):
+    """Test that backup command completed successfully"""
+    result = backup_result['result']
+    assert result.rc == 0, f"Backup command should succeed, got rc={result.rc}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+def test_database_dumps_created(server, backup_result):
+    """Test that all database dump files are created and valid"""
+    backup_dir = backup_result['backup_dir']
+
+    expected_dumps = ['foreman.dump', 'candlepin.dump', 'pulp.dump']
+
+    for dump_file in expected_dumps:
+        dump_path = f"{backup_dir}/{dump_file}"
+        file_check = server.file(dump_path)
+        assert file_check.exists, f"Database dump {dump_file} should exist at {dump_path}"
+        assert file_check.is_file, f"{dump_file} should be a file"
+        assert file_check.size > 0, f"{dump_file} should not be empty"
+        assert file_check.mode & 0o400, f"{dump_file} should be readable by owner"
+
+        # Verify pg_dump custom format
+        result = server.run(f"head -c 5 {dump_path}")
+        assert result.rc == 0
+        assert result.stdout.startswith('PGDMP'), \
+            f"{dump_file} should be a valid pg_dump custom format file (should start with PGDMP)"
+
+
+@pytest.mark.feature("iop")
+def test_iop_database_dumps_created(server, backup_result):
+    """Test that all IOP database dump files are created and valid"""
+    backup_dir = backup_result['backup_dir']
+
+    expected_iop_dumps = [
+        'iop_advisor.dump',
+        'iop_inventory.dump',
+        'iop_remediation.dump',
+        'iop_vmaas.dump',
+        'iop_vulnerability.dump',
+    ]
+
+    for dump_file in expected_iop_dumps:
+        dump_path = f"{backup_dir}/{dump_file}"
+        file_check = server.file(dump_path)
+        assert file_check.exists, f"IOP database dump {dump_file} should exist at {dump_path}"
+        assert file_check.is_file, f"{dump_file} should be a file"
+        assert file_check.size > 0, f"{dump_file} should not be empty"
+        assert file_check.mode & 0o400, f"{dump_file} should be readable by owner"
+
+        # Verify pg_dump custom format
+        result = server.run(f"head -c 5 {dump_path}")
+        assert result.rc == 0
+        assert result.stdout.startswith('PGDMP'), \
+            f"{dump_file} should be a valid pg_dump custom format file (should start with PGDMP)"
+
+
+def test_foremanctl_state_archived(server, backup_result):
+    """
+    Test that foremanctl state directory is archived.
+
+    NOTE: This test is conditional because foremanctl-state.tar.gz is only
+    created in production deployments where Foreman and foremanctl run on
+    the same machine (ansible_connection=local).
+
+    In VM-based development and CI environments:
+    - foremanctl runs on the HOST
+    - Foreman runs on a separate VM
+    - obsah_state_path points to the host's .var/lib/foremanctl/
+    - The backup playbook runs on the VM where this path doesn't exist
+    - Therefore, foremanctl-state.tar.gz is NOT created
+
+    This is expected and not a bug. The backup feature is designed for
+    production deployments where everything runs on the same server.
+    """
+    backup_dir = backup_result['backup_dir']
+    state_archive = f"{backup_dir}/foremanctl-state.tar.gz"
+
+    file_check = server.file(state_archive)
+
+    if file_check.exists:
+        # Production deployment - verify the archive
+        assert file_check.is_file, "foremanctl-state.tar.gz should be a file"
+        assert file_check.size > 0, "foremanctl-state.tar.gz should not be empty"
+        assert file_check.mode & 0o400, "foremanctl-state.tar.gz should be readable by owner"
+
+        result = server.run(f"tar -tzf {state_archive} | head -5")
+        assert result.rc == 0, "foremanctl-state.tar.gz should be a valid tar.gz archive"
+    else:
+        pytest.skip(
+            "foremanctl-state.tar.gz not created in VM-based testing. "
+            "This is expected - the state directory exists on the host, "
+            "but the backup playbook runs on the VM. "
+            "In production (ansible_connection=local), this file is created."
+        )
+
+
+def test_pulp_content_archived(server, backup_result):
+    backup_dir = backup_result['backup_dir']
+    pulp_archive = f"{backup_dir}/pulp-content.tar.gz"
+
+    file_check = server.file(pulp_archive)
+    assert file_check.exists, "pulp-content.tar.gz should exist"
+    assert file_check.is_file, "pulp-content.tar.gz should be a file"
+    assert file_check.size > 0, "pulp-content.tar.gz should not be empty"
+    assert file_check.mode & 0o400, "pulp-content.tar.gz should be readable by owner"
+
+    result = server.run(f"tar -tzf {pulp_archive} | head -10")
+    assert result.rc == 0, "pulp-content.tar.gz should be a valid tar.gz archive"
+
+    archive_contents = server.run(f"tar -tzf {pulp_archive}").stdout
+    assert 'media' in archive_contents, "Archive should contain media directory"
+    assert 'database_fields.symmetric.key' in archive_contents, "Archive should contain database encryption key"
+    assert 'django_secret_key' in archive_contents, "Archive should contain django secret key"
+
+
+def test_pulp_content_excludes_correct_directories(server, backup_result):
+    backup_dir = backup_result['backup_dir']
+    pulp_archive = f"{backup_dir}/pulp-content.tar.gz"
+
+    archive_contents = server.run(f"tar -tzf {pulp_archive}").stdout
+
+    assert 'media/exports' not in archive_contents, "Archive should exclude media/exports"
+    assert 'media/imports' not in archive_contents, "Archive should exclude media/imports"
+    assert 'media/sync_imports' not in archive_contents, "Archive should exclude media/sync_imports"
+
+
+def test_metadata_file_exists(server, backup_result):
+    backup_dir = backup_result['backup_dir']
+    metadata_file = f"{backup_dir}/metadata.yml"
+
+    file_check = server.file(metadata_file)
+    assert file_check.exists, "metadata.yml should exist"
+    assert file_check.is_file, "metadata.yml should be a file"
+    assert file_check.size > 0, "metadata.yml should not be empty"
+    assert file_check.mode & 0o400, "metadata.yml should be readable by owner"
+
+
+def test_metadata_structure(backup_metadata):
+    required_fields = ['hostname', 'os_version', 'type', 'timestamp', 'databases', 'database_mode']
+    for field in required_fields:
+        assert field in backup_metadata, f"Metadata should contain '{field}' field"
+
+    assert backup_metadata['type'] == 'offline', "Backup type should be 'offline'"
+    assert backup_metadata['incremental'] is False, "Backup should not be incremental"
+    assert backup_metadata['database_mode'] in ['internal', 'external'], "Database mode should be 'internal' or 'external'"
+
+    # Core databases should always be present
+    core_databases = {'foreman', 'candlepin', 'pulp'}
+    actual_databases = set(backup_metadata['databases'])
+    assert core_databases.issubset(actual_databases), \
+        f"Core databases {core_databases} should be present, got {actual_databases}"
+
+
+def test_metadata_backed_up_components(backup_metadata):
+    assert 'backed_up_components' in backup_metadata, "Metadata should list backed up components"
+
+    expected_components = {'databases', 'container_images', 'foremanctl_state', 'pulp_content'}
+    components_set = set(backup_metadata['backed_up_components'])
+
+    assert expected_components.issubset(components_set), \
+        f"Backed up components should include {expected_components}, got {components_set}"
+
+
+@pytest.mark.feature("iop")
+def test_metadata_includes_iop_databases(backup_metadata):
+    assert 'databases' in backup_metadata, "Metadata should contain 'databases' field"
+
+    expected_databases = {'foreman', 'candlepin', 'pulp'}
+    expected_iop_databases = {
+        'advisor_db',
+        'inventory_db',
+        'remediations_db',
+        'vmaas_db',
+        'vulnerability_db',
+    }
+
+    all_expected = expected_databases | expected_iop_databases
+    actual_databases = set(backup_metadata['databases'])
+
+    assert all_expected == actual_databases, \
+        f"With IOP enabled, databases should be {all_expected}, got {actual_databases}"
+
+
+def test_metadata_timestamp_valid(backup_result, backup_metadata):
+    backup_dir_name = backup_result['backup_dir_name']
+    dir_timestamp = backup_dir_name.replace('foreman-backup-', '')
+
+    assert backup_metadata['timestamp'] == dir_timestamp, \
+        "Metadata timestamp should match backup directory timestamp"
+
+
+def test_health_check_passes_after_backup(server, backup_result):
+    """Verify system is healthy after backup using foremanctl health check"""
+    result = server.run("./foremanctl health")
+    assert result.rc == 0, f"Health check should pass after backup. Output:\n{result.stdout}\n{result.stderr}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,15 +45,20 @@ class UserParameters:
     def enabled_features(self):
         return set(feature for feature, status, _desc in self.features if status == 'enabled')
 
+    @cached_property
+    def flavor(self):
+        with open(PARAMETERS_FILE) as f:
+            params = yaml.safe_load(f)
+        return params.get('flavor', 'katello')
+
 
 def pytest_addoption(parser):
     parser.addoption("--server-hostname", action="store", default="quadlet", help="Hostname of the server VM to test against")
 
 
-def flavor():
-    with open(PARAMETERS_FILE) as f:
-        params = yaml.safe_load(f)
-    return params.get('flavor', 'katello')
+@pytest.fixture(scope="module")
+def flavor(pytestconfig):
+    return pytestconfig.user_parameters.flavor
 
 
 @pytest.fixture(scope="module")
@@ -265,7 +270,7 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    active_flavor = flavor()
+    active_flavor = config.user_parameters.flavor
     active_flavor_dir = FLAVOR_TESTS_DIR / active_flavor
 
     deselected = []


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Add tests for foremanctl backup
#### What are the changes introduced in this pull request?

* Add tests for foremanctl backup

#### How to test this pull request
The CI should run the new tests.
Steps to reproduce:

* Check CI

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)


PS: I had some issues with the OBSAH_STATE_PATH running these locally in a repo checkout. The backup is supposed to work on a host with services deployed and with path as /var/lib/foremanctl. The repo setup is different from production-like installs where the quadlet is mapped to localhost. On dev setup, quadlet is actual VM so the test finds OBSAH_STATE_PATH as /.var/lib/foremanctl inside the VM. Hence the conditional test for foremanctl state archive which archives this path. 