### PR TITLE
Fix Candlepin service failure with Tomcat 9

### DIFF
--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -28,6 +28,19 @@
   notify:
     - Restart candlepin
 
+- name: Query Tomcat version from container image
+  ansible.builtin.command:
+    cmd: >-
+      podman run --rm --entrypoint rpm
+      {{ candlepin_container_image }}:{{ candlepin_container_tag }}
+      -q --queryformat '%{VERSION}' tomcat
+  register: _candlepin_tomcat_version
+  changed_when: false
+
+- name: Set Tomcat major version fact
+  ansible.builtin.set_fact:
+    candlepin_tomcat_major_version: "{{ _candlepin_tomcat_version.stdout.split('.')[0] | int }}"
+
 - name: Create Tomcat server.xml
   containers.podman.podman_secret:
     state: present

--- a/src/roles/candlepin/templates/server.xml.j2
+++ b/src/roles/candlepin/templates/server.xml.j2
@@ -1,7 +1,9 @@
 <Server port="8005" shutdown="SHUTDOWN">
 
+{% if candlepin_tomcat_major_version | int >= 10 %}
   <!-- OpenSSL library loader using FFM -->
   <Listener className="org.apache.catalina.core.OpenSSLLifecycleListener" />
+{% endif %}
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
@@ -16,7 +18,7 @@
 
   <Service name="Catalina">
 
-    <!-- SSL HTTP/1.1 Connector using OpenSSL via FFM -->
+    <!-- SSL HTTP/1.1 Connector -->
     <Connector port="{{ candlepin_ssl_port }}"
                address="{{ candlepin_hostname }}"
                protocol="org.apache.coyote.http11.Http11NioProtocol"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The candlepin service fails to start on deployments using the nightly candlepin container image. The failure occurs because `server.xml` references `org.apache.catalina.core.OpenSSLLifecycleListener`, which is a Tomcat 10.1+ class, but the current nightly candlepin image ships Tomcat 9.0.87.

#### What are the changes introduced in this pull request?

* Added tasks to query the Tomcat version from the container image at deploy time
* Made the OpenSSLLifecycleListener conditional on Tomcat major version >= 10
* Updated connector comment to be version-agnostic

#### How to test this pull request

Steps to reproduce:

* Deploy with the nightly candlepin image (which has Tomcat 9)
* Verify candlepin service starts successfully without errors
* Check that server.xml does not include OpenSSLLifecycleListener

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)