### PR TITLE
Fixes #596 - Add iso block to pulp apache config

### DIFF
--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -68,6 +68,13 @@
     ProxyPassReverse {{ httpd_pulp_content_backend }}/pulp/content
   </Location>
 
+  <Location "/pulp/isos">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    ProxyPass {{ httpd_pulp_content_backend }}/pulp/content disablereuse=on timeout=600
+    ProxyPassReverse {{ httpd_pulp_content_backend }}/pulp/content
+  </Location>
+
 {% for httpd_pulp_snippet in httpd_enabled_pulp_snippets %}
 {% include httpd_pulp_snippet+'.j2' %}
 {% endfor %}

--- a/src/roles/httpd/templates/foreman-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-vhost.conf.j2
@@ -42,6 +42,14 @@
     ProxyPassReverse {{ httpd_pulp_content_backend }}/pulp/content
   </Location>
 
+  <Location "/pulp/isos">
+    RequestHeader unset X-CLIENT-CERT
+    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT
+    RequestHeader set X-FORWARDED-PROTO expr=%{REQUEST_SCHEME}
+    ProxyPass {{ httpd_pulp_content_backend }}/pulp/content disablereuse=on timeout=600
+    ProxyPassReverse {{ httpd_pulp_content_backend }}/pulp/content
+  </Location>
+
   Alias /pub /var/www/html/pub
 
   <Location /pub>


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Add /pulp/iso config to apache
#### What are the changes introduced in this pull request?

* Add /pulp/iso/ path to apache config to expose file repos.

#### How to test this pull request
Sync a file repo on your foreman
Go to /pulp/isos/Default_Organization/Library/custom/<product>/<file-repo>/
You should see the repo
Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
