### PR TITLE
Fixes #589 - Add IOP services to foreman.target

### DIFF
--- a/src/roles/iop_advisor/tasks/main.yaml
+++ b/src/roles/iop_advisor/tasks/main.yaml
@@ -70,10 +70,11 @@
         Description=Advisor Backend API
         After=iop-core-kafka.service
         Wants=iop-core-kafka.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Deploy Advisor Backend Service Container
   containers.podman.podman_container:
@@ -99,10 +100,11 @@
         Description=Advisor Backend Service
         After=iop-core-kafka.service
         Wants=iop-core-kafka.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_engine/tasks/main.yaml
+++ b/src/roles/iop_engine/tasks/main.yaml
@@ -27,10 +27,11 @@
         Description=IOP Core Engine Container
         After=iop-core-kafka.service iop-core-ingress.service iop-core-puptoo.service
         Wants=iop-core-kafka.service iop-core-ingress.service iop-core-puptoo.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_gateway/tasks/main.yaml
+++ b/src/roles/iop_gateway/tasks/main.yaml
@@ -74,11 +74,12 @@
         Description=IOP Core Gateway Container
         After=iop-core-kafka.service iop-core-engine.service iop-core-ingress.service
         Wants=iop-core-kafka.service iop-core-engine.service iop-core-ingress.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
         WantedBy=multi-user.target
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_ingress/tasks/main.yaml
+++ b/src/roles/iop_ingress/tasks/main.yaml
@@ -22,10 +22,11 @@
       - |
         [Unit]
         Description=IOP Core Ingress Container
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -54,11 +54,12 @@
       - |
         [Unit]
         Description=Database Readiness and Migration Init Container
+        PartOf=foreman.target
         [Service]
         Type=oneshot
         RemainAfterExit=true
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Deploy Host Inventory MQ Service Container
   containers.podman.podman_container:
@@ -84,10 +85,11 @@
         Description=IOP Core Host-Based Inventory Container
         After=network-online.target iop-core-host-inventory-migrate.service
         Requires=iop-core-host-inventory-migrate.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Deploy Host Inventory API Container
   containers.podman.podman_container:
@@ -113,10 +115,11 @@
       - |
         [Unit]
         Description=IOP Core Host-Based Inventory Web Container
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Deploy Host Inventory Cleanup Container
   containers.podman.podman_container:

--- a/src/roles/iop_kafka/tasks/main.yaml
+++ b/src/roles/iop_kafka/tasks/main.yaml
@@ -49,10 +49,11 @@
       - |
         [Unit]
         Description=IOP Core Kafka Container
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_puptoo/tasks/main.yaml
+++ b/src/roles/iop_puptoo/tasks/main.yaml
@@ -19,10 +19,11 @@
         Description=IOP Core Puptoo Container
         After=iop-core-kafka.service
         Wants=iop-core-kafka.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_remediation/tasks/main.yaml
+++ b/src/roles/iop_remediation/tasks/main.yaml
@@ -64,10 +64,11 @@
         Description=Remediations API
         Wants=iop-core-host-inventory-api.service iop-service-advisor-backend-api.service
         After=iop-core-host-inventory-api.service iop-service-advisor-backend-api.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_vmaas/tasks/main.yaml
+++ b/src/roles/iop_vmaas/tasks/main.yaml
@@ -66,10 +66,11 @@
       - |
         [Unit]
         Description=VMAAS Reposcan Service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Deploy VMAAS Webapp-Go container
   containers.podman.podman_container:
@@ -97,10 +98,11 @@
         Description=VMAAS Webapp-Go Service
         Wants=iop-service-vmaas-reposcan.service
         After=iop-service-vmaas-reposcan.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_vulnerability/tasks/main.yaml
+++ b/src/roles/iop_vulnerability/tasks/main.yaml
@@ -61,11 +61,12 @@
       - |
         [Unit]
         Description=Vulnerability Database Upgrade Init Container
+        PartOf=foreman.target
         [Service]
         Type=oneshot
         RemainAfterExit=true
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability dbupgrade
 
 # 2. Manager service (main service)
@@ -93,10 +94,11 @@
         Description=Vulnerability Manager Service
         After=network-online.target iop-service-vuln-dbupgrade.service
         Requires=iop-service-vuln-dbupgrade.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability manager
 
 # 3. Taskomatic service (task scheduler)
@@ -126,10 +128,11 @@
         Description=Vulnerability Taskomatic Service
         Wants=iop-service-vuln-manager.service
         After=iop-service-vuln-manager.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability taskomatic
 
 # 4. Grouper service
@@ -163,10 +166,11 @@
         Description=Vulnerability Grouper Service
         Wants=iop-service-vuln-manager.service
         After=iop-service-vuln-manager.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability grouper
 
 # 5. Listener service (event listener)
@@ -200,10 +204,11 @@
         Description=Vulnerability Listener Service
         Wants=iop-service-vuln-manager.service
         After=iop-service-vuln-manager.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability listener
 
 # 6. Evaluator (Recalc) service
@@ -237,10 +242,11 @@
         Description=Vulnerability Evaluator (Recalc) Service
         Wants=iop-service-vuln-manager.service
         After=iop-service-vuln-manager.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability evaluator-recalc
 
 # 7. Evaluator (Upload) service
@@ -274,10 +280,11 @@
         Description=Vulnerability Evaluator (Upload) Service
         Wants=iop-service-vuln-grouper.service iop-service-vuln-manager.service
         After=iop-service-vuln-grouper.service iop-service-vuln-manager.service
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
   notify: Restart vulnerability evaluator-upload
 
 # 8. VMAAS Sync service (oneshot with timer)

--- a/src/roles/iop_yuptoo/tasks/main.yaml
+++ b/src/roles/iop_yuptoo/tasks/main.yaml
@@ -17,10 +17,11 @@
       - |
         [Unit]
         Description=IOP Core Yuptoo Container
+        PartOf=foreman.target
         [Service]
         Restart=on-failure
         [Install]
-        WantedBy=default.target
+        WantedBy=default.target foreman.target
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
IOP services should also be managed under foreman.target when deployed.
#### What are the changes introduced in this pull request?

* Adds IOP services to foreman.target

#### How to test this pull request
systemctl list-dependencies foreman.target
Try systemctl stop/start foreman.target

Steps to reproduce:

* Today systemctl stop foreman.target doesn't target IOP

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
