### PR TITLE
Switch to openvox repositories

### DIFF
--- a/development/playbooks/setup-repositories/setup-repositories.yaml
+++ b/development/playbooks/setup-repositories/setup-repositories.yaml
@@ -6,9 +6,9 @@
   tasks:
     - name: Setup Puppet repositories
       ansible.builtin.include_role:
-        name: theforeman.operations.puppet_repositories
+        name: theforeman.operations.openvox_repositories
       vars:
-        foreman_puppet_repositories_version: "8"
+        foreman_openvox_repositories_version: "8"
       when:
         - ansible_distribution_major_version == '9'
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The puppet repositories do not get updates anymore, and our community is switching to openvox as the default.

#### What are the changes introduced in this pull request?

* Switches from the puppet repositories to openvox

