### PR TITLE
Use a unix socket between httpd and Foreman's Puma

### DIFF
--- a/src/roles/foreman/defaults/main.yaml
+++ b/src/roles/foreman/defaults/main.yaml
@@ -12,6 +12,7 @@ foreman_database_ssl_ca: # noqa: no-empty-defaults
 foreman_database_ssl_ca_path: /etc/foreman/db-ca.crt
 
 foreman_name: "{{ ansible_facts['fqdn'] }}"
+foreman_listen_stream: localhost:3000
 foreman_url: "http://{{ ansible_facts['fqdn'] }}:3000"
 
 # Puma threads calculation:

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -100,6 +100,12 @@
     - Restart foreman
     - Restart dynflow-sidekiq@
 
+- name: Deploy Foreman socket
+  ansible.builtin.template:
+    src: foreman.socket.j2
+    dest: /etc/systemd/system/foreman.socket
+    mode: '0644'
+
 - name: Deploy Foreman Container
   containers.podman.podman_container:
     name: "foreman"
@@ -130,6 +136,8 @@
       FOREMAN_ENABLED_PLUGINS: "{{ foreman_plugins | join(' ') }}"
     quadlet_options:
       - |
+        [Unit]
+        Requires=foreman.socket
         [Install]
         WantedBy=default.target foreman.target
         [Unit]

--- a/src/roles/foreman/templates/foreman.socket.j2
+++ b/src/roles/foreman/templates/foreman.socket.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Foreman socket
+
+[Socket]
+ListenStream={{ foreman_listen_stream }}
+
+[Install]
+WantedBy=sockets.target

--- a/src/roles/foreman/templates/foreman.socket.j2
+++ b/src/roles/foreman/templates/foreman.socket.j2
@@ -3,6 +3,12 @@ Description=Foreman socket
 
 [Socket]
 ListenStream={{ foreman_listen_stream }}
+SocketUser=apache
+SocketMode=0600
+
+NoDelay=false
+ReusePort=true
+Backlog=1024
 
 [Install]
 WantedBy=sockets.target

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -13,6 +13,13 @@
     persistent: true
   when: ansible_facts['selinux']['status'] == "enabled"
 
+# TODO: probably not the right boolean
+- name: Set daemons_enable_cluster_mode so Apache can connect to unix sockets
+  ansible.posix.seboolean:
+    name: daemons_enable_cluster_mode
+    state: true
+    persistent: true
+
 - name: Disable welcome page
   ansible.builtin.file:
     path: /etc/httpd/conf.d/welcome.conf

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -25,6 +25,9 @@ foreman_plugins: "{{ enabled_features | features_to_foreman_plugins }}"
 foreman_name: "{{ ansible_facts['fqdn'] }}"
 foreman_url: "https://{{ foreman_name }}"
 
+foreman_listen_stream: /run/httpd.foreman.sock
+httpd_foreman_backend: "unix://{{ foreman_listen_stream }}|http://%{HTTP_HOST}"
+
 httpd_server_ca_certificate: "{{ server_ca_certificate }}"
 httpd_client_ca_certificate: "{{ client_ca_certificate }}"
 httpd_server_certificate: "{{ server_certificate }}"

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 FOREMAN_HOST = 'localhost'
-FOREMAN_PORT = 3000
+FOREMAN_SOCKET = '/run/httpd.foreman.sock'
 
 RECURRING_INSTANCES = [
     "hourly",
@@ -15,7 +15,7 @@ RECURRING_INSTANCES = [
 
 @pytest.fixture(scope="module")
 def foreman_status_curl(server):
-    return server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' http://{FOREMAN_HOST}:{FOREMAN_PORT}/api/v2/ping")
+    return server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} http://{FOREMAN_HOST}/api/v2/ping")
 
 
 @pytest.fixture(scope="module")
@@ -28,9 +28,8 @@ def test_foreman_service(server):
     assert foreman.is_running
 
 
-def test_foreman_port(server):
-    foreman = server.addr(FOREMAN_HOST)
-    assert foreman.port(FOREMAN_PORT).is_reachable
+def test_foreman_socket(server):
+    assert server.socket(f"unix://{FOREMAN_SOCKET}").is_listening
 
 
 def test_foreman_status(foreman_status_curl):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

https://github.com/theforeman/foremanctl/pull/118 included this previously, but splitting the focus.

In foreman-installer we saw using a unix socket had reliability benefits.

#### What are the changes introduced in this pull request?

* https://github.com/theforeman/foremanctl/pull/118
* Use a unix socket for httpd and Puma instead of a TCP socket

#### How to test this pull request

Steps to reproduce:

* The Foreman UI loads
* Test suite passes

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)