### PR TITLE
do not add cnames to localhost certs

### DIFF
--- a/src/roles/certificates/tasks/issue.yml
+++ b/src/roles/certificates/tasks/issue.yml
@@ -22,7 +22,8 @@
         extended_key_usage:
           - serverAuth
       vars:
-        _certificates_desired_server_sans: "{{ (([certificates_hostname] + certificates_cnames) | map('regex_replace', '^', 'DNS:') | list) }}"
+        _certificates_extra_sans: "{{ certificates_cnames if certificates_hostname != 'localhost' else [] }}"
+        _certificates_desired_server_sans: "{{ ([certificates_hostname] + _certificates_extra_sans) | map('regex_replace', '^', 'DNS:') | list }}"
 
     - name: 'Sign server certificate'
       community.crypto.x509_certificate:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
When the user supplies a CNAME the CNAME is being added to the generated localhost certificates which is an incorrect behaviour.

Fixes #487 


#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
