### PR TITLE
Downgrade openssl on CentOS Stream 9 VMs in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,12 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start --vms "quadlet client ${{ matrix.database == 'external' && 'database' || '' }}"
+      - name: Downgrade openssl
+        if: matrix.box == 'centos/stream9'
+        run: |
+          for vm in quadlet client ${{ matrix.database == 'external' && 'database' || '' }}; do
+            vagrant ssh "$vm" -- sudo dnf downgrade -y openssl openssl-libs
+          done
       - name: Configure remote-database
         if: matrix.database == 'external'
         run: |
@@ -202,6 +208,9 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start
+      - name: Downgrade openssl
+        run: |
+          vagrant ssh quadlet -- sudo dnf downgrade -y openssl openssl-libs
       - name: Configure repositories
         run: |
           ./forge setup-repositories
@@ -242,6 +251,9 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start
+      - name: Downgrade openssl
+        run: |
+          vagrant ssh quadlet -- sudo dnf downgrade -y openssl openssl-libs
       - name: Configure repositories
         run: |
           ./forge setup-repositories
@@ -319,6 +331,11 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start --vms "quadlet client"
+      - name: Downgrade openssl
+        run: |
+          for vm in quadlet client; do
+            vagrant ssh "$vm" -- sudo dnf downgrade -y openssl openssl-libs
+          done
       - name: Configure repositories
         run: |
           ./forge setup-repositories
@@ -398,6 +415,11 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start --vms "quadlet proxy"
+      - name: Downgrade openssl
+        run: |
+          for vm in quadlet proxy; do
+            vagrant ssh "$vm" -- sudo dnf downgrade -y openssl openssl-libs
+          done
       - name: Run image pull
         run: |
           ./foremanctl pull-images


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

openssl is currently broken in CentOS Stream 9, causing CI failures. As a temporary workaround, downgrade openssl and openssl-libs on VMs after they are started.

#### What are the changes introduced in this pull request?

* Add a "Downgrade openssl" step after "Start VMs" in all CI test jobs (tests, devel-tests, upgrade, migration, foreman-proxy-content-tests)
* For the `tests` job, the step is conditional on `matrix.box == 'centos/stream9'` to skip it on CentOS Stream 10
* Other jobs default to CentOS Stream 9 so the step runs unconditionally

#### How to test this pull request

Steps to reproduce:

* Push the branch and observe CI passes with the openssl downgrade applied

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)