### PR TITLE
Make sure Podman uses  netavark as network backend

### DIFF
--- a/docs/developer/checks.md
+++ b/docs/developer/checks.md
@@ -40,6 +40,11 @@ Please update this file as check usage evolves.
 - **Fail state**: Fails if FQDN conditions are not met.
 - **Rationale**: Foreman requires a properly-configured server FQDN. This check ensures server hostname was modified from the default and approximates a valid FQDN.
 
+### check_podman_network_backend
+- **Description**: Verifies the Podman network backend is `netavark`.
+- **Fail state**: Fails if the network backend is anything other than `netavark`.
+- **Rationale**: Foremanctl requires netavark as the Podman network backend. Using a different backend such as CNI can cause container networking failures. This is a documented installation prerequisite.
+
 ### check_services
 - **Description**: Reports the status of all non-recurring services in the foreman.target systemd dependency tree.
 - **Fail state**: Fails if any services are inactive.

--- a/src/roles/check_podman_network_backend/tasks/main.yaml
+++ b/src/roles/check_podman_network_backend/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- name: Gather Podman system info
+  containers.podman.podman_system_info:
+  register: check_podman_network_backend_info
+
+- name: Assert Podman network backend is netavark
+  ansible.builtin.assert:
+    that:
+      - check_podman_network_backend_value == 'netavark'
+    fail_msg: >-
+      Podman network backend is '{{ check_podman_network_backend_value }}'
+      but must be 'netavark'. See the installation prerequisites for more information.
+  vars:
+    check_podman_network_backend_value: "{{ check_podman_network_backend_info.podman_system_info.host.networkBackendInfo.backend }}"

--- a/src/vars/flavors/foreman-proxy-content.yml
+++ b/src/vars/flavors/foreman-proxy-content.yml
@@ -12,6 +12,7 @@ checks_to_execute:
   - check_features
   - check_hostname
   - check_database_connection
+  - check_podman_network_backend
 
 health_checks_to_execute:
   - check_hostname

--- a/src/vars/flavors/katello.yml
+++ b/src/vars/flavors/katello.yml
@@ -13,6 +13,7 @@ checks_to_execute:
   - check_hostname
   - check_database_connection
   - check_system_requirements
+  - check_podman_network_backend
 
 health_checks_to_execute:
   - check_hostname


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Foremanctl requires netavark as the Podman network backend. This adds a preflight check using containers.podman.podman_system_info that fails with a clear error if the system is configured to use a different backend such as CNI. The check runs for both katello and foreman-proxy-content flavors.

#### What are the changes introduced in this pull request?

* New `check_podman_network_backend` role that uses `containers.podman.podman_system_info` to retrieve the active Podman network backend and fails with a clear error message if it is
   not `netavark`
 * Role added to `checks_to_execute` for both `katello` and `foreman-proxy-content` flavors so it runs as a preflight check before both deployments
* `docs/developer/checks.md` updated with description, fail state, and rationale for the new check


#### How to test this pull request

Steps to reproduce:

* Deploy foremanctl against a host where `podman info --format '{{.Host.NetworkBackend}}'` returns `netavark` — the preflight check should pass
* Deploy foremanctl against a host configured to use CNI — the preflight check should fail with a message indicating the network backend must be `netavark`

#### Checklist
* [ ] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)