### PR TITLE
add support for providing an own ca

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,10 @@ jobs:
             security: none
             database: internal
             box: centos/stream9
+          - certificate_source: custom_ca
+            security: none
+            database: internal
+            box: centos/stream9
     runs-on: ubuntu-24.04
     env:
       FOREMANCTL_BASE_BOX: ${{ matrix.box }}
@@ -113,7 +117,7 @@ jobs:
         run: |
           ./forge setup-repositories
       - name: Create custom certificates
-        if: matrix.certificate_source == 'custom_server'
+        if: matrix.certificate_source == 'custom_server' || matrix.certificate_source == 'custom_ca'
         run: |
           ./forge custom-certs
       - name: Setup security mode ${{ matrix.security }}
@@ -137,6 +141,7 @@ jobs:
             --certificate-source=${{ matrix.certificate_source }} \
             ${{ matrix.database == 'external' && '--database-mode=external --database-host=database.example.com --database-ssl-ca $(pwd)/.var/lib/foremanctl/db-ca.crt --database-ssl-mode verify-full' || '' }} \
             ${{ matrix.certificate_source == 'custom_server' && '--certificate-server-certificate /root/custom-certificates/certs/quadlet.example.com.crt --certificate-server-key /root/custom-certificates/private/quadlet.example.com.key --certificate-server-ca-certificate /root/custom-certificates/certs/ca.crt' || '' }} \
+            ${{ matrix.certificate_source == 'custom_ca' && '--certificate-ca-certificate /root/custom-certificates/certs/ca.crt --certificate-ca-key /root/custom-certificates/private/ca.key' || '' }} \
             --initial-admin-password=changeme \
             --initial-organization "Foreman CI" \
             --initial-location "Internet" \

--- a/docs/user/certificates.md
+++ b/docs/user/certificates.md
@@ -6,7 +6,7 @@ This document describes how certificate generation and management works in forem
 
 ### Certificate Sources
 
-foremanctl supports two certificate sources that determine how certificates are obtained:
+foremanctl supports three certificate sources that determine how certificates are obtained:
 
 **Default Source (`certificate_source: default`)**
 - Automatically generates self-signed certificates during deployment
@@ -18,6 +18,14 @@ foremanctl supports two certificate sources that determine how certificates are 
 - Automatically generates an internal CA for client certificates and localhost
 - Server certificate, key, and CA bundle are copied to `/var/lib/foremanctl/certs/`
 - Certificate source persists across deployments; original files only needed on first deploy or when updating certificates
+
+**Custom CA (`certificate_source: custom_ca`)**
+- Uses a CA provided certificate and key that issues all certs
+- The provided CA key is stored unencrypted, the same way the managed internal CA key is stored
+- The CA must have `basicConstraints CA:TRUE`
+- **On an existing deployment, replacing the CA invalidates all certs**
+  `custom_ca` refuses to overwrite an existing CA unless you pass `--replace-ca`.
+  A fresh install, or re-applying the same CA, does not need `--replace-ca`
 
 ### Usage
 
@@ -52,6 +60,19 @@ foremanctl deploy \
 
 # Switch back to auto-generated certificates
 foremanctl deploy --certificate-source=default
+```
+
+#### Using a Custom CA
+
+```bash
+# First deployment
+foremanctl deploy \
+  --certificate-source=custom_ca \
+  --certificate-ca-certificate /path/to/ca.crt \
+  --certificate-ca-key /path/to/ca.key
+
+# With encrypted CA, add:
+  --certificate-ca-key-password 'secret'
 ```
 
 #### Migrating from foreman-installer

--- a/src/playbooks/_certificate_source/metadata.obsah.yaml
+++ b/src/playbooks/_certificate_source/metadata.obsah.yaml
@@ -1,8 +1,9 @@
 ---
 variables:
   certificates_source:
-    help: Where certificates are coming from. Currently default Ansible role or custom server certificates.
+    help: Where certificates come from - the default self-signed CA, custom server certificates, or a custom user supplied CA
     parameter: --certificate-source
     choices:
       - default
       - custom_server
+      - custom_ca

--- a/src/playbooks/_certificates_custom/metadata.obsah.yaml
+++ b/src/playbooks/_certificates_custom/metadata.obsah.yaml
@@ -15,7 +15,29 @@ variables:
     type: AbsolutePath
     parameter: --certificate-server-ca-certificate
     persist: false
+  certificates_custom_ca_certificate:
+    help: Path to self supplied CA certificate
+    type: AbsolutePath
+    parameter: --certificate-ca-certificate
+    persist: false
+  certificates_custom_ca_key:
+    help: Path to the private key of the CA certificate
+    type: AbsolutePath
+    parameter: --certificate-ca-key
+    persist: false
+  certificates_custom_ca_key_password:
+    help: Password for the custom CA private key
+    parameter: --certificate-ca-key-password
+    persist: false
+  certificates_replace_ca:
+    help: >-
+      Required when replacing an existing CA when using --certificate-source=custom_ca.
+      On an existing deployment this invalidates all previously signed certs!
+    parameter: --replace-ca
+    action: store_true
+    persist: false
 
 constraints:
   required_together:
     - [certificates_custom_server_certificate, certificates_custom_server_key, certificates_custom_server_ca_certificate]
+    - [certificates_custom_ca_certificate, certificates_custom_ca_key]

--- a/src/roles/certificates/tasks/custom_ca.yml
+++ b/src/roles/certificates/tasks/custom_ca.yml
@@ -1,0 +1,72 @@
+---
+# Import a user-supplied CA (certificate + key)
+#
+# The CA private key is stored unencrypted, matching the internal CA
+
+- name: 'Read the provided custom CA certificate'
+  community.crypto.x509_certificate_info:
+    path: "{{ certificates_custom_ca_certificate }}"
+  register: _certificates_custom_ca_info
+
+- name: 'Assert the provided custom CA can sign certificates'
+  ansible.builtin.assert:
+    that:
+      - "'CA:TRUE' in (_certificates_custom_ca_info.basic_constraints | default([]))"
+    fail_msg: >-
+      The certificate at {{ certificates_custom_ca_certificate }} is not a CA
+      certificate.
+    success_msg: 'Provided custom CA is a valid signing CA.'
+
+- name: 'Stat the existing managed CA'
+  ansible.builtin.stat:
+    path: "{{ certificates_ca_directory_certs }}/ca.crt"
+  register: _certificates_existing_ca
+
+- name: 'Read the existing managed CA for comparison'
+  community.crypto.x509_certificate_info:
+    path: "{{ certificates_ca_directory_certs }}/ca.crt"
+  register: _certificates_existing_ca_info
+  when: _certificates_existing_ca.stat.exists
+
+- name: 'Do not replace existing ca without --replace-ca'
+  ansible.builtin.fail:
+    msg: >-
+      --certificate-source=custom_ca would REPLACE the existing CA at
+      {{ certificates_ca_directory_certs }}/ca.crt!
+      That would invalidate all previously signed certs!
+      Re-run with --replace-ca only if you know what you are doing!
+  when:
+    - _certificates_existing_ca.stat.exists
+    - (_certificates_existing_ca_info.fingerprints.sha256 | default(''))
+      != (_certificates_custom_ca_info.fingerprints.sha256 | default(''))
+    - not (certificates_replace_ca | default(false) | bool)
+
+- name: 'Import custom CA certificate'
+  ansible.builtin.copy:
+    src: "{{ certificates_custom_ca_certificate }}"
+    dest: "{{ certificates_ca_directory_certs }}/ca.crt"
+    remote_src: true
+    mode: '0444'
+
+- name: 'Import the custom CA key, unencrypted'
+  community.crypto.openssl_privatekey_convert:
+    src_path: "{{ certificates_custom_ca_key }}"
+    src_passphrase: "{{ certificates_custom_ca_key_password | default(omit, true) }}"
+    dest_path: "{{ certificates_ca_directory_keys }}/ca.key"
+    format: pkcs8
+    mode: '0600'
+  no_log: true
+
+- name: 'Copy custom CA as server CA certificate'
+  ansible.builtin.copy:
+    src: "{{ certificates_ca_directory_certs }}/ca.crt"
+    dest: "{{ certificates_ca_directory_certs }}/server-ca.crt"
+    remote_src: true
+    mode: '0444'
+
+- name: 'Create CA bundle from the custom CA'
+  ansible.builtin.copy:
+    src: "{{ certificates_ca_directory_certs }}/ca.crt"
+    dest: "{{ certificates_ca_directory_certs }}/ca-bundle.crt"
+    remote_src: true
+    mode: '0444'

--- a/src/roles/certificates/tasks/host.yml
+++ b/src/roles/certificates/tasks/host.yml
@@ -2,7 +2,6 @@
 - name: Apply custom server certificates
   ansible.builtin.include_tasks: custom.yml
   when:
-    - certificates_source == 'custom_server'
     - certificates_custom_server_certificate is defined
 
 - name: Issue certificates

--- a/src/roles/certificates/tasks/issue.yml
+++ b/src/roles/certificates/tasks/issue.yml
@@ -1,7 +1,7 @@
 ---
 - name: Issue server certificate
   when:
-    - (certificates_source != 'custom_server') or (certificates_hostname == 'localhost')
+    - (certificates_custom_server_certificate is not defined) or (certificates_hostname == 'localhost')
   block:
     - name: 'Create server private key'
       community.crypto.openssl_privatekey:

--- a/src/roles/certificates/tasks/main.yml
+++ b/src/roles/certificates/tasks/main.yml
@@ -40,6 +40,12 @@
     - auth_bundle is not defined
     - certificates_generate
   block:
+    - name: 'Import the custom CA'
+      ansible.builtin.include_tasks: custom_ca.yml
+      when:
+        - certificates_source == 'custom_ca'
+        - certificates_custom_ca_certificate is defined
+
     - name: 'Generate CA certificate'
       ansible.builtin.include_tasks: ca.yml
       when:

--- a/src/roles/certificates/tasks/main.yml
+++ b/src/roles/certificates/tasks/main.yml
@@ -66,7 +66,7 @@
         regexp: '(ca|server-ca)\.crt$'
         mode: '0444'
       when:
-        - certificates_source == 'custom_server'
+        - certificates_custom_server_certificate is defined
 
 - name: 'Consume certs'
   when:

--- a/tests/certificates_test.py
+++ b/tests/certificates_test.py
@@ -47,6 +47,31 @@ def test_client_certificate_issued_by_internal_ca(server, certificates, custom_c
         "Client certificate should still be issued by the internal CA"
 
 
+def test_custom_ca_signs_entire_stack(server, certificates, custom_ca_certificates):
+    ca_info = certificate_info(server, certificates['ca_certificate'])
+    server_info = certificate_info(server, certificates['server_certificate'])
+    client_info = certificate_info(server, certificates['client_certificate'])
+    assert server_info['issuer'] == ca_info['subject'], \
+        "Server certificate should be issued by the custom CA"
+    assert client_info['issuer'] == ca_info['subject'], \
+        "Client certificate should be issued by the custom CA"
+
+
+def test_custom_ca_signs_candlepin(server, certificates, custom_ca_certificates):
+    assert server.service("candlepin").is_running, \
+        "Candlepin failed to start with the custom CA"
+    result = server.run(
+        "podman exec candlepin cat /etc/candlepin/certs/tomcat.crt "
+        "| openssl x509 -noout -subject -issuer"
+    )
+    assert result.succeeded, \
+        f"could not read Candlepin certificate: {result.stderr}"
+    tomcat_info = dict(line.split('=', 1) for line in result.stdout.splitlines())
+    ca_info = certificate_info(server, certificates['ca_certificate'])
+    assert tomcat_info['issuer'] == ca_info['subject'], \
+        "Candlepin certificate should be issued by the custom CA"
+
+
 def test_ca_bundle_contains_both_cas(server, certificates, custom_certificates):
     openssl_result = server.run(f"awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' {certificates['ca_bundle']} | openssl crl2pkcs7 -nocrl -certfile /dev/stdin | openssl pkcs7 -print_certs -noout -text | grep 'Subject:'")
     subjects = [line.strip() for line in openssl_result.stdout.splitlines()]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,8 +143,14 @@ def custom_certificates(certificate_source):
 
 
 @pytest.fixture(scope="module")
+def custom_ca_certificates(certificate_source):
+    if certificate_source != 'custom_ca':
+        pytest.skip("Only applies to custom_ca deployments")
+
+
+@pytest.fixture(scope="module")
 def default_certificates(certificate_source):
-    if certificate_source == 'custom_server':
+    if certificate_source != 'default':
         pytest.skip("Only applies to non-custom certificate deployments")
 
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Foremanctl should be able to handle user supplied CAs for signing certificates

partly fixes #297 

#### What are the changes introduced in this pull request?

* New certificate source `custom_ca`: imports a supplied CA and uses it to sign certificates
* New command line parameters `--certificate-ca-certificate`, `--certificate-ca-key`,                                                                                                                                                                               
    `--certificate-ca-key-password` 
* In case the CA is unencrypted it will be reencrypted so it looks like a generated one to the system, some tools like candlepin seem to want an encrypted CA and doing it differently would introduce many non-trivial changes

#### How to test this pull request

Steps to reproduce:

* Create a CA
* Deploy with the command line options above

#### Checklist
* [ ] Tests added/updated (if applicable)
* [X] Documentation updated (if applicable)
