### PR TITLE
Foremanct - Log levels for Foreman & Proxy

### DIFF
--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -72,6 +72,21 @@ There are multiple use cases from the users perspective that dictate what parame
 | foreman-installer Parameter | Description | Reason |
 | --------------------------- | ----------- | ------ |
 
+#### Logging
+
+##### New
+
+| Parameter | Description |
+| ----------| ----------- |
+| `--log-level` | Default log level for all services. Accepted values: `debug`, `info`, `warn`, `error`, `fatal`. Defaults to `info`. |
+
+##### Mapped
+
+| Parameter | Description | foreman-installer Parameters |
+| ----------| ----------- | ---------------------------- |
+| `--foreman-log-level` | Log level for Foreman. Overrides `--log-level` for Foreman only. | `--foreman-logging-level` |
+| `--foreman-proxy-log-level` | Log level for Foreman Proxy. Overrides `--log-level` for Foreman Proxy only. | `--foreman-proxy-log-level` |
+
 #### Undetermined
 
 | foreman-installer Parameter | Description | Module | Puppet Parameter | Keep |
@@ -95,7 +110,6 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--foreman-keycloak-app-name` | | |
 | `--foreman-keycloak-realm` | | |
 | `--foreman-logging-layout` | | |
-| `--foreman-logging-level` | | |
 | `--foreman-logging-type` | | |
 | `--foreman-oauth-map-users` | | |
 | `--foreman-plugin-remote-execution-cockpit-ensure` | | |
@@ -165,7 +179,6 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--foreman-proxy-content-enable-ostree` | | | |
 | `--foreman-proxy-http` | | | |
 | `--foreman-proxy-log` | | | |
-| `--foreman-proxy-log-level` | | | |
 | `--foreman-proxy-plugin-ansible-working-dir` | | | |
 | `--foreman-proxy-plugin-dhcp-infoblox-dns-view` | | | |
 | `--foreman-proxy-plugin-dhcp-infoblox-network-view` | | | |

--- a/src/playbooks/_flavors/foreman-proxy-content/metadata.obsah.yaml
+++ b/src/playbooks/_flavors/foreman-proxy-content/metadata.obsah.yaml
@@ -1,4 +1,5 @@
 ---
 include:
+  - _logging
   - _pulp
   - _foreman_proxy

--- a/src/playbooks/_flavors/katello/metadata.obsah.yaml
+++ b/src/playbooks/_flavors/katello/metadata.obsah.yaml
@@ -26,5 +26,6 @@ include:
   - _database_connection
   - _foreman
   - _foreman_proxy
+  - _logging
   - _pulp
   - _tuning

--- a/src/playbooks/_logging/metadata.obsah.yaml
+++ b/src/playbooks/_logging/metadata.obsah.yaml
@@ -1,0 +1,27 @@
+---
+variables:
+  log_level:
+    help: Default log level for all services.
+    parameter: --log-level
+    choices:
+      - debug
+      - info
+      - warn
+      - error
+      - fatal
+  foreman_log_level:
+    help: Log level for Foreman. Defaults to the global log level.
+    choices:
+      - debug
+      - info
+      - warn
+      - error
+      - fatal
+  foreman_proxy_log_level:
+    help: Log level for Foreman Proxy. Defaults to the global log level.
+    choices:
+      - debug
+      - info
+      - warn
+      - error
+      - fatal

--- a/src/playbooks/_logging/metadata.obsah.yaml
+++ b/src/playbooks/_logging/metadata.obsah.yaml
@@ -9,14 +9,6 @@ variables:
       - warn
       - error
       - fatal
-  foreman_log_level:
-    help: Log level for Foreman. Defaults to the global log level.
-    choices:
-      - debug
-      - info
-      - warn
-      - error
-      - fatal
   foreman_proxy_log_level:
     help: Log level for Foreman Proxy. Defaults to the global log level.
     choices:

--- a/src/playbooks/deploy-proxy/deploy-proxy.yaml
+++ b/src/playbooks/deploy-proxy/deploy-proxy.yaml
@@ -11,6 +11,7 @@
     - "../../vars/tuning/{{ tuning }}.yml"
     - "../../vars/database.yml"
     - "../../vars/foreman.yml"
+    - "../../vars/logging.yml"
     - "../../vars/base.yaml"
   roles:
     - role: pre_install

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -11,6 +11,7 @@
     - "../../vars/tuning/{{ tuning }}.yml"
     - "../../vars/database.yml"
     - "../../vars/foreman.yml"
+    - "../../vars/logging.yml"
     - "../../vars/base.yaml"
   roles:
     - role: pre_install

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -14,6 +14,14 @@ variables:
       - ipa_with_api
   external_authentication_pam_service:
     help: Name of the PAM service to use for IPA authentication
+  foreman_log_level:
+    help: Log level for Foreman. Defaults to the global log level.
+    choices:
+      - debug
+      - info
+      - warn
+      - error
+      - fatal
 
 include:
   - _flavor_features

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -128,6 +128,7 @@
       FOREMAN_PUMA_THREADS_MAX: "{{ foreman_puma_threads_max }}"
       FOREMAN_PUMA_WORKERS: "{{ foreman_puma_workers }}"
       FOREMAN_ENABLED_PLUGINS: "{{ foreman_plugins | join(' ') }}"
+      FOREMAN_LOGGING_LEVEL: "{{ foreman_log_level }}"
     quadlet_options:
       - |
         [Install]
@@ -165,6 +166,7 @@
       DYNFLOW_REDIS_URL: "redis://localhost:6379/6"
       REDIS_PROVIDER: "DYNFLOW_REDIS_URL"
       FOREMAN_ENABLED_PLUGINS: "{{ foreman_plugins | join(' ') }}"
+      FOREMAN_LOGGING_LEVEL: "{{ foreman_log_level }}"
     command: "/usr/libexec/foreman/sidekiq-selinux -e production -r ./extras/dynflow-sidekiq.rb -C /etc/foreman/dynflow/%i.yml"
     quadlet_options:
       - |
@@ -222,6 +224,7 @@
     env:
       SEED_ORGANIZATION: "{{ foreman_initial_organization }}"
       SEED_LOCATION: "{{ foreman_initial_location }}"
+      FOREMAN_LOGGING_LEVEL: "{{ foreman_log_level }}"
     quadlet_options:
       - |
         [Unit]

--- a/src/roles/foreman_proxy/templates/settings.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.yml.j2
@@ -17,7 +17,7 @@
 
 :bind_host: '*'
 
-:log_level: INFO
+:log_level: {{ _foreman_proxy_log_level_map[foreman_proxy_log_level] }}
 :log_file: JOURNAL
 :log_buffer: 2000
 :log_buffer_errors: 1000

--- a/src/roles/foreman_proxy/templates/settings.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.yml.j2
@@ -17,7 +17,7 @@
 
 :bind_host: '*'
 
-:log_level: {{ _foreman_proxy_log_level_map[foreman_proxy_log_level] }}
+:log_level: {{ foreman_proxy_log_level | upper }}
 :log_file: JOURNAL
 :log_buffer: 2000
 :log_buffer_errors: 1000

--- a/src/vars/logging.yml
+++ b/src/vars/logging.yml
@@ -3,10 +3,3 @@ log_level: info
 
 foreman_log_level: "{{ log_level }}"
 foreman_proxy_log_level: "{{ log_level }}"
-
-_foreman_proxy_log_level_map:
-  debug: DEBUG
-  info: INFO
-  warn: WARN
-  error: ERROR
-  fatal: FATAL

--- a/src/vars/logging.yml
+++ b/src/vars/logging.yml
@@ -1,0 +1,12 @@
+---
+log_level: info
+
+foreman_log_level: "{{ log_level }}"
+foreman_proxy_log_level: "{{ log_level }}"
+
+_foreman_proxy_log_level_map:
+  debug: DEBUG
+  info: INFO
+  warn: WARN
+  error: ERROR
+  fatal: FATAL


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

To give users the option to change the log level of the services.

### What changes are introduced in this pull request?

Three new `deploy` parameters:

* `--log-level` Default log level for all services.
* `--foreman-log-level` Log level for `foreman.service`
* `--foreman-proxy-log-level` Log level for `foreman-proxy.service`

### How to test this pull request

```
foremanctl deploy --initial-admin-password=changeme \
--add-feature foreman-proxy \
--tuning development \
--log-level=debug
```

or

```
foremanctl deploy --foreman-log-level=error --foreman-proxy-log-level=error
```

and then:

```
journalctl -f -u foreman.service
journalctl -f -u foreman-proxy.service
```

### Notes

Resetting params won't work

```shell
./foremanctl deploy --reset-foreman-log-level --reset-foreman-proxy-log-level
```
Fixed in https://github.com/theforeman/obsah/pull/127/changes

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
