### PR TITLE
Send httpd vhost logs to journald via systemd-cat

### DIFF
--- a/src/roles/httpd/README.md
+++ b/src/roles/httpd/README.md
@@ -1,0 +1,32 @@
+httpd Role
+==========
+
+Deploys Apache httpd as the reverse proxy for Foreman and Pulp.
+
+Journal logging
+---------------
+
+Apache access and error logs are sent to journald via `systemd-cat`.
+Each vhost uses its own syslog identifier (filter with `journalctl -t`).
+
+| Identifier | VHost | Log type | Typical content |
+|------------|-------|----------|-------------------|
+| `httpd-access` | HTTP (80) | Access | All requests, including 404 responses |
+| `httpd-error` | HTTP (80) | Error | Server/proxy errors (backend unreachable, malformed requests) |
+| `httpd-ssl-access` | HTTPS (443) | Access | All requests, including 404 responses |
+| `httpd-ssl-error` | HTTPS (443) | Error | Server/proxy errors |
+
+Pulp-only or mirror deployments use `pulpcore-ssl-access`, `pulpcore-ssl-error`,
+`mirror-access`, and `mirror-error` instead.
+
+Examples:
+
+```bash
+# Access log (404s, normal traffic)
+journalctl -t httpd-ssl-access --since "10 min ago"
+journalctl -t httpd-access | grep "/pub/"
+
+# Error log (proxy failures, malformed requests)
+journalctl -t httpd-ssl-error --since "1 hour ago"
+```
+

--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -5,9 +5,9 @@
   IncludeOptional "/etc/httpd/conf.d/05-foreman-ssl.d/*.conf"
 
   ## Logging
-  ErrorLog "/var/log/httpd/{{ 'foreman-ssl_error_ssl' if httpd_with_foreman else 'pulpcore_error' }}.log"
+  ErrorLog "|/usr/bin/systemd-cat -t {{ 'httpd-ssl-error' if httpd_with_foreman else 'pulpcore-ssl-error' }} -p err"
   ServerSignature Off
-  CustomLog "/var/log/httpd/{{ 'foreman-ssl_access_ssl' if httpd_with_foreman else 'pulpcore_access' }}.log" combined
+  CustomLog "|/usr/bin/systemd-cat -t {{ 'httpd-ssl-access' if httpd_with_foreman else 'pulpcore-ssl-access' }}" combined
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader

--- a/src/roles/httpd/templates/foreman-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-vhost.conf.j2
@@ -5,9 +5,9 @@
   IncludeOptional "/etc/httpd/conf.d/05-foreman.d/*.conf"
 
   ## Logging
-  ErrorLog "/var/log/httpd/{{ 'foreman_error' if httpd_with_foreman else 'mirror_error' }}.log"
+  ErrorLog "|/usr/bin/systemd-cat -t {{ 'httpd-error' if httpd_with_foreman else 'mirror-error' }} -p err"
   ServerSignature Off
-  CustomLog "/var/log/httpd/{{ 'foreman_access' if httpd_with_foreman else 'mirror_access' }}.log" combined
+  CustomLog "|/usr/bin/systemd-cat -t {{ 'httpd-access' if httpd_with_foreman else 'mirror-access' }}" combined
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -147,6 +147,42 @@ def test_httpd_headers_use_dashes(server):
     assert cmd.stdout.strip() == '', f"HTTP header names should use dashes, not underscores:\n{cmd.stdout}"
 
 
+@pytest.mark.feature('foreman')
+def test_httpd_vhost_custom_logs_in_journal(server, server_fqdn, curl_request):
+    http_marker = 'httpd-journal-http-access-test'
+    ssl_marker = 'httpd-journal-ssl-access-test'
+
+    server.run(f"{CURL_CMD} http://{server_fqdn}/{http_marker}")
+    curl_request(ssl_marker)
+
+    http_access = server.run("journalctl -t httpd-access --since '2 min ago' --no-pager").stdout
+    ssl_access = server.run("journalctl -t httpd-ssl-access --since '2 min ago' --no-pager").stdout
+
+    assert http_marker in http_access
+    assert http_marker not in ssl_access
+    assert ssl_marker in ssl_access
+    assert ssl_marker not in http_access
+
+
+@pytest.mark.feature('foreman')
+def test_httpd_vhost_error_logs_in_journal(server):
+    server.run(
+        "printf 'GET /http-error-test HTTP/1.0\\r\\n\\r\\n' | nc -w 2 127.0.0.1 80 >/dev/null 2>&1 || true"
+    )
+    server.run(
+        "(echo -e 'GET /ssl-error-test HTTP/1.0\\r\\n\\r\\n'; sleep 1) | "
+        "openssl s_client -connect 127.0.0.1:443 -quiet >/dev/null 2>&1 || true"
+    )
+
+    http_error = server.run("journalctl -t httpd-error --since '2 min ago' --no-pager").stdout
+    ssl_error = server.run("journalctl -t httpd-ssl-error --since '2 min ago' --no-pager").stdout
+
+    assert 'http-error-test' in http_error
+    assert 'http-error-test' not in ssl_error
+    assert 'ssl-error-test' in ssl_error
+    assert 'ssl-error-test' not in http_error
+
+
 def test_httpd_foreman_target_config(server):
     drop_in = server.file("/etc/systemd/system/httpd.service.d/foreman-target.conf")
     assert drop_in.exists


### PR DESCRIPTION
## Why are you introducing these changes?

foremanctl deploys httpd as a host service, but the Foreman vhosts currently write access and error logs to files under `/var/log/httpd/`. This does not align with the containerized logging model, where logs should be written to `stdout`/`stderr` and collected by `journald`.

On EL9, logging directly to `/dev/stdout` was unreliable under systemd. Using `systemd-cat` with dedicated journal tags provides reliable integration with `journald`.



---

## What are the changes introduced in this pull request?

- Update `foreman-vhost.conf.j2` and `foreman-ssl-vhost.conf.j2` to pipe access and error logs through `systemd-cat` instead of writing to `/var/log/httpd/`.
- Add integration tests to verify:
  - vhost configuration uses `systemd-cat`
  - HTTPS access logs are written to the system journal

---

## How to test this pull request

1. Deploy foremanctl from this branch.
2. Verify the generated Apache configuration uses `systemd-cat`:
   ```bash
   grep -E 'ErrorLog|CustomLog' /etc/httpd/conf.d/foreman-ssl.conf
   ```
3. Generate an HTTPS request:
   ```bash
   curl -sk https://localhost/api/v2/ping
   ```
4. Confirm the request appears in the journal:
   ```bash
   sudo journalctl -t httpd-ssl-access --since "1 min ago" --no-pager
   ```
5. Verify the old log files under `/var/log/httpd/` are no longer being updated.
6. Run the new integration tests.

---

## Checklist

- [x] Tests added/updated
