### PR TITLE
Set :logging: :type: stdout in settings.yaml so Foreman uses the cons…

### DIFF
--- a/src/roles/foreman/templates/settings.yaml.j2
+++ b/src/roles/foreman/templates/settings.yaml.j2
@@ -9,6 +9,9 @@
 
 :require_ssl: true
 
+:logging:
+  :type: stdout
+
 :rails_cache_store:
   :type: redis
   :urls:

--- a/tests/foreman_test.py
+++ b/tests/foreman_test.py
@@ -30,6 +30,15 @@ def test_foreman_service(server):
     assert foreman.is_running
 
 
+def test_foreman_no_production_log(server):
+    settings = server.run("podman exec foreman grep -A1 ':logging:' /etc/foreman/settings.yaml")
+    assert settings.succeeded
+    assert ':type: stdout' in settings.stdout
+
+    log_file = server.run("podman exec foreman test ! -f /var/log/foreman/production.log")
+    assert log_file.succeeded
+
+
 def test_foreman_port(server):
     foreman = server.addr(FOREMAN_HOST)
     assert foreman.port(FOREMAN_PORT).is_reachable


### PR DESCRIPTION
## Why are you introducing these changes?

Containerized Foreman already logs to **journald** via `RAILS_LOG_TO_STDOUT`, but it still creates a stale `/var/log/foreman/production.log` containing only early boot logs. Since this file is not the primary log destination, it can be misleading during logging audits and troubleshooting.

Setting `:logging: :type: stdout` in `settings.yaml` ensures Foreman uses the console appender from startup, preventing `production.log` from being created.


---

## What changes does this pull request introduce?

- Add `:logging: :type: stdout` to `src/roles/foreman/templates/settings.yaml.j2`
- Add `test_foreman_no_production_log` to verify:
  - `settings.yaml` contains the stdout setting.
  - `/var/log/foreman/production.log` is not created.

---

## How to test

Deploy:

```bash
source .venv/bin/activate
./forge vms start
./foremanctl deploy \
  --initial-admin-password=changeme \
  --initial-organization "Foreman CI" \
  --initial-location "Internet" \
  --tuning development
```

Verify the setting:

```bash
vagrant ssh quadlet
sudo podman exec foreman grep -A1 ':logging:' /etc/foreman/settings.yaml
```

Expected:

```yaml
:logging:
  :type: stdout
```

Verify `production.log` is absent:

```bash
sudo podman exec foreman test ! -f /var/log/foreman/production.log && echo OK
```

Confirm logs still reach journald:

```bash
curl --header 'X-FORWARDED-PROTO: https' -s http://localhost:3000/api/v2/ping
sudo journalctl -u foreman --since '1 min ago' --no-pager
```

Run the test:

```bash
./forge test --pytest-args="tests/foreman_test.py::test_foreman_no_production_log -vv"
```

> **Note:** Existing deployments may already have a stale `production.log`. Remove the file or recreate the container before testing.

---

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated