### PR TITLE
Use content_view_environment_ids in content tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,11 +216,12 @@ def client_environment(activation_key, content_view, lifecycle_environment, yum_
     foremanapi.resource_action('content_views', 'publish', {'id': content_view['id']})
 
     library = foremanapi.list('lifecycle_environments', 'name=Library', {'organization_id': organization['id']})[0]
-    foremanapi.update('activation_keys', {'id': activation_key['id'], 'organization_id': organization['id'], 'environment_id': library['id'], 'content_view_id': content_view['id']})
+    cve = foremanapi.list('content_view_environments', params={'organization_id': organization['id'], 'environment_id': library['id'], 'content_view_id': content_view['id']})[0]
+    foremanapi.update('activation_keys', {'id': activation_key['id'], 'organization_id': organization['id'], 'content_view_environment_ids': [cve['id']]})
 
     yield activation_key
 
-    foremanapi.update('activation_keys', {'id': activation_key['id'], 'organization_id': organization['id'], 'environment_id': None, 'content_view_id': None})
+    foremanapi.update('activation_keys', {'id': activation_key['id'], 'organization_id': organization['id'], 'content_view_environment_ids': []})
 
     versions = foremanapi.list('content_view_versions', params={'content_view_id': content_view['id']})
     for version in versions:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Support for the old content_view_id/lifecycle_environment_id was removed in https://github.com/Katello/katello/commit/a46d7afdf677bcc71bd128d4566b5e50371c322e

#### What are the changes introduced in this pull request?

* Use the new API

#### How to test this pull request

Steps to reproduce:

* CI

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
