### PR TITLE
Install the skopeo utility

### DIFF
--- a/src/roles/pre_install/tasks/main.yaml
+++ b/src/roles/pre_install/tasks/main.yaml
@@ -3,10 +3,11 @@
   ansible.builtin.include_role:
     name: debug_tools
 
-- name: Install podman
+- name: Install podman and utilities
   ansible.builtin.package:
     name:
       - podman
+      - skopeo
 
 - name: Install other dependencies
   ansible.builtin.package:


### PR DESCRIPTION
Skopeo is a utility that performs various operations on container images and image repositories
This is a prerequisite for disconnected installations.

See https://github.com/podman-container-tools/skopeo

