### PR TITLE
Add --target-host parameter for multi-host management

### DIFF
--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -7,6 +7,12 @@ This document covers installation parameters as presented to users, and includes
 * Using a single parameter when there are multiple variables that should have the same value
 * Aim for minimal configuration values for the user
 
+## Global Parameters
+
+| Parameter | Description | Applies to |
+| ----------| ----------- | ---------- |
+| `--target-host` | Target hostname or IP address for deployment. Defaults to `quadlet`. This value is persisted between runs. For remote hosts, the specified host must be present in the Ansible inventory. | All commands except `deploy-proxy` |
+
 ## Mapping
 
 Parameters are split into either mapped or unmapped groupings per category.

--- a/src/playbooks/_target_host/metadata.obsah.yaml
+++ b/src/playbooks/_target_host/metadata.obsah.yaml
@@ -1,0 +1,5 @@
+---
+variables:
+  target_host:
+    help: Target hostname or IP address for deployment
+    action: store

--- a/src/playbooks/backup/metadata.obsah.yaml
+++ b/src/playbooks/backup/metadata.obsah.yaml
@@ -23,3 +23,6 @@ variables:
     help: Wait for running tasks to complete instead of failing immediately
     action: store_true
     persist: false
+
+include:
+  - _target_host

--- a/src/playbooks/certificate-bundle/certificate-bundle.yaml
+++ b/src/playbooks/certificate-bundle/certificate-bundle.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Generate a certificate bundle for a hostname
-  hosts:
-    - quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   become: true
   vars_files:
     - "../../vars/base.yaml"

--- a/src/playbooks/certificate-bundle/metadata.obsah.yaml
+++ b/src/playbooks/certificate-bundle/metadata.obsah.yaml
@@ -31,4 +31,5 @@ constraints:
     - ['certificates_source', 'default', ['certificates_custom_server_certificate', 'certificates_custom_server_key']]
 
 include:
+  - _target_host
   - _certificate_source

--- a/src/playbooks/checks/checks.yaml
+++ b/src/playbooks/checks/checks.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Run preflight checks
-  hosts: quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   gather_facts: true
   vars:
     flavor: katello

--- a/src/playbooks/checks/metadata.obsah.yaml
+++ b/src/playbooks/checks/metadata.obsah.yaml
@@ -3,6 +3,7 @@ help: |
   Run preflight checks before installing Foreman
 
 include:
+  - _target_host
   - _database_mode
   - _database_connection
   - _tuning

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Setup machine
-  hosts:
-    - quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   become: true
   vars:
     flavor: katello

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -24,5 +24,6 @@ variables:
       - fatal
 
 include:
+  - _target_host
   - _flavor_features
   - _flavors/katello

--- a/src/playbooks/features/features.yaml
+++ b/src/playbooks/features/features.yaml
@@ -1,6 +1,6 @@
 ---
 - name: List features
-  hosts: quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   gather_facts: false
   tags:
     - foremanctl_suppress_default_output

--- a/src/playbooks/features/metadata.obsah.yaml
+++ b/src/playbooks/features/metadata.obsah.yaml
@@ -7,3 +7,6 @@ variables:
     help: List only enabled features
     action: store_true
     persist: false
+
+include:
+  - _target_host

--- a/src/playbooks/health/health.yaml
+++ b/src/playbooks/health/health.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Run Foreman health checks
-  hosts: quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   become: true
   gather_facts: true
   vars:

--- a/src/playbooks/health/metadata.obsah.yaml
+++ b/src/playbooks/health/metadata.obsah.yaml
@@ -11,4 +11,5 @@ variables:
     action: store_true
     persist: false
 include:
+  - _target_host
   - _database_mode

--- a/src/playbooks/migrate/metadata.obsah.yaml
+++ b/src/playbooks/migrate/metadata.obsah.yaml
@@ -27,3 +27,6 @@ variables:
   output:
     help: Path where the migrated configuration should be written. If not specified and --apply is used, writes to the foremanctl configuration.
     persist: false
+
+include:
+  - _target_host

--- a/src/playbooks/migrate/migrate.yaml
+++ b/src/playbooks/migrate/migrate.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Migrate from foreman-installer to foremanctl
-  hosts:
-    - quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   gather_facts: true
   become: true
   vars_files:

--- a/src/playbooks/pull-images/metadata.obsah.yaml
+++ b/src/playbooks/pull-images/metadata.obsah.yaml
@@ -3,5 +3,6 @@ help: |
   Pull necessary container images
 
 include:
+  - _target_host
   - _database_mode
   - _flavor_features

--- a/src/playbooks/pull-images/pull-images.yaml
+++ b/src/playbooks/pull-images/pull-images.yaml
@@ -1,9 +1,6 @@
 ---
 - name: Pull images
-  hosts:
-    - quadlet
-  vars:
-    flavor: katello
+  hosts: "{{ target_host | default('quadlet') }}"
   vars_files:
     - "../../vars/defaults.yml"
     - "../../vars/flavors/{{ flavor }}.yml"


### PR DESCRIPTION
## Summary

Adds a `--target-host` argument to all 8 production `foremanctl` commands (deploy, features, health, migrate, backup, pull-images, certificate-bundle, checks), allowing users to specify which host to run against instead of the hardcoded `quadlet` default.

This is a first step toward multi-host management — running commands against different targets such as external proxies or remote servers. Full multi-host workflows will additionally require per-host state isolation (#630), since today all commands share a single `parameters.yaml`.

The parameter defaults to `quadlet` when not specified, preserving existing behavior. The value is persisted between runs and can be cleared with `--reset-target-host`.

For remote hosts, the specified host must be present in the Ansible inventory.

## Changes

- New shared metadata fragment `_target_host` included by all 8 commands
- Playbook `hosts:` directives use `{{ target_host | default('quadlet') }}`
- Updated `docs/user/parameters.md` with a Global Parameters section

## Test plan

- [x] `foremanctl <command> --help` shows `--target-host` for all 8 commands
- [x] ansible-lint passes
- [x] All playbook tests pass