### PR TITLE
Add satellite flavor for downstream deployments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -465,6 +465,76 @@ jobs:
           limit-access-to-actor: true
           wait-timeout-minutes: 5
 
+  satellite-tests:
+    runs-on: ubuntu-24.04
+    name: "Tests Satellite Deployment"
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: Setup libvirt for Vagrant
+        uses: voxpupuli/setup-vagrant@v0
+        with:
+          configure_dns: true
+      - name: Install Ansible
+        run: pip install --upgrade ansible-core
+      - name: Setup environment
+        run: ./setup-environment
+      - name: Start VMs
+        run: |
+          ./forge vms start --vms "quadlet client"
+      - name: Configure repositories
+        run: |
+          ./forge setup-repositories
+      - name: Run image pull
+        run: |
+          ./foremanctl pull-images
+      - name: Run deployment
+        run: |
+          ./foremanctl deploy \
+            --flavor satellite \
+            --initial-admin-password=changeme \
+            --initial-organization "Foreman CI" \
+            --initial-location "Internet" \
+            --tuning development
+      - name: Deploy features
+        run: |
+          ./foremanctl deploy \
+            --add-feature hammer \
+            --add-feature foreman-proxy \
+            --add-feature azure-rm \
+            --add-feature google \
+            --add-feature bmc
+      - name: Run tests
+        run: |
+          ./forge test
+      - name: Run smoker
+        run: |
+          ./forge smoker
+      - name: Archive smoker report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoker-satellite
+          path: "/home/runner/smoker/report/"
+      - name: Generate sos reports
+        if: ${{ always() }}
+        run: ./forge sos
+      - name: Archive sos reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: sosreport-satellite
+          path: sos/
+      - name: Setup upterm session
+        if: ${{ failure() }}
+        uses: owenthereal/action-upterm@v1
+        with:
+          limit-access-to-actor: true
+          wait-timeout-minutes: 5
+
   # A dummy job that you can mark as a required check instead of each individual test
   test-suite:
     if: always()
@@ -474,6 +544,7 @@ jobs:
       - upgrade
       - migration
       - foreman-proxy-content-tests
+      - satellite-tests
       - ansible-lint
       - python-lint
     runs-on: ubuntu-latest

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -92,5 +92,6 @@ registration:
     - templates
 theme-satellite:
   description: Satellite theme for Foreman
+  internal: true
   foreman:
     plugin_name: foreman_theme_satellite

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -90,3 +90,7 @@ registration:
     plugin_name: registration
   dependencies:
     - templates
+theme-satellite:
+  description: Satellite theme for Foreman
+  foreman:
+    plugin_name: foreman_theme_satellite

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -7,6 +7,7 @@ variables:
     help: Base flavor to use in this deployment.
     choices:
       - katello
+      - satellite
   external_authentication:
     help: External authentication method to use
     choices:

--- a/src/roles/post_install/tasks/message.yaml
+++ b/src/roles/post_install/tasks/message.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Post install message
-  when: flavor in ['katello']
+  when: flavor in ['katello', 'satellite']
   ansible.builtin.debug:
     msg:
       - "{{ _post_install_url_msg }}"

--- a/src/vars/flavors/satellite.yml
+++ b/src/vars/flavors/satellite.yml
@@ -10,3 +10,20 @@ flavor_features:
   - remote-execution
   - rh-cloud
   - theme-satellite
+  - webhooks
+
+checks_to_execute:
+  - check_features
+  - check_hostname
+  - check_database_connection
+  - check_system_requirements
+  - check_podman_network_backend
+
+health_checks_to_execute:
+  - check_hostname
+  - check_database_connection
+  - check_services
+  - check_foreman_api
+  - check_foreman_tasks
+  - check_host_facts_count
+  - check_duplicate_permissions

--- a/src/vars/flavors/satellite.yml
+++ b/src/vars/flavors/satellite.yml
@@ -1,0 +1,12 @@
+---
+flavor_features:
+  - foreman
+  - katello
+  - content/ansible
+  - content/container
+  - content/deb
+  - content/python
+  - content/rpm
+  - remote-execution
+  - rh-cloud
+  - theme-satellite

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -18,8 +18,8 @@ def expected_databases(enabled_features, flavor):
     """
     databases = []
 
-    # Katello flavor has foreman, candlepin, and pulp
-    if flavor == 'katello':
+    # Katello and Satellite flavors have foreman, candlepin, and pulp
+    if flavor in ('katello', 'satellite'):
         databases = ['foreman', 'candlepin', 'pulp']
 
     # Foreman-proxy-content flavor only has pulp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,16 +284,25 @@ def pytest_configure(config):
     config.user_parameters = UserParameters(config)
 
 
+FLAVOR_TEST_DIRS = {
+    'katello': ['katello', 'satellite'],
+    'foreman-proxy-content': ['foreman-proxy-content', 'capsule'],
+}
+
+
 def pytest_collection_modifyitems(config, items):
     active_flavor = config.user_parameters.flavor
-    active_flavor_dir = FLAVOR_TESTS_DIR / active_flavor
+    allowed_dirs = set()
+    for test_dir, flavors in FLAVOR_TEST_DIRS.items():
+        if active_flavor in flavors:
+            allowed_dirs.add(test_dir)
 
     deselected = []
     selected = []
     for item in items:
         test_path = py.path.local(item.fspath)
         if test_path.relto(FLAVOR_TESTS_DIR):
-            if not test_path.relto(active_flavor_dir):
+            if not any(test_path.relto(FLAVOR_TESTS_DIR / d) for d in allowed_dirs):
                 deselected.append(item)
                 continue
         selected.append(item)


### PR DESCRIPTION
## Summary
- Adds a `satellite` flavor (`src/vars/flavors/satellite.yml`) with the feature set for Satellite deployments
- Enables: foreman, katello, content/{ansible,container,deb,python,rpm}, remote-execution, rh-cloud, theme-satellite, webhooks
- Compared to `katello` flavor: adds features that Satellite ships by default (remote-execution, rh-cloud, theme-satellite, webhooks)

## Details

The `theme-satellite` feature requires a corresponding entry in `features.yaml` (or `features.d/`) to take effect. Without one, it is silently ignored. It is marked as `internal` so users cannot enable it manually.

Usage:
```bash
foremanctl deploy --flavor satellite --initial-admin-password=changeme
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)