### PR TITLE
Don't generate sosreports when running with fapolicyd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,10 +166,10 @@ jobs:
           name: smoker-${{ env.ARTIFACT_SUFFIX }}
           path: "/home/runner/smoker/report/"
       - name: Generate sos reports
-        if: ${{ always() }}
+        if: ${{ always() && matrix.security != 'fapolicyd' }}
         run: ./forge sos
       - name: Archive sos reports
-        if: ${{ always() }}
+        if: ${{ always() && matrix.security != 'fapolicyd' }}
         uses: actions/upload-artifact@v7
         with:
           name: sosreport-${{ env.ARTIFACT_SUFFIX }}


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

It's currently broken [1] and makes the tests red

[1] https://github.com/linux-application-whitelisting/fapolicyd/issues/413


#### What are the changes introduced in this pull request?

*

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
