### PR TITLE
Add copy-bundle forge command for proxy deployments

### DIFF
--- a/development/playbooks/fetch-bundle/fetch-bundle.yaml
+++ b/development/playbooks/fetch-bundle/fetch-bundle.yaml
@@ -6,9 +6,36 @@
   vars_files:
     - "../../../src/vars/base.yaml"
     - "../../../src/vars/certificates.yml"
+    - "../../../src/vars/foreman.yml"
   tasks:
     - name: Fetch bundle
       ansible.builtin.fetch:
         src: "{{ certificates_ca_directory }}/bundles/{{ hostname }}.tar.gz"
         dest: "{{ obsah_state_path }}/{{ hostname }}.tar.gz"
         flat: true
+
+    - name: Store oauth credentials
+      ansible.builtin.set_fact:
+        oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
+        oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"
+
+- name: Copy bundle to proxy
+  hosts:
+    - proxy
+  become: true
+  tasks:
+    - name: Copy bundle
+      ansible.builtin.copy:
+        src: "{{ obsah_state_base }}/quadlet/{{ hostname }}.tar.gz"
+        dest: "/root/{{ hostname }}.tar.gz"
+        mode: "0644"
+
+    - name: Print deploy-proxy instructions
+      ansible.builtin.debug:
+        msg: >-
+          To deploy the proxy, run:
+          ./foremanctl deploy-proxy
+          --certificate-bundle /root/{{ hostname }}.tar.gz
+          --foreman-fqdn {{ hostvars['quadlet']['ansible_facts']['fqdn'] }}
+          --oauth-consumer-key {{ hostvars['quadlet']['oauth_consumer_key'] }}
+          --oauth-consumer-secret {{ hostvars['quadlet']['oauth_consumer_secret'] }}

--- a/development/playbooks/fetch-bundle/metadata.obsah.yaml
+++ b/development/playbooks/fetch-bundle/metadata.obsah.yaml
@@ -1,6 +1,6 @@
 ---
 help: |
-  Fetch a certificate bundle
+  Fetch a certificate bundle from the server and copy it to the proxy if available
 
 variables:
   hostname:

--- a/src/roles/certificates/tasks/extract.yml
+++ b/src/roles/certificates/tasks/extract.yml
@@ -3,7 +3,6 @@
   ansible.builtin.stat:
     path: "{{ certificates_bundle }}"
   register: _certificates_tar_file_path
-  delegate_to: localhost
 
 - name: Fail if path to certificate tar file does not exist
   ansible.builtin.fail:
@@ -14,5 +13,6 @@
   ansible.builtin.unarchive:
     src: "{{ certificates_bundle }}"
     dest: "{{ certificates_ca_directory }}"
+    remote_src: true
     extra_opts:
       - --strip-components=1


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Deploying a proxy requires manually fetching the certificate bundle, copying it to the proxy VM, and then constructing the `deploy-proxy` command with the correct bundle path, FQDN, and oauth credentials. This is error-prone and requires looking up values from multiple sources.

#### What are the changes introduced in this pull request?

* Extend `forge fetch-bundle` to copy the certificate bundle to the proxy VM at `/root/<hostname>.tar.gz` when a proxy is in the inventory
* Print the full `deploy-proxy` command with the correct `--certificate-bundle`, `--foreman-fqdn`, `--oauth-consumer-key`, and `--oauth-consumer-secret` arguments
* When no proxy is in the inventory, the command behaves as before (fetch only)
* Update the certificates `extract.yml` to use `remote_src: true` on the `unarchive` task and remove `delegate_to: localhost` on the stat check, since the bundle now resides on the target host rather than the Ansible controller

#### How to test this pull request

Steps to reproduce:

* Deploy Foreman on quadlet: `./foremanctl deploy --initial-admin-password=changeme --tuning development --add-feature foreman-proxy`
* Generate a certificate bundle: `./foremanctl certificate-bundle proxy.example.com`
* Fetch and copy the bundle: `./forge fetch-bundle proxy.example.com`
* Verify the output shows the `deploy-proxy` command with all required arguments
* Run the printed `deploy-proxy` command and verify the proxy deploys successfully
* Verify `./forge fetch-bundle` still works without a proxy VM in the inventory

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

