### PR TITLE
Only set pulp_rhsm_url for content proxies

### DIFF
--- a/src/roles/pulp/defaults/main.yaml
+++ b/src/roles/pulp/defaults/main.yaml
@@ -29,7 +29,6 @@ pulp_pulp_url: "http://{{ ansible_facts['fqdn'] }}:24817"
 pulp_enable_analytics: false
 pulp_mirror: false
 pulp_register_foreman_proxy: true
-pulp_rhsm_url: "https://{{ ansible_facts['fqdn'] }}/rhsm"
 
 pulp_default_import_paths: "{{ pulp_mirror | ternary([], ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']) }}"
 pulp_default_export_paths: "{{ pulp_mirror | ternary([], ['/var/lib/pulp/exports']) }}"
@@ -80,7 +79,7 @@ pulp_settings_other_env:
     ['rest_framework.authentication.SessionAuthentication', 'pulpcore.app.authentication.PulpRemoteUserAuthentication']
   PULP_SMART_PROXY_PULP_URL: "{{ pulp_pulp_url }}"
   PULP_SMART_PROXY_MIRROR: "{{ pulp_mirror }}"
-  PULP_SMART_PROXY_RHSM_URL: "{{ pulp_rhsm_url }}"
+  PULP_SMART_PROXY_RHSM_URL: "{{ pulp_rhsm_url | default('') }}"
   PULP_API_WORKERS: "{{ pulp_api_service_worker_count }}"
   PULP_CONTENT_WORKERS: "{{ pulp_content_service_worker_count }}"
   PULP_TOKEN_AUTH_DISABLED: "true"

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -44,7 +44,6 @@ pulp_storage_path: /var/lib/pulp
 pulp_content_origin: "https://{{ ansible_facts['fqdn'] }}"
 pulp_pulp_url: "https://{{ ansible_facts['fqdn'] }}"
 pulp_plugins: "{{ enabled_features | select('contains', 'content/') | map('replace', 'content/', 'pulp_') | list }}"
-pulp_rhsm_url: "{{ foreman_proxy_foreman_server_url }}/rhsm"
 pulp_foreman_url: "{{ foreman_proxy_foreman_server_url }}"
 pulp_foreman_ca_certificate: "{{ foreman_ca_certificate }}"
 pulp_foreman_oauth_consumer_key: "{{ foreman_proxy_oauth_consumer_key }}"

--- a/src/vars/flavors/foreman-proxy-content.yml
+++ b/src/vars/flavors/foreman-proxy-content.yml
@@ -7,6 +7,7 @@ flavor_features:
   - content/python
 
 pulp_mirror: true
+pulp_rhsm_url: "https://{{ ansible_facts['fqdn'] }}/rhsm"
 
 checks_to_execute:
   - check_features

--- a/tests/flavor/foreman-proxy-content/pulp_test.py
+++ b/tests/flavor/foreman-proxy-content/pulp_test.py
@@ -15,11 +15,16 @@ def pulp_settings(server):
     py = (
         'from django.conf import settings; import json; '
         'print(json.dumps({"import": list(settings.ALLOWED_IMPORT_PATHS), '
-        '"export": list(settings.ALLOWED_EXPORT_PATHS)}))'
+        '"export": list(settings.ALLOWED_EXPORT_PATHS), '
+        '"rhsm_url": settings.SMART_PROXY_RHSM_URL}))'
     )
     result = server.run(f"podman exec pulp-api pulpcore-manager shell -c '{py}'")
     assert result.succeeded, f"Failed to read Pulp settings: {result.stderr}"
     return json.loads(result.stdout)
+
+
+def test_pulp_rhsm_url_set_on_content_proxy(pulp_settings, server_fqdn):
+    assert pulp_settings['rhsm_url'] == f'https://{server_fqdn}/rhsm'
 
 
 def test_import_paths_restricted(pulp_settings):

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -37,6 +37,15 @@ def pulp_import_export_paths():
     return load_pulp_paths_from_parameters()
 
 
+@pytest.fixture(scope="module")
+def pulp_smart_proxy_settings(server):
+    py = (
+        'from django.conf import settings; import json; '
+        'print(json.dumps({"rhsm_url": settings.SMART_PROXY_RHSM_URL}))'
+    )
+    return json.loads(server.check_output(f"podman exec pulp-api pulpcore-manager shell -c '{py}'"))
+
+
 def test_pulp_api_service(server):
     pulp_api = server.service("pulp-api")
     assert pulp_api.is_running
@@ -140,3 +149,10 @@ def test_pulp_import_export_volume_mounts(server, container, pulp_import_export_
     for path in import_paths + export_paths:
         mounted = path in destinations or any(path.startswith(d + '/') for d in destinations)
         assert mounted, f"expected {path} to be mounted as a volume in {container}"
+
+
+def test_pulp_rhsm_url_empty_on_server(pulp_smart_proxy_settings, obsah_params):
+    if obsah_params.get('flavor') == 'foreman-proxy-content':
+        pytest.skip("content proxy deployments set PULP_SMART_PROXY_RHSM_URL")
+
+    assert pulp_smart_proxy_settings["rhsm_url"] == ""


### PR DESCRIPTION
## Problem

`pulp_rhsm_url` is currently set for all Pulp deployments.

On Foreman server deployments, that makes foremanctl export
`PULP_SMART_PROXY_RHSM_URL` even though Katello can already derive the
server RHSM URL on its own when the setting is absent.

On content proxies, an explicit RHSM URL is still needed so clients use the
proxy's `/rhsm` endpoint rather than the Foreman server directly.

## Solution

- Stop exporting `PULP_SMART_PROXY_RHSM_URL` for Foreman server deployments
- Set `pulp_rhsm_url` only for the `foreman-proxy-content` flavor
- Keep the explicit content proxy RHSM URL as `https://<proxy-fqdn>/rhsm`

## Testing

- Added coverage that server deployments do not export
  `PULP_SMART_PROXY_RHSM_URL`, while Katello still derives the server
  `/rhsm` URL for the server Pulp smart proxy
- Added coverage that `foreman-proxy-content` deployments do export it and
  point it to the proxy host
