### PR TITLE
Enable flatpak content in katello flavor

### DIFF
--- a/src/vars/flavors/katello.yml
+++ b/src/vars/flavors/katello.yml
@@ -5,5 +5,6 @@ flavor_features:
   - content/ansible
   - content/container
   - content/deb
+  - content/flatpak
   - content/python
   - content/rpm


### PR DESCRIPTION
## Summary
- add `content/flatpak` to the Katello flavor defaults
- reuse the existing `content/*` to `pulp_*` mapping already used for other content types
- keep the change scoped to the flavor list, matching how `content/ansible` and `content/deb` were added

## Test plan
- not run locally

Made with [Cursor](https://cursor.com)