### PR TITLE
Use unix sockets for httpd -> Foreman and Pulp communication

### DIFF
--- a/src/roles/foreman/defaults/main.yaml
+++ b/src/roles/foreman/defaults/main.yaml
@@ -12,6 +12,7 @@ foreman_database_ssl_ca: # noqa: no-empty-defaults
 foreman_database_ssl_ca_path: /etc/foreman/db-ca.crt
 
 foreman_name: "{{ ansible_facts['fqdn'] }}"
+foreman_listen_stream: localhost:3000
 foreman_url: "http://{{ ansible_facts['fqdn'] }}:3000"
 foreman_aliases: []
 

--- a/src/roles/foreman/handlers/main.yml
+++ b/src/roles/foreman/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Restart foreman socket
+  ansible.builtin.systemd:
+    name: foreman.socket
+    state: restarted
+
 - name: Restart foreman
   ansible.builtin.systemd:
     name: foreman

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -100,6 +100,12 @@
     - Restart foreman
     - Restart dynflow-sidekiq@
 
+- name: Deploy Foreman socket
+  ansible.builtin.template:
+    src: foreman.socket.j2
+    dest: /etc/systemd/system/foreman.socket
+    mode: '0644'
+
 - name: Deploy Foreman Container
   containers.podman.podman_container:
     name: "foreman"
@@ -130,6 +136,8 @@
       FOREMAN_ENABLED_PLUGINS: "{{ foreman_plugins | join(' ') }}"
     quadlet_options:
       - |
+        [Unit]
+        Requires=foreman.socket
         [Install]
         WantedBy=default.target foreman.target
         [Unit]

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -105,6 +105,7 @@
     src: foreman.socket.j2
     dest: /etc/systemd/system/foreman.socket
     mode: '0644'
+  notify: Restart foreman socket
 
 - name: Deploy Foreman Container
   containers.podman.podman_container:

--- a/src/roles/foreman/templates/foreman.socket.j2
+++ b/src/roles/foreman/templates/foreman.socket.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Foreman socket
+
+[Socket]
+ListenStream={{ foreman_listen_stream }}
+
+[Install]
+WantedBy=sockets.target

--- a/src/roles/foreman/templates/foreman.socket.j2
+++ b/src/roles/foreman/templates/foreman.socket.j2
@@ -3,6 +3,12 @@ Description=Foreman socket
 
 [Socket]
 ListenStream={{ foreman_listen_stream }}
+SocketUser=apache
+SocketMode=0600
+
+NoDelay=false
+ReusePort=true
+Backlog=1024
 
 [Install]
 WantedBy=sockets.target

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -13,6 +13,13 @@
     persistent: true
   when: ansible_facts['selinux']['status'] == "enabled"
 
+# TODO: probably not the right boolean
+- name: Set daemons_enable_cluster_mode so Apache can connect to unix sockets
+  ansible.posix.seboolean:
+    name: daemons_enable_cluster_mode
+    state: true
+    persistent: true
+
 - name: Disable welcome page
   ansible.builtin.file:
     path: /etc/httpd/conf.d/welcome.conf

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -13,6 +13,15 @@
     persistent: true
   when: ansible_facts['selinux']['status'] == "enabled"
 
+- name: Set httpd_can_network_relay so Apache can reverse proxy to remote servers
+  ansible.posix.seboolean:
+    name: httpd_can_network_relay
+    state: true
+    persistent: true
+  when:
+    - ansible_facts['selinux']['status'] == "enabled"
+    - not httpd_with_foreman
+
 - name: Disable welcome page
   ansible.builtin.file:
     path: /etc/httpd/conf.d/welcome.conf

--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -6,19 +6,12 @@
       - mod_ssl
     state: present
 
-- name: Set httpd_can_network_connect so Apache can connect to Puma and Gunicorn
-  ansible.posix.seboolean:
-    name: httpd_can_network_connect
-    state: true
-    persistent: true
-  when: ansible_facts['selinux']['status'] == "enabled"
-
-# TODO: probably not the right boolean
 - name: Set daemons_enable_cluster_mode so Apache can connect to unix sockets
   ansible.posix.seboolean:
     name: daemons_enable_cluster_mode
     state: true
     persistent: true
+  when: ansible_facts['selinux']['status'] == "enabled"
 
 - name: Disable welcome page
   ansible.builtin.file:

--- a/src/roles/pulp/defaults/main.yaml
+++ b/src/roles/pulp/defaults/main.yaml
@@ -20,6 +20,9 @@ pulp_api_container_name: pulp-api
 pulp_content_container_name: pulp-content
 pulp_worker_container_name: pulp-worker
 
+pulp_api_listen_stream: localhost:24817
+pulp_content_listen_stream: localhost:24816
+
 pulp_content_origin: "http://{{ ansible_facts['fqdn'] }}:24816"
 pulp_pulp_url: "http://{{ ansible_facts['fqdn'] }}:24817"
 

--- a/src/roles/pulp/handlers/main.yml
+++ b/src/roles/pulp/handlers/main.yml
@@ -1,7 +1,17 @@
 ---
+- name: Restart pulp-api socket
+  ansible.builtin.systemd:
+    name: pulp-api.socket
+    state: restarted
+
 - name: Restart pulp-api
   ansible.builtin.systemd:
     name: pulp-api
+    state: restarted
+
+- name: Restart pulp-content socket
+  ansible.builtin.systemd:
+    name: pulp-content.socket
     state: restarted
 
 - name: Restart pulp-content

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -92,16 +92,37 @@
     - Restart pulp-content
     - Restart pulp-worker
 
+- name: Deploy Pulp API socket
+  ansible.builtin.template:
+    src: pulp-api.socket.j2
+    dest: /etc/systemd/system/pulp-api.socket
+    mode: '0644'
+
+# TODO: The --bind argument is passed here to override pulpcore-api's default
+# bind address (0.0.0.0:24817) with a unix socket. This duplicates arguments
+# from the container's pulp-api entry point script, which is fragile if the
+# image changes. The proper fix is to add a PULP_API_BIND environment variable
+# to the pulp-oci-images container (like PULP_API_WORKERS already works),
+# then set it via env: instead of overriding the command.
+# See: https://github.com/theforeman/pulp-oci-images
 - name: Deploy Pulp API Container
   containers.podman.podman_container:
     name: "{{ pulp_api_container_name }}"
     image: pulp.image
     state: quadlet
     sdnotify: true
-    command: pulp-api
+    command: >-
+      /usr/bin/pulpcore-api
+      --bind unix:{{ pulp_api_listen_stream }}
+      --timeout 90
+      --workers {{ pulp_api_service_worker_count }}
+      --max-requests 800
+      --max-requests-jitter 100
+      --access-logfile -
+      --access-logformat 'pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
     network: host
     hostname: "pulp-api.{{ ansible_facts['hostname'] }}.local"
-    volumes: "{{ pulp_volumes }}"
+    volumes: "{{ pulp_volumes + ['/run:/run:rw'] }}"
     security_opt:
       - "label=disable"
     secrets:
@@ -112,6 +133,8 @@
     env: "{{ pulp_settings_env }}"
     quadlet_options:
       - |
+        [Unit]
+        Requires=pulp-api.socket
         [Install]
         WantedBy=default.target foreman.target
         [Unit]
@@ -123,16 +146,29 @@
         RestartSec=3
   notify: Restart pulp-api
 
+- name: Deploy Pulp Content socket
+  ansible.builtin.template:
+    src: pulp-content.socket.j2
+    dest: /etc/systemd/system/pulp-content.socket
+    mode: '0644'
+
+# TODO: Same as pulp-api above — add PULP_CONTENT_BIND to pulp-oci-images
+# and use env: instead of overriding the command.
 - name: Deploy Pulp Content Container
   containers.podman.podman_container:
     name: "{{ pulp_content_container_name }}"
     image: pulp.image
     state: quadlet
     sdnotify: true
-    command: pulp-content
+    command: >-
+      /usr/bin/pulpcore-content
+      --bind unix:{{ pulp_content_listen_stream }}
+      --timeout 90
+      --workers {{ pulp_content_service_worker_count }}
+      --access-logfile -
     network: host
     hostname: "pulp-content.{{ ansible_facts['hostname'] }}.local"
-    volumes: "{{ pulp_volumes }}"
+    volumes: "{{ pulp_volumes + ['/run:/run:rw'] }}"
     security_opt:
       - "label=disable"
     secrets:
@@ -143,6 +179,8 @@
     env: "{{ pulp_settings_env }}"
     quadlet_options:
       - |
+        [Unit]
+        Requires=pulp-content.socket
         [Install]
         WantedBy=default.target foreman.target
         [Unit]

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -97,6 +97,7 @@
     src: pulp-api.socket.j2
     dest: /etc/systemd/system/pulp-api.socket
     mode: '0644'
+  notify: Restart pulp-api socket
 
 - name: Deploy Pulp API Container
   containers.podman.podman_container:
@@ -136,6 +137,7 @@
     src: pulp-content.socket.j2
     dest: /etc/systemd/system/pulp-content.socket
     mode: '0644'
+  notify: Restart pulp-content socket
 
 - name: Deploy Pulp Content Container
   containers.podman.podman_container:

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -98,31 +98,16 @@
     dest: /etc/systemd/system/pulp-api.socket
     mode: '0644'
 
-# TODO: The --bind argument is passed here to override pulpcore-api's default
-# bind address (0.0.0.0:24817) with a unix socket. This duplicates arguments
-# from the container's pulp-api entry point script, which is fragile if the
-# image changes. The proper fix is to add a PULP_API_BIND environment variable
-# to the pulp-oci-images container (like PULP_API_WORKERS already works),
-# then set it via env: instead of overriding the command.
-# See: https://github.com/theforeman/pulp-oci-images
 - name: Deploy Pulp API Container
   containers.podman.podman_container:
     name: "{{ pulp_api_container_name }}"
     image: pulp.image
     state: quadlet
     sdnotify: true
-    command: >-
-      /usr/bin/pulpcore-api
-      --bind unix:{{ pulp_api_listen_stream }}
-      --timeout 90
-      --workers {{ pulp_api_service_worker_count }}
-      --max-requests 800
-      --max-requests-jitter 100
-      --access-logfile -
-      --access-logformat 'pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+    command: pulp-api
     network: host
     hostname: "pulp-api.{{ ansible_facts['hostname'] }}.local"
-    volumes: "{{ pulp_volumes + ['/run:/run:rw'] }}"
+    volumes: "{{ pulp_volumes }}"
     security_opt:
       - "label=disable"
     secrets:
@@ -152,23 +137,16 @@
     dest: /etc/systemd/system/pulp-content.socket
     mode: '0644'
 
-# TODO: Same as pulp-api above — add PULP_CONTENT_BIND to pulp-oci-images
-# and use env: instead of overriding the command.
 - name: Deploy Pulp Content Container
   containers.podman.podman_container:
     name: "{{ pulp_content_container_name }}"
     image: pulp.image
     state: quadlet
     sdnotify: true
-    command: >-
-      /usr/bin/pulpcore-content
-      --bind unix:{{ pulp_content_listen_stream }}
-      --timeout 90
-      --workers {{ pulp_content_service_worker_count }}
-      --access-logfile -
+    command: pulp-content
     network: host
     hostname: "pulp-content.{{ ansible_facts['hostname'] }}.local"
-    volumes: "{{ pulp_volumes + ['/run:/run:rw'] }}"
+    volumes: "{{ pulp_volumes }}"
     security_opt:
       - "label=disable"
     secrets:

--- a/src/roles/pulp/templates/pulp-api.socket.j2
+++ b/src/roles/pulp/templates/pulp-api.socket.j2
@@ -1,12 +1,12 @@
 [Unit]
-Description=Foreman socket
+Description=Pulp API socket
 
 [Socket]
-ListenStream={{ foreman_listen_stream }}
+ListenStream={{ pulp_api_listen_stream }}
 SocketUser=apache
 SocketMode=0600
 
-NoDelay=true
+NoDelay=false
 ReusePort=true
 # Default on EL10 (v254+), needed explicitly for EL9 (v252)
 Backlog=4294967295

--- a/src/roles/pulp/templates/pulp-content.socket.j2
+++ b/src/roles/pulp/templates/pulp-content.socket.j2
@@ -1,12 +1,12 @@
 [Unit]
-Description=Foreman socket
+Description=Pulp Content socket
 
 [Socket]
-ListenStream={{ foreman_listen_stream }}
+ListenStream={{ pulp_content_listen_stream }}
 SocketUser=apache
 SocketMode=0600
 
-NoDelay=true
+NoDelay=false
 ReusePort=true
 # Default on EL10 (v254+), needed explicitly for EL9 (v252)
 Backlog=4294967295

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -26,6 +26,11 @@ foreman_url: "https://{{ foreman_name }}"
 foreman_listen_stream: /run/httpd.foreman.sock
 httpd_foreman_backend: "unix://{{ foreman_listen_stream }}|http://%{HTTP_HOST}"
 
+pulp_api_listen_stream: /run/httpd.pulp-api.sock
+pulp_content_listen_stream: /run/httpd.pulp-content.sock
+httpd_pulp_api_backend: "unix://{{ pulp_api_listen_stream }}|http://%{HTTP_HOST}"
+httpd_pulp_content_backend: "unix://{{ pulp_content_listen_stream }}|http://%{HTTP_HOST}"
+
 httpd_server_ca_certificate: "{{ server_ca_certificate }}"
 httpd_client_ca_certificate: "{{ client_ca_certificate }}"
 httpd_server_certificate: "{{ server_certificate }}"

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -23,6 +23,9 @@ foreman_plugins: "{{ enabled_features | features_to_foreman_plugins }}"
 foreman_name: "{{ ansible_facts['fqdn'] }}"
 foreman_url: "https://{{ foreman_name }}"
 
+foreman_listen_stream: /run/httpd.foreman.sock
+httpd_foreman_backend: "unix://{{ foreman_listen_stream }}|http://%{HTTP_HOST}"
+
 httpd_server_ca_certificate: "{{ server_ca_certificate }}"
 httpd_client_ca_certificate: "{{ client_ca_certificate }}"
 httpd_server_certificate: "{{ server_certificate }}"

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -24,12 +24,12 @@ foreman_name: "{{ ansible_facts['fqdn'] }}"
 foreman_url: "https://{{ foreman_name }}"
 
 foreman_listen_stream: /run/httpd.foreman.sock
-httpd_foreman_backend: "unix://{{ foreman_listen_stream }}|http://%{HTTP_HOST}"
+httpd_foreman_backend: "unix://{{ foreman_listen_stream }}|http://foreman"
 
 pulp_api_listen_stream: /run/httpd.pulp-api.sock
 pulp_content_listen_stream: /run/httpd.pulp-content.sock
-httpd_pulp_api_backend: "unix://{{ pulp_api_listen_stream }}|http://%{HTTP_HOST}"
-httpd_pulp_content_backend: "unix://{{ pulp_content_listen_stream }}|http://%{HTTP_HOST}"
+httpd_pulp_api_backend: "unix://{{ pulp_api_listen_stream }}|http://pulpcore-api"
+httpd_pulp_content_backend: "unix://{{ pulp_content_listen_stream }}|http://pulpcore-content"
 
 httpd_server_ca_certificate: "{{ server_ca_certificate }}"
 httpd_client_ca_certificate: "{{ client_ca_certificate }}"

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -5,7 +5,7 @@ import pytest
 pytestmark = pytest.mark.feature('foreman')
 
 FOREMAN_HOST = 'localhost'
-FOREMAN_PORT = 3000
+FOREMAN_SOCKET = '/run/httpd.foreman.sock'
 
 RECURRING_INSTANCES = [
     "hourly",
@@ -16,8 +16,8 @@ RECURRING_INSTANCES = [
 
 
 @pytest.fixture(scope="module")
-def foreman_status_curl(server, server_fqdn):
-    return server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' http://{server_fqdn}:{FOREMAN_PORT}/api/v2/ping")
+def foreman_status_curl(server):
+    return server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} http://{FOREMAN_HOST}/api/v2/ping")
 
 
 @pytest.fixture(scope="module")
@@ -30,9 +30,8 @@ def test_foreman_service(server):
     assert foreman.is_running
 
 
-def test_foreman_port(server):
-    foreman = server.addr(FOREMAN_HOST)
-    assert foreman.port(FOREMAN_PORT).is_reachable
+def test_foreman_socket(server):
+    assert server.socket(f"unix://{FOREMAN_SOCKET}").is_listening
 
 
 def test_foreman_status(foreman_status_curl):
@@ -99,6 +98,6 @@ def test_foreman_domain_in_mail_settings(foremanapi, server_fqdn, setting):
 
 
 def test_foreman_host_injection(server):
-    cmd = server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --resolve evil.hackers.test:{FOREMAN_PORT}:127.0.0.1 http://evil.hackers.test:{FOREMAN_PORT}/api/v2/ping")
+    cmd = server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} --header 'Host: evil.hackers.test' http://{FOREMAN_HOST}/api/v2/ping")
     assert cmd.succeeded
     assert cmd.stderr == '403'

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -4,7 +4,6 @@ import pytest
 
 pytestmark = pytest.mark.feature('foreman')
 
-FOREMAN_HOST = 'localhost'
 FOREMAN_SOCKET = '/run/httpd.foreman.sock'
 
 RECURRING_INSTANCES = [
@@ -16,8 +15,8 @@ RECURRING_INSTANCES = [
 
 
 @pytest.fixture(scope="module")
-def foreman_status_curl(server):
-    return server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} http://{FOREMAN_HOST}/api/v2/ping")
+def foreman_status_curl(server, server_fqdn):
+    return server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} http://{server_fqdn}/api/v2/ping")
 
 
 @pytest.fixture(scope="module")
@@ -98,6 +97,6 @@ def test_foreman_domain_in_mail_settings(foremanapi, server_fqdn, setting):
 
 
 def test_foreman_host_injection(server):
-    cmd = server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} --header 'Host: evil.hackers.test' http://{FOREMAN_HOST}/api/v2/ping")
+    cmd = server.run(f"curl --header 'X-FORWARDED-PROTO: https' --silent --write-out '%{{stderr}}%{{http_code}}' --unix-socket {FOREMAN_SOCKET} http://evil.hackers.test/api/v2/ping")
     assert cmd.succeeded
     assert cmd.stderr == '403'

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -4,7 +4,6 @@ import os
 import pytest
 import yaml
 
-PULP_HOST = 'localhost'
 PULP_API_SOCKET = '/run/httpd.pulp-api.sock'
 PULP_CONTENT_SOCKET = '/run/httpd.pulp-content.sock'
 
@@ -24,8 +23,8 @@ def load_pulp_paths_from_parameters():
 
 
 @pytest.fixture(scope="module")
-def pulp_status_curl(server):
-    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --unix-socket {PULP_API_SOCKET} http://{PULP_HOST}/pulp/api/v3/status/")
+def pulp_status_curl(server, server_fqdn):
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --unix-socket {PULP_API_SOCKET} http://{server_fqdn}/pulp/api/v3/status/")
 
 
 @pytest.fixture(scope="module")

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -5,8 +5,8 @@ import pytest
 import yaml
 
 PULP_HOST = 'localhost'
-PULP_API_PORT = 24817
-PULP_CONTENT_PORT = 24816
+PULP_API_SOCKET = '/run/httpd.pulp-api.sock'
+PULP_CONTENT_SOCKET = '/run/httpd.pulp-content.sock'
 
 
 def load_pulp_paths_from_parameters():
@@ -25,7 +25,7 @@ def load_pulp_paths_from_parameters():
 
 @pytest.fixture(scope="module")
 def pulp_status_curl(server):
-    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' http://{PULP_HOST}:{PULP_API_PORT}/pulp/api/v3/status/")
+    return server.run(f"curl -k -s -w '%{{stderr}}%{{http_code}}' --unix-socket {PULP_API_SOCKET} http://{PULP_HOST}/pulp/api/v3/status/")
 
 
 @pytest.fixture(scope="module")
@@ -58,14 +58,12 @@ def test_pulp_worker_services(server):
         assert worker.is_running
 
 
-def test_pulp_api_port(server):
-    pulp_api = server.addr(PULP_HOST)
-    assert pulp_api.port(PULP_API_PORT).is_reachable
+def test_pulp_api_socket(server):
+    assert server.socket(f"unix://{PULP_API_SOCKET}").is_listening
 
 
-def test_pulp_content_port(server):
-    pulp_content = server.addr(PULP_HOST)
-    assert pulp_content.port(PULP_CONTENT_PORT).is_reachable
+def test_pulp_content_socket(server):
+    assert server.socket(f"unix://{PULP_CONTENT_SOCKET}").is_listening
 
 
 def test_pulp_status(pulp_status_curl):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
On hosts without IPv4 (IPv6-only), Apache resolves `localhost` to `::1` but Puma/Gunicorn only listen on `127.0.0.1`, causing connection refused errors:
 ```
AH00957: http: attempt to connect to [::1]:3000 (localhost:3000) failed
```
This affects all three httpd backends: Foreman (port 3000), Pulp API (port 24817), and Pulp Content (port 24816).
Builds on the work started by @ekohl in #118 and #593. In foreman-installer, using a unix socket had reliability benefits, this brings the same approach to foremanctl.

**Why unix sockets instead of binding to `127.0.0.1` explicitly:**

  * **Parity with foreman-installer:** puppet-foreman and puppet-pulpcore already use unix sockets
  * **No TCP port conflicts:**  doesn't occupy TCP ports 3000, 24816, 24817
  * **Filesystem-level access control:**  socket permissions via `SocketUser`/`SocketMode`
  * **Eliminates TCP loopback overhead**
  * **Systemd socket activation:** clean dependency ordering via `Requires=`

#### What are the changes introduced in this pull request?

  Foreman (cherry-picked from #593, authored by @ekohl):
  * Systemd socket activation for Foreman
  * Unix socket between httpd and Puma at `/run/httpd.foreman.sock`

  SELinux fixes (on top of #593):
  * Add missing `when` guard for `daemons_enable_cluster_mode` boolean
  * Remove `httpd_can_network_connect`,  no longer needed with all backends on unix sockets

  Pulp:
  * Unix sockets for Pulp API (`/run/httpd.pulp-api.sock`) and Pulp Content (`/run/httpd.pulp-content.sock`)
  * Systemd socket units for both services
  * Container command overrides to bind Gunicorn to unix sockets


#### How to test this pull request
  * Deploy using foremanctl on an IPv6-only or IPv4-only host
  * Verify no TCP listeners on ports 3000, 24816, 24817: `ss -tlnp | grep -E '(3000|24816|24817)'`
  * Verify unix sockets exist: `ls -laZ /run/httpd.*.sock`
  * The Foreman UI loads
  * Pulp API responds: `curl -k https://$(hostname -f)/pulp/api/v3/status/`
  * Test suite passes

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
