### PR TITLE
Move flavor default into playbook vars

### DIFF
--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -2,6 +2,10 @@
 - name: Deploy Foreman Development Environment
   hosts: "{{ target_host if target_host is defined and target_host != '' else 'quadlet' }}"
   become: true
+  vars:
+    flavor: katello
+    httpd_foreman_backend: "http://localhost:3000"
+    pulp_register_foreman_proxy: false
   vars_files:
     - "../../../src/vars/defaults.yml"
     - "../../../src/vars/flavors/{{ flavor }}.yml"
@@ -10,9 +14,6 @@
     - "../../../src/vars/database.yml"
     - "../../../src/vars/foreman.yml"
     - "../../../src/vars/base.yaml"
-  vars:
-    httpd_foreman_backend: "http://localhost:3000"
-    pulp_register_foreman_proxy: false
   pre_tasks:
     - name: Set development postgresql databases
       ansible.builtin.set_fact:

--- a/development/playbooks/remote-database/remote-database.yaml
+++ b/development/playbooks/remote-database/remote-database.yaml
@@ -3,16 +3,17 @@
   hosts:
     - database
   become: true
-  vars_files:
-    - "../../../src/vars/defaults.yml"
-    - "../../../src/vars/flavors/{{ flavor }}.yml"
-    - "../../../src/vars/database.yml"
   vars:
+    flavor: katello
     certificates_hostnames:
       - "{{ ansible_facts['fqdn'] }}"
     certificates_ca_password: "CHANGEME"
     postgresql_ssl_crt: "{{ certificates_ca_directory }}/certs/{{ ansible_facts['fqdn'] }}.crt"
     postgresql_ssl_key: "{{ certificates_ca_directory }}/private/{{ ansible_facts['fqdn'] }}.key"
+  vars_files:
+    - "../../../src/vars/defaults.yml"
+    - "../../../src/vars/flavors/{{ flavor }}.yml"
+    - "../../../src/vars/database.yml"
   roles:
     - role: pre_install
     - role: certificates

--- a/src/playbooks/backup/backup.yaml
+++ b/src/playbooks/backup/backup.yaml
@@ -3,6 +3,8 @@
   hosts: "{{ target_host | default('quadlet') }}"
   become: true
   gather_facts: true
+  vars:
+    flavor: katello
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"

--- a/src/playbooks/checks/checks.yaml
+++ b/src/playbooks/checks/checks.yaml
@@ -2,6 +2,8 @@
 - name: Run preflight checks
   hosts: quadlet
   gather_facts: true
+  vars:
+    flavor: katello
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"

--- a/src/playbooks/deploy-proxy/deploy-proxy.yaml
+++ b/src/playbooks/deploy-proxy/deploy-proxy.yaml
@@ -3,6 +3,8 @@
   hosts:
     - proxy
   become: true
+  vars:
+    flavor: foreman-proxy-content
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -3,6 +3,8 @@
   hosts:
     - quadlet
   become: true
+  vars:
+    flavor: katello
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"

--- a/src/playbooks/features/features.yaml
+++ b/src/playbooks/features/features.yaml
@@ -5,6 +5,7 @@
   tags:
     - foremanctl_suppress_default_output
   vars:
+    flavor: katello
     list_enabled: false
   vars_files:
     - "../../vars/defaults.yml"

--- a/src/playbooks/health/health.yaml
+++ b/src/playbooks/health/health.yaml
@@ -3,6 +3,8 @@
   hosts: quadlet
   become: true
   gather_facts: true
+  vars:
+    flavor: katello
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"

--- a/src/playbooks/pull-images/pull-images.yaml
+++ b/src/playbooks/pull-images/pull-images.yaml
@@ -2,6 +2,8 @@
 - name: Pull images
   hosts:
     - quadlet
+  vars:
+    flavor: katello
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"

--- a/src/vars/defaults.yml
+++ b/src/vars/defaults.yml
@@ -2,6 +2,5 @@
 certificates_source: default
 database_mode: internal
 tuning: default
-flavor: katello
 features: []
 enabled_features: "{{ (flavor_features + features) }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The `flavor` variable was defined as a global default (`katello`) in `defaults.yml`. This works when all playbooks target quadlet, but breaks with per-host state partitioning where `deploy-proxy` uses a different flavor (`foreman-proxy-content`). Having a single global default obscures which flavor each playbook actually requires and makes it easy for new playbooks to silently depend on a default that may not apply.

#### What are the changes introduced in this pull request?

* Remove `flavor: katello` from `src/vars/defaults.yml`
* Set `flavor` explicitly in the `vars:` block of every playbook that loads `flavors/{{ flavor }}.yml`:
  - `deploy.yaml` — `katello`
  - `deploy-proxy.yaml` — `foreman-proxy-content`
  - `checks.yaml`, `health.yaml`, `backup.yaml`, `pull-images.yaml`, `features.yaml` — `katello`
  - `deploy-dev.yaml`, `remote-database.yaml` — `katello`

#### How to test this pull request

Steps to reproduce:

* Run `./foremanctl deploy --initial-admin-password=changeme --tuning development` and verify deployment succeeds
* Run `./foremanctl checks`, `./foremanctl health`, `./foremanctl features` and verify no undefined variable errors
* Run `./forge deploy-dev` and verify no undefined variable errors
* Run the full CI test suite

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)