### PR TITLE
Refactor post_install role

### DIFF
--- a/src/roles/post_install/tasks/foreman-proxy-content.yaml
+++ b/src/roles/post_install/tasks/foreman-proxy-content.yaml
@@ -1,8 +1,0 @@
----
-- name: Mark installation as complete
-  ansible.builtin.copy:
-    dest: "{{ post_install_done_flag }}"
-    content: ''
-    mode: '0640'
-  delegate_to: localhost
-  become: false

--- a/src/roles/post_install/tasks/main.yaml
+++ b/src/roles/post_install/tasks/main.yaml
@@ -1,6 +1,14 @@
 ---
-- name: Run post install tasks
-  ansible.builtin.include_tasks: "{{ flavor }}.yaml"
-
 - name: Check for unrecognized Smart Proxy features
   ansible.builtin.include_tasks: smart_proxy_features_check.yaml
+
+- name: Post install message
+  ansible.builtin.include_tasks: message.yaml
+
+- name: Mark installation as complete
+  ansible.builtin.copy:
+    dest: "{{ post_install_done_flag }}"
+    content: ''
+    mode: '0640'
+  delegate_to: localhost
+  become: false

--- a/src/roles/post_install/tasks/message.yaml
+++ b/src/roles/post_install/tasks/message.yaml
@@ -1,5 +1,6 @@
 ---
-- name: Admin credentials
+- name: Post install message
+  when: flavor in ['katello']
   ansible.builtin.debug:
     msg:
       - "{{ _post_install_url_msg }}"
@@ -7,10 +8,3 @@
   vars:
     _post_install_url_msg: "Foreman is running at {{ post_install_foreman_server_url }}"
     _post_install_cred_msg: "Admin credentials: {{ post_install_foreman_initial_admin_username }}:{{ post_install_foreman_initial_admin_password }}"
-- name: Mark installation as complete
-  ansible.builtin.copy:
-    dest: "{{ post_install_done_flag }}"
-    content: ''
-    mode: '0640'
-  delegate_to: localhost
-  become: false

--- a/src/roles/post_install/tasks/smart_proxy_features_check.yaml
+++ b/src/roles/post_install/tasks/smart_proxy_features_check.yaml
@@ -14,6 +14,11 @@
     msg: >-
       Proxy {{ item.name }} reports unrecognized features: {{ item.unrecognized_features | join(', ') }}.
       Enable matching features in foremanctl or disable them on the proxy.
-  loop: "{{ _post_install_smart_proxies.resources }}"
-  when:
-    - item.unrecognized_features | default([]) | length > 0
+  loop: "{{ _post_install_proxies_with_unrecognized_features }}"
+  loop_control:
+    label: "{{ item.name }}"
+  vars:
+    _post_install_proxies_with_unrecognized_features: >-
+      {{ _post_install_smart_proxies.resources |
+         selectattr('unrecognized_features', 'defined') |
+         selectattr('unrecognized_features', '!=', []) | list }}


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The `Warn about unrecognized Smart Proxy features` task looped over all registered
smart proxies and emitted a verbose skip line for each one when there were no
unrecognized features. Each skip line dumped the full proxy data structure, producing
a large noisy block at the end of every run even when everything was fine.

Additionally, `main.yaml` dispatched to flavor-specific task files (`{{ flavor }}.yaml`)
via a dynamic include, which required a separate file per flavor (`katello.yaml`,
`foreman-proxy-content.yaml`). These files duplicated the "mark installation as complete"
task and made the structure harder to follow.

#### What are the changes introduced in this pull request?

* Pre-filter smart proxies into a fact before looping, so the warn task only iterates
  over proxies that actually have unrecognized features — eliminating per-item skip output
  in the common (no-problem) case
* Add `loop_control: label` to the warn task so any loop output shows only the proxy name,
  not the full data dict
* Collapse flavor-specific task dispatch in `main.yaml` into explicit, unconditional
  includes for `smart_proxy_features_check.yaml` and `message.yaml`, with the
  flavor-specific debug guarded inline by `when: flavor == 'katello'`
* Rename `katello.yaml` → `message.yaml` to reflect its new flavor-agnostic role
* Delete the now-redundant `foreman-proxy-content.yaml`

#### How to test this pull request

Steps to reproduce:

* Deploy with `./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development`
* Verify the post-install output no longer contains a large `skipping` block for the
  smart proxy features check
* Verify the post-install admin credentials message still appears at the end of a katello deployment
* Run with a proxy that has an unrecognized feature and confirm the warning is still emitted,
  showing only the proxy name (not the full dict) in the task label

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

