### PR TITLE
generate random rails enc key and attach as secret

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -29,6 +29,15 @@
     - Restart foreman
     - Restart dynflow-sidekiq@
 
+- name: Create secret for ENCRYPTION_KEY
+  containers.podman.podman_secret:
+    state: present
+    name: foreman-encryption-key
+    data: "{{ foreman_encryption_key }}"
+  notify:
+    - Restart foreman
+    - Restart dynflow-sidekiq@
+
 - name: Create settings config secret
   containers.podman.podman_secret:
     state: present
@@ -103,6 +112,7 @@
       - 'foreman-data-run:/var/run/foreman:rw,z'
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
+      - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'
       - 'foreman-seed-admin-user,type=env,target=SEED_ADMIN_USER'
       - 'foreman-seed-admin-password,type=env,target=SEED_ADMIN_PASSWORD'
       - 'foreman-settings-yaml,type=mount,target=/etc/foreman/settings.yaml'
@@ -143,6 +153,7 @@
       - 'foreman-data-run:/var/run/foreman:rw,z'
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
+      - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'
       - 'foreman-settings-yaml,type=mount,target=/etc/foreman/settings.yaml'
       - 'foreman-katello-yaml,type=mount,target=/etc/foreman/plugins/katello.yaml'
       - 'foreman-ca-cert,type=mount,target=/etc/foreman/katello-default-ca.crt'
@@ -200,6 +211,7 @@
       - 'foreman-data-run:/var/run/foreman:rw,z'
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
+      - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'
       - 'foreman-seed-admin-user,type=env,target=SEED_ADMIN_USER'
       - 'foreman-seed-admin-password,type=env,target=SEED_ADMIN_PASSWORD'
       - 'foreman-settings-yaml,type=mount,target=/etc/foreman/settings.yaml'
@@ -246,6 +258,7 @@
       SEED_LOCATION: "{{ foreman_initial_location }}"
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
+      - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'
       - 'foreman-seed-admin-user,type=env,target=SEED_ADMIN_USER'
       - 'foreman-seed-admin-password,type=env,target=SEED_ADMIN_PASSWORD'
       - 'foreman-settings-yaml,type=mount,target=/etc/foreman/settings.yaml'

--- a/src/vars/foreman.yml
+++ b/src/vars/foreman.yml
@@ -9,3 +9,5 @@ foreman_oauth_consumer_key_file: "{{ obsah_state_path }}/foreman-oauth-consumer-
 foreman_oauth_consumer_key: "{{ lookup('ansible.builtin.password', foreman_oauth_consumer_key_file, chars=['ascii_letters', 'digits'], length=32) }}"
 foreman_oauth_consumer_secret_file: "{{ obsah_state_path }}/foreman-oauth-consumer-secret"
 foreman_oauth_consumer_secret: "{{ lookup('ansible.builtin.password', foreman_oauth_consumer_secret_file, chars=['ascii_letters', 'digits'], length=32) }}"
+foreman_encryption_key_file: "{{ obsah_state_path }}/foreman-encryption-key"
+foreman_encryption_key: "{{ lookup('ansible.builtin.password', foreman_encryption_key_file, chars=['digits', 'abcdef'], length=32) }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Currently, the rails encryption key is baked into the foreman container image (it is created by the post install script during RPM installation and never deleted). I checked upstream, the 3.18 and 3.19 even have different keys, so currently, an upgrade would break encrypted values in the DB.

#### What are the changes introduced in this pull request?

* Create a rails encryption key during deployment and write to obsah state dir
* Attach as secret to the foreman and dynflow containers as env var inside the container. 

Note: This works because the env var takes precedence over the file. Yet maybe the encryption key created during installation should be removed from the image after build.

#### How to test this pull request

Steps to reproduce:

* Deploy and encrypt a secret
* Redeploy with a newer image, see that secrets can still be decrypted

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
