### PR TITLE
fix(FDW): update inventory view to match current HBI schema

### DIFF
--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -230,21 +230,28 @@
     login_user: postgres
     login_password: "{{ postgresql_admin_password }}"
     login_host: localhost
+    # TODO(RHINENG-26911): remove this view once Cyndi decommission completes
+    # across all IoP services.
+    # Staleness intervals are hardcoded HBI defaults (29h, 7d, 30d).
+    # Per-org custom staleness from hbi.staleness is not supported.
     query: |
       CREATE OR REPLACE VIEW "inventory"."hosts" AS SELECT
-        id,
-        account,
-        display_name,
-        created_on as created,
-        modified_on as updated,
-        stale_timestamp,
-        stale_timestamp + INTERVAL '1' DAY * '7' AS stale_warning_timestamp,
-        stale_timestamp + INTERVAL '1' DAY * '14' AS culled_timestamp,
-        tags_alt as tags,
-        system_profile_facts as system_profile,
-        (canonical_facts ->> 'insights_id')::uuid as insights_id,
-        reporter,
-        per_reporter_staleness,
-        org_id,
-        groups
-      FROM hbi.hosts WHERE (canonical_facts->'insights_id' IS NOT NULL);
+        h.id,
+        h.account,
+        h.display_name,
+        h.created_on as created,
+        h.modified_on as updated,
+        h.last_check_in + INTERVAL '29 hours' AS stale_timestamp,
+        h.last_check_in + INTERVAL '7 days' AS stale_warning_timestamp,
+        h.last_check_in + INTERVAL '30 days' AS culled_timestamp,
+        h.tags_alt as tags,
+        jsonb_build_object('operating_system', sps.operating_system, 'host_type', sps.host_type, 'owner_id', sps.owner_id) as system_profile,
+        h.insights_id,
+        h.reporter,
+        h.per_reporter_staleness,
+        h.org_id,
+        h.groups,
+        h.last_check_in
+      FROM hbi.hosts h
+      LEFT JOIN hbi.system_profiles_static sps ON sps.org_id = h.org_id AND sps.host_id = h.id
+      WHERE h.insights_id != '00000000-0000-0000-0000-000000000000';


### PR DESCRIPTION
Three columns dropped upstream require view changes:

- `canonical_facts`: read insights_id directly as UUID column (RedHatInsights/insights-host-inventory@7754a5ad)
- `system_profile_facts`: `LEFT JOIN to system_profiles_static` for `operating_system`, `host_type`, `owner_id` (RedHatInsights/insights-host-inventory@62f4d244)
- `stale_timestamp`: compute from `last_check_in` using HBI defaults: 29h/7d/30d (RedHatInsights/insights-host-inventory@426d5e0d). Fixes pre-existing bug where `stale_warning` and culled were chained off `stale_timestamp` instead of computed independently from `last_check_in`.

WHERE clause updated: `canonical_facts->'insights_id' IS NOT NULL` replaced with `insights_id != '00000000-...'` (DEFAULT_INSIGHTS_ID sentinel).

Staleness intervals are hardcoded HBI defaults. Per-org overrides from hbi.staleness table are not reflected in this view.
