### PR TITLE
Enforce has_feature filter for enabled_features checks

### DIFF
--- a/.ansible-lint-rules/use_has_feature_filter.py
+++ b/.ansible-lint-rules/use_has_feature_filter.py
@@ -1,0 +1,93 @@
+"""Implementation of use-has-feature-filter rule."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.utils import parse_yaml_from_file
+
+if TYPE_CHECKING:
+    from ansiblelint.errors import MatchError
+    from ansiblelint.file_utils import Lintable
+
+_ANTI_PATTERN = "in enabled_features"
+
+
+def _check_when(when: Any) -> str | None:
+    """Return the offending condition string, or None."""
+    if isinstance(when, str):
+        when = [when]
+    if not isinstance(when, list):
+        return None
+    for condition in when:
+        if isinstance(condition, str) and _ANTI_PATTERN in condition and "has_feature" not in condition:
+            return condition
+    return None
+
+
+class UseHasFeatureFilterRule(AnsibleLintRule):
+    """Use the has_feature filter instead of 'in enabled_features' checks."""
+
+    id = "use-has-feature-filter"
+    description = (
+        "Feature checks must use the has_feature filter "
+        "(e.g. enabled_features | has_feature('x')) "
+        "instead of raw 'in enabled_features' tests, "
+        "which bypass prefix and transitive-dependency matching."
+    )
+    severity = "HIGH"
+    tags = ["idiom"]
+    version_added = "custom"
+
+    def matchtask(self, task: dict[str, Any], file: Lintable | None = None) -> bool | str:
+        """Flag task-level when clauses that use 'in enabled_features'."""
+        condition = _check_when(task.get("when"))
+        if condition:
+            return f"Use 'enabled_features | has_feature(...)' instead of '{condition}'"
+        return False
+
+    def matchplay(self, file: Lintable, data: dict[str, Any]) -> list[MatchError]:
+        """Flag role-level when clauses that use 'in enabled_features'."""
+        results: list[MatchError] = []
+
+        for role_entry in data.get("roles", []):
+            if not isinstance(role_entry, dict):
+                continue
+            condition = _check_when(role_entry.get("when"))
+            if condition:
+                results.append(
+                    self.create_matcherror(
+                        message=f"Use 'enabled_features | has_feature(...)' instead of '{condition}'",
+                        filename=file,
+                        tag="use-has-feature-filter",
+                    ),
+                )
+
+        return results
+
+    def matchyaml(self, file: Lintable) -> list[MatchError]:
+        """Flag variable values that use 'in enabled_features'."""
+        results: list[MatchError] = super().matchyaml(file)
+
+        if str(file.kind) != "vars" or not file.data:
+            return results
+
+        meta_data = parse_yaml_from_file(str(file.path))
+        if not isinstance(meta_data, dict):
+            return results
+
+        for key, value in meta_data.items():
+            if not isinstance(value, str):
+                continue
+            if _ANTI_PATTERN in value and "has_feature" not in value:
+                results.append(
+                    self.create_matcherror(
+                        message=f"Variable '{key}' uses 'in enabled_features'. Use the has_feature filter instead.",
+                        filename=file,
+                        tag="use-has-feature-filter",
+                        data=key,
+                    ),
+                )
+
+        return results

--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -30,7 +30,7 @@
 
     - name: Setup iop requirements
       when:
-        - "'iop' in enabled_features"
+        - "enabled_features | has_feature('iop')"
       block:
         - name: Enable foreman_rh_cloud plugin for iop
           ansible.builtin.set_fact:
@@ -54,7 +54,7 @@
         foreman_development_candlepin_oauth_secret: "{{ candlepin_oauth_secret }}"
     - role: iop_core
       when:
-        - "'iop' in enabled_features"
+        - "enabled_features | has_feature('iop')"
       vars:
         iop_core_foreman_oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
         iop_core_foreman_oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"

--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -252,9 +252,9 @@
 - name: Configure smart-proxy for development
   ansible.builtin.include_tasks: smart-proxy/main.yml
   when:
-    - "'foreman-proxy' in enabled_features"
+    - "enabled_features | has_feature('foreman-proxy')"
 
 - name: Configure hammer for development
   ansible.builtin.include_tasks: hammer/main.yml
   when:
-    - "'hammer' in enabled_features"
+    - "enabled_features | has_feature('hammer')"

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -34,14 +34,14 @@
     - role: systemd_target
     - role: iop_core
       when:
-        - "'iop' in enabled_features"
+        - "enabled_features | has_feature('iop')"
         - database_mode == 'internal'
     - role: foreman_proxy
       when:
-        - "'foreman-proxy' in enabled_features"
+        - "enabled_features | has_feature('foreman-proxy')"
     - role: hammer
       when:
-        - "'hammer' in enabled_features"
+        - "enabled_features | has_feature('hammer')"
     - role: post_install
       vars:
         post_install_foreman_ca_path: "{{ foreman_ca_certificate }}"

--- a/src/roles/httpd/defaults/main.yml
+++ b/src/roles/httpd/defaults/main.yml
@@ -21,6 +21,6 @@ httpd_ipa_keytab: /etc/httpd/conf/http.keytab
 httpd_ipa_pam_service: "{{ external_authentication_pam_service | default('foreman') }}"
 httpd_ipa_gssapi_local_name: true
 
-httpd_with_foreman: "{{ 'foreman' in enabled_features }}"
+httpd_with_foreman: "{{ enabled_features | has_feature('foreman') }}"
 httpd_with_pulpcore: "{{ not httpd_with_foreman and not httpd_with_pulp_mirror }}"
 httpd_with_pulp_mirror: "{{ pulp_mirror | default(false) }}"

--- a/tests/ansible_lint/test_use_has_feature_filter.py
+++ b/tests/ansible_lint/test_use_has_feature_filter.py
@@ -1,0 +1,33 @@
+"""Tests for use-has-feature-filter rule."""
+
+import pytest
+
+RULE_ID = "use-has-feature-filter"
+
+
+@pytest.mark.parametrize("ansible_lint_runner", [("tests/fixtures/ansible-lint/roles/test_has_feature_filter", RULE_ID)], indirect=True)
+def test_raw_in_check_flagged(ansible_lint_runner) -> None:
+    """Task when clauses using 'in enabled_features' produce match errors."""
+    assert len(ansible_lint_runner) == 3
+    for result in ansible_lint_runner:
+        assert result.rule.id == RULE_ID
+
+
+@pytest.mark.parametrize("ansible_lint_runner", [("tests/fixtures/ansible-lint/roles/test_has_feature_filter_pass", RULE_ID)], indirect=True)
+def test_has_feature_filter_passes(ansible_lint_runner) -> None:
+    """Tasks using has_feature filter do not produce errors."""
+    assert len(ansible_lint_runner) == 0
+
+
+@pytest.mark.parametrize("ansible_lint_runner", [("tests/fixtures/ansible-lint/playbooks/test_has_feature_filter_roles.yml", RULE_ID)], indirect=True)
+def test_role_level_when_flagged(ansible_lint_runner) -> None:
+    """Role-level when clauses using 'in enabled_features' produce match errors."""
+    assert len(ansible_lint_runner) == 2
+    for result in ansible_lint_runner:
+        assert result.rule.id == RULE_ID
+
+
+@pytest.mark.parametrize("ansible_lint_runner", [("tests/fixtures/ansible-lint/playbooks/test_has_feature_filter_roles_pass.yml", RULE_ID)], indirect=True)
+def test_role_level_has_feature_passes(ansible_lint_runner) -> None:
+    """Role-level when clauses using has_feature filter do not produce errors."""
+    assert len(ansible_lint_runner) == 0

--- a/tests/fixtures/ansible-lint/playbooks/test_has_feature_filter_roles.yml
+++ b/tests/fixtures/ansible-lint/playbooks/test_has_feature_filter_roles.yml
@@ -1,0 +1,11 @@
+---
+# Should be flagged (raw 'in enabled_features' in role-level when)
+- name: Test play with role-level feature checks
+  hosts: all
+  roles:
+    - role: some_role
+      when:
+        - "'iop' in enabled_features"
+    - role: another_role
+      when:
+        - "'foreman-proxy' in enabled_features"

--- a/tests/fixtures/ansible-lint/playbooks/test_has_feature_filter_roles_pass.yml
+++ b/tests/fixtures/ansible-lint/playbooks/test_has_feature_filter_roles_pass.yml
@@ -1,0 +1,11 @@
+---
+# Should NOT be flagged (uses has_feature filter)
+- name: Test play with correct role-level feature checks
+  hosts: all
+  roles:
+    - role: some_role
+      when:
+        - "enabled_features | has_feature('iop')"
+    - role: another_role
+      when:
+        - "enabled_features | has_feature('foreman-proxy')"

--- a/tests/fixtures/ansible-lint/roles/test_has_feature_filter/defaults/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_has_feature_filter/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Should be flagged (raw 'in enabled_features' in variable value)
+test_has_feature_with_foreman: "{{ 'foreman' in enabled_features }}"
+# Should NOT be flagged (uses has_feature)
+test_has_feature_with_pulp: "{{ enabled_features | has_feature('pulp') }}"

--- a/tests/fixtures/ansible-lint/roles/test_has_feature_filter/tasks/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_has_feature_filter/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# Should be flagged (raw 'in enabled_features')
+- name: Task with raw in check
+  ansible.builtin.debug:
+    msg: "checking feature"
+  when: "'iop' in enabled_features"
+
+- name: Task with raw not-in check
+  ansible.builtin.debug:
+    msg: "checking feature"
+  when: "'hammer' not in enabled_features"

--- a/tests/fixtures/ansible-lint/roles/test_has_feature_filter_pass/defaults/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_has_feature_filter_pass/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+test_has_feature_pass_with_foreman: "{{ enabled_features | has_feature('foreman') }}"
+test_has_feature_pass_unrelated: "some_value"

--- a/tests/fixtures/ansible-lint/roles/test_has_feature_filter_pass/tasks/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_has_feature_filter_pass/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# Should NOT be flagged (uses has_feature filter)
+- name: Task with has_feature filter
+  ansible.builtin.debug:
+    msg: "checking feature"
+  when: enabled_features | has_feature('iop')
+
+- name: Task with has_feature in list
+  ansible.builtin.debug:
+    msg: "checking feature"
+  when:
+    - enabled_features | has_feature('katello')
+    - database_mode == 'internal'
+
+- name: Task without feature check
+  ansible.builtin.debug:
+    msg: "no feature check here"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The `has_feature` Jinja2 filter handles feature membership correctly via exact match, prefix match (e.g. `content/deb` matching `content`), and transitive dependency resolution. Several places in the codebase were using raw `'x' in enabled_features` checks instead, which bypasses prefix and dependency logic.

#### What are the changes introduced in this pull request?

* Replace all 8 instances of `'x' in enabled_features` with `enabled_features | has_feature('x')` across `src/` and `development/`
* Add a custom ansible-lint rule (`use-has-feature-filter`) to prevent regressions, checking task-level `when` clauses, role-level `when` clauses, and variable values

#### How to test this pull request

Steps to reproduce:

* Run `cd src && ansible-lint` - should pass
* Run `cd development && ansible-lint` - should pass
* Temporarily revert a fix (e.g. change `has_feature('iop')` back to `'iop' in enabled_features` in `src/playbooks/deploy/deploy.yaml`) and verify the rule flags it

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
