### PR TITLE
Add mutually exclusive feature support via conflicts metadata

### DIFF
--- a/docs/developer/feature-metadata.md
+++ b/docs/developer/feature-metadata.md
@@ -31,6 +31,7 @@ The following properties are defined:
   * `role` (_String_): The name of the Ansible role to be executed if the feature is not implemented as a Foreman Proxy plugin.
 * `hammer` (_String_): The name of the Hammer plugin to be enabled (the package installed will be `hammer-cli-plugin-{{ hammer }}`).
 * `dependencies` (_Array_ of _String_): List of features that are automatically enabled when the user requests this feature. Usually will point at features with `internal: true`.
+* `conflicts` (_Array_ of _String_): List of features that are mutually exclusive with this feature. If both are enabled, deployment will fail with an error. Conflicts must be declared on both sides — if feature A lists B in its conflicts, B must also list A.
 
 Properties can be omitted.
 

--- a/docs/developer/how-to-add-a-feature.md
+++ b/docs/developer/how-to-add-a-feature.md
@@ -63,6 +63,28 @@ dynflow:
     plugin_name: dynflow
 ```
 
+### Conflicts
+
+Use `conflicts` to declare that two features are mutually exclusive and cannot both be enabled in the same deployment. Conflicts must be declared on both sides:
+
+```yaml
+cloud-connector:
+  description: Cloud Connector for Red Hat Hybrid Cloud Console
+  dependencies:
+    - rh-cloud
+  conflicts:
+    - iop
+
+iop:
+  description: iop services
+  dependencies:
+    - rh-cloud
+  conflicts:
+    - cloud-connector
+```
+
+When a user tries to enable both conflicting features, the deploy will fail early with an error identifying the conflict.
+
 ## Step 2: Configure the Foreman Proxy Plugin (if needed)
 
 If the feature has no `foreman_proxy` section, skip to Step 3.

--- a/src/filter_plugins/foremanctl.py
+++ b/src/filter_plugins/foremanctl.py
@@ -93,6 +93,16 @@ def invalid_features(features):
     return [feature for feature in features if feature not in FEATURE_MAP]
 
 
+def conflicting_features(features):
+    """Return a list of conflict violation strings for enabled features."""
+    conflicts = set()
+    for feature in features:
+        for conflict in FEATURE_MAP.get(feature, {}).get('conflicts', []):
+            if conflict in features:
+                conflicts.add(tuple(sorted([feature, conflict])))
+    return [f"{pair[0]} conflicts with {pair[1]}" for pair in conflicts]
+
+
 def hammer_plugins(value):
     dependencies = list(get_dependencies(filter_features(value)))
     plugins = [FEATURE_MAP.get(feature, {}).get('hammer') for feature in filter_features(value + dependencies)]
@@ -142,6 +152,7 @@ class FilterModule(object):
             'available_foreman_proxy_plugins': available_foreman_proxy_plugins,
             'list_all_features': list_all_features,
             'invalid_features': invalid_features,
+            'conflicting_features': conflicting_features,
             'has_feature': has_feature,
             'databases_for_features': databases_for_features,
             'to_postgresql_databases': to_postgresql_databases,

--- a/src/roles/check_features/tasks/main.yaml
+++ b/src/roles/check_features/tasks/main.yaml
@@ -10,3 +10,17 @@
   vars:
     found_invalid_features: "{{ features | invalid_features }}"
   when: features | length > 0
+
+- name: Validate feature conflicts
+  ansible.builtin.assert:
+    that:
+      - found_conflicts | length == 0
+    fail_msg: |
+      ERROR: Conflicting features detected:
+      {% for conflict in found_conflicts %}
+        - {{ conflict }}
+      {% endfor %}
+
+      These features cannot be enabled together.
+  vars:
+    found_conflicts: "{{ enabled_features | conflicting_features }}"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'filter_plugins'))

--- a/tests/unit/filter_test.py
+++ b/tests/unit/filter_test.py
@@ -1,0 +1,56 @@
+from foremanctl import FEATURE_MAP
+from foremanctl import conflicting_features
+
+
+def _asymmetric_conflicts():
+    errors = []
+    for feature, meta in FEATURE_MAP.items():
+        for conflict in meta.get('conflicts', []):
+            if conflict not in FEATURE_MAP:
+                errors.append(f"{feature} declares conflict with unknown feature {conflict}")
+            elif feature not in FEATURE_MAP.get(conflict, {}).get('conflicts', []):
+                errors.append(f"{feature} declares conflict with {conflict}, but {conflict} does not declare conflict with {feature}")
+    return errors
+
+
+def test_no_conflicts():
+    assert conflicting_features(['foreman', 'hammer']) == []
+
+
+def test_detects_conflict(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'conflicts': ['test-b']})
+    monkeypatch.setitem(FEATURE_MAP, 'test-b', {'conflicts': ['test-a']})
+    result = conflicting_features(['test-a', 'test-b'])
+    assert len(result) == 1
+    assert 'test-a conflicts with test-b' in result
+
+
+def test_deduplicates_conflict_pairs(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'conflicts': ['test-b']})
+    monkeypatch.setitem(FEATURE_MAP, 'test-b', {'conflicts': ['test-a']})
+    result = conflicting_features(['test-b', 'test-a'])
+    assert len(result) == 1
+
+
+def test_no_conflict_when_only_one_present(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'conflicts': ['test-b']})
+    monkeypatch.setitem(FEATURE_MAP, 'test-b', {'conflicts': ['test-a']})
+    assert conflicting_features(['test-a', 'foreman']) == []
+
+
+def test_no_asymmetric_conflicts_in_features_yaml():
+    errors = _asymmetric_conflicts()
+    assert errors == [], f"Asymmetric conflicts found: {errors}"
+
+
+def test_asymmetric_conflict_detected(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'conflicts': ['test-b']})
+    monkeypatch.setitem(FEATURE_MAP, 'test-b', {})
+    errors = _asymmetric_conflicts()
+    assert any('test-a declares conflict with test-b' in e for e in errors)
+
+
+def test_conflict_with_unknown_feature_detected(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'conflicts': ['nonexistent']})
+    errors = _asymmetric_conflicts()
+    assert any('unknown feature nonexistent' in e for e in errors)


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Features in foremanctl can declare dependencies but have no way to declare that two features conflict with each other. When incompatible features are both enabled — whether via `--add-feature` on the same command, from a previous deploy's persisted state, or from flavor defaults — the deploy proceeds silently and produces a broken deployment. For example, `cloud-connector` and `iop` both provide connectivity to the Red Hat Hybrid Cloud Console using different mechanisms and cannot coexist (see #569).

#### What are the changes introduced in this pull request?

* Added `conflicts` property to the feature metadata schema in `features.yaml`, allowing features to declare mutual exclusivity alongside existing `dependencies`
* Added `conflicting_features` Jinja2 filter in `src/filter_plugins/foremanctl.py` that checks `enabled_features` for conflict violations and returns deduplicated conflict pair descriptions
* Added `asymmetric_conflicts` filter that validates all conflict declarations are bidirectional (both sides must declare the conflict)
* Extended `src/roles/check_features/tasks/main.yaml` with a "Validate feature conflicts" assertion that fails the deploy early with a clear error message
* Updated `docs/developer/feature-metadata.md` and `docs/developer/how-to-add-a-feature.md` with conflicts documentation and examples
* Added unit tests for the new filter functions

#### How to test this pull request

Steps to reproduce:

* Add a pair of conflicting features to `src/features.yaml` (e.g. when `cloud-connector` lands via #569, add `conflicts: [iop]` to it and `conflicts: [cloud-connector]` to `iop`)
* Run `./foremanctl deploy --add-feature <feature-a> --add-feature <feature-b>` with both conflicting features — deploy should fail with "Conflicting features detected" error
* Run unit tests: `.venv/bin/python -m pytest tests/unit/filter_test.py -vv --noconftest`
* Run ansible-lint: `cd src; ansible-lint roles/check_features/tasks/main.yaml`

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
