### PR TITLE
Route Candlepin logs to journald via stdout

### DIFF
--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -2,17 +2,6 @@
 - name: Deploy candlepin image
   ansible.builtin.include_tasks: image.yaml
 
-- name: Create log directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  loop:
-    - /var/log/candlepin
-    - /var/log/tomcat
-
 - name: Configure certificates
   ansible.builtin.include_tasks:
     file: certs.yml
@@ -50,6 +39,28 @@
   notify:
     - Restart candlepin
 
+- name: Create Candlepin logback configuration
+  containers.podman.podman_secret:
+    state: present
+    name: candlepin-logback-xml
+    data: "{{ lookup('ansible.builtin.template', 'logback.xml') }}"
+    labels:
+      filename: logback.xml
+      app: candlepin
+  notify:
+    - Restart candlepin
+
+- name: Create Tomcat logging configuration
+  containers.podman.podman_secret:
+    state: present
+    name: candlepin-tomcat-logging-properties
+    data: "{{ lookup('ansible.builtin.template', 'logging.properties') }}"
+    labels:
+      filename: logging.properties
+      app: tomcat
+  notify:
+    - Restart candlepin
+
 - name: Create DB SSL cert
   containers.podman.podman_secret:
     state: present
@@ -73,10 +84,9 @@
       - 'candlepin-candlepin-conf,target=/etc/candlepin/candlepin.conf,mode=0440,type=mount'
       - 'candlepin-tomcat-server-xml,target=/etc/tomcat/server.xml,mode=0440,type=mount'
       - 'candlepin-tomcat-conf,target=/etc/tomcat/tomcat.conf,mode=0440,type=mount'
+      - 'candlepin-tomcat-logging-properties,target=/etc/tomcat/logging.properties,mode=0440,type=mount'
+      - 'candlepin-logback-xml,target=/var/lib/tomcat/webapps/candlepin/WEB-INF/classes/logback.xml,mode=0440,type=mount'
       - 'candlepin-db-ca,target={{ candlepin_database_ssl_ca_path }},mode=0440,type=mount'
-    volumes:
-      - /var/log/candlepin:/var/log/candlepin:rw,Z
-      - /var/log/tomcat:/var/log/tomcat:rw,Z
     quadlet_options:
       - |
         [Install]

--- a/src/roles/candlepin/templates/logback.xml
+++ b/src/roles/candlepin/templates/logback.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Container logging configuration from upstream Candlepin:
+  https://github.com/candlepin/candlepin/blob/master/containers/logback.xml
+-->
+<configuration>
+    <contextName>candlepin</contextName>
+
+    <turboFilter class="org.candlepin.logging.LoggerAndMDCFilter">
+        <key>logLevel</key>
+        <topLogger>org.candlepin</topLogger>
+        <OnMatch>ACCEPT</OnMatch>
+    </turboFilter>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [thread=%thread] [%X{requestType}=%X{requestUuid}, %replace(job_key=%X{jobKey}, ){'job_key=, ', ''}org=%X{org}, csid=%X{csid}] %-5p %c - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT"/>
+    </appender>
+
+    <appender name="AUDITLOG" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} %m</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC-AUDITLOG" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="AUDITLOG"/>
+    </appender>
+
+    <logger name="org.candlepin" level="INFO"/>
+    <logger name="org.candlepin.audit.LoggingListener.AuditLog" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC-AUDITLOG"/>
+    </logger>
+
+    <!-- Silence the hibernate deprecation warnings -->
+    <logger name="org.hibernate.orm.deprecation" level="DEBUG" additivity="false"/>
+
+    <root level="WARN">
+        <appender-ref ref="ASYNC"/>
+    </root>
+</configuration>

--- a/src/roles/candlepin/templates/logging.properties
+++ b/src/roles/candlepin/templates/logging.properties
@@ -1,0 +1,20 @@
+
+handlers = java.util.logging.ConsoleHandler
+
+.handlers = java.util.logging.ConsoleHandler
+
+
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+java.util.logging.ConsoleHandler.encoding = UTF-8
+
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = java.util.logging.ConsoleHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = java.util.logging.ConsoleHandler
+

--- a/src/roles/candlepin/templates/server.xml.j2
+++ b/src/roles/candlepin/templates/server.xml.j2
@@ -38,6 +38,13 @@
 
       <Host name="localhost" appBase="webapps"
             unpackWARs="true" autoDeploy="true">
+
+        <Valve className="org.apache.catalina.valves.AccessLogValve"
+               directory="/proc/self/fd"
+               prefix="1"
+               suffix=""
+               rotatable="false"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
       </Host>
     </Engine>
   </Service>

--- a/tests/candlepin_test.py
+++ b/tests/candlepin_test.py
@@ -25,6 +25,28 @@ def test_candlepin_status(server, certificates):
     assert status.stdout == '200'
 
 
+def test_candlepin_logs_in_journal(server, certificates):
+    server.run(
+        f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null "
+        f"https://localhost:23443/candlepin/status"
+    )
+
+    journal = server.run("journalctl -u candlepin --since '2 min ago' --no-pager").stdout
+    assert 'candlepin/status' in journal
+    assert 'LoggingFilter' in journal
+
+
+def test_candlepin_tomcat_logs_in_journal(server, certificates):
+    server.run(
+        f"curl --cacert {certificates['ca_certificate']} --silent --output /dev/null "
+        f"https://localhost:23443/candlepin/status"
+    )
+
+    journal = server.run("journalctl -u candlepin --no-pager").stdout
+    assert '"GET /candlepin/status HTTP/1.1"' in journal
+    assert 'org.apache.catalina' in journal
+
+
 def test_tls(server):
     result = server.run('nmap --script +ssl-enum-ciphers localhost -p 23443')
     result = result.stdout


### PR DESCRIPTION
## Why are you introducing these changes?

Candlepin runs as a Podman container but currently writes application and Tomcat logs to host-mounted directories under `/var/log/candlepin` and `/var/log/tomcat`. This does not align with the containerized logging model, where services should log to `stdout`/`stderr` and rely on `journald`.

This change switches Candlepin, Tomcat, and HTTP access logging to stdout so all logs are collected by `journald`.

Related: Logging audit for journal-only deployments.

---

## What are the changes introduced in this pull request?

- Add `logback.xml` template using `ConsoleAppender` for Candlepin application logs.
- Add `logging.properties` template using `ConsoleHandler` for Tomcat internal logs.
- Mount both configuration files as Podman secrets.
- Remove host log volume mounts (`/var/log/candlepin` and `/var/log/tomcat`) and the task creating those directories.
- Add a Tomcat `AccessLogValve` to write HTTP access logs to stdout.
- Add integration tests to verify:
  - Candlepin logs are written to the journal.
  - Log volume mounts are no longer present.

---

## How to test this pull request

1. Deploy foremanctl from this branch.
2. Verify Candlepin is running:
   ```bash
   curl -sk https://localhost:23443/candlepin/status
   systemctl is-active candlepin
   ```
3. Generate a request and verify logs appear in the journal:
   ```bash
   curl -sk https://localhost:23443/candlepin/status
   sudo journalctl -u candlepin --since "1 min ago" --no-pager
   ```
4. Confirm the container no longer mounts `/var/log/candlepin` or `/var/log/tomcat`:
   ```bash
   sudo podman inspect candlepin --format '{{range .Mounts}}{{.Destination}} {{end}}'
   ```
5. Verify the old log files are no longer updated.
6. Run the new integration tests.

---

## Checklist

- [x] Tests added/updated
