### PR TITLE
prepare proxy before deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -449,9 +449,9 @@ jobs:
           ./foremanctl certificate-bundle proxy.example.com \
             --certificate-source=${{ matrix.certificate_source }} \
             ${{ matrix.certificate_source == 'custom_server' && '--certificate-server-certificate /root/custom-certificates/certs/proxy.example.com.crt --certificate-server-key /root/custom-certificates/private/proxy.example.com.key' || '' }}
-      - name: Fetch certificates bundle from quadlet
+      - name: Prepare proxy host
         run: |
-          ./forge fetch-bundle proxy.example.com
+          ./foremanctl prepare-proxy proxy.example.com
       - name: Deploy content proxy
         run: |
           ./foremanctl deploy-proxy \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -449,9 +449,9 @@ jobs:
           ./foremanctl certificate-bundle proxy.example.com \
             --certificate-source=${{ matrix.certificate_source }} \
             ${{ matrix.certificate_source == 'custom_server' && '--certificate-server-certificate /root/custom-certificates/certs/proxy.example.com.crt --certificate-server-key /root/custom-certificates/private/proxy.example.com.key' || '' }}
-      - name: Prepare proxy host
+      - name: Fetch certificates bundle from quadlet
         run: |
-          ./foremanctl prepare-proxy proxy.example.com
+          ./forge fetch-bundle proxy.example.com
       - name: Deploy content proxy
         run: |
           ./foremanctl deploy-proxy \

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -15,9 +15,9 @@ Deploys a Foreman server. This is the primary deployment type and the default en
 
 ### Proxy
 
-Deploys a Foreman Proxy node that connects to a Foreman server.
+Deploys a Foreman Proxy server that connects to a Foreman server.
 
-Before running the proxy deployment, a certificate bundle must be generated on the Foreman server and copied to the proxy VM:
+Before running the proxy deployment, a certificate bundle must be generated on the Foreman server:
 
 1. On the **Foreman server**, generate a certificate bundle for the proxy hostname:
 
@@ -27,18 +27,25 @@ Before running the proxy deployment, a certificate bundle must be generated on t
 
    This produces a tar archive at a path like `/var/lib/foremanctl/certs/bundles/<hostname>.tar.gz`.
 
-2. Copy the bundle to the **proxy VM**:
 
-   ```bash
-   scp /var/lib/foremanctl/certs/bundles/proxy.example.com.tar.gz root@proxy.example.com:/root/proxy.example.com.tar.gz
+2. On the **Foreman server**, run following command to prepare proxy server for deployment.
+
+  ```bash
+   ./foremanctl prepare-proxy proxy.example.com
    ```
+
+  This transfers generated certificate bundle and oauth credentials on proxy server.
+
+> [!NOTE]
+> `prepare-proxy` connects to the proxy server over SSH. Ensure key-based SSH access from the Foreman server to the proxy server is working before proceeding (e.g. `ssh root@proxy.example.com)
+
 
 3. On the **proxy VM**, run the deployment:
 
    ```bash
    ./foremanctl deploy-proxy \
      --flavor foreman-proxy-content \
-     --certificate-bundle /root/proxy.example.com.tar.gz \
+     --certificate-bundle /var/lib/foremanctl/proxy.example.com.tar.gz \
      --foreman-fqdn quadlet.example.com
    ```
 

--- a/src/playbooks/deploy-proxy/metadata.obsah.yaml
+++ b/src/playbooks/deploy-proxy/metadata.obsah.yaml
@@ -15,12 +15,6 @@ variables:
   foreman_name:
     parameter: --foreman-fqdn
     help: FQDN of the Foreman server this proxy connects to.
-  foreman_proxy_oauth_consumer_key:
-    parameter: --oauth-consumer-key
-    help: OAuth key to be used for communication with Foreman.
-  foreman_proxy_oauth_consumer_secret:
-    parameter: --oauth-consumer-secret
-    help: OAuth secret to be used for communication with Foreman.
 
 include:
   - _flavor_features

--- a/src/playbooks/prepare-proxy/metadata.obsah.yaml
+++ b/src/playbooks/prepare-proxy/metadata.obsah.yaml
@@ -1,0 +1,8 @@
+---
+help: |
+  Prepare a proxy host for deployment.
+
+variables:
+  hostname:
+    parameter: hostname
+    help: FQDN of the proxy host to prepare.

--- a/src/playbooks/prepare-proxy/prepare-proxy.yaml
+++ b/src/playbooks/prepare-proxy/prepare-proxy.yaml
@@ -1,0 +1,67 @@
+---
+- name: Validate and fetch proxy prerequisites
+  hosts: quadlet
+  become: true
+  vars_files:
+    - "../../vars/certificates.yml"
+    - "../../vars/foreman.yml"
+  tasks:
+    - name: Check certificate bundle exists
+      ansible.builtin.stat:
+        path: "{{ certificates_ca_directory }}/bundles/{{ hostname }}.tar.gz"
+      register: _bundle_stat
+
+    - name: Fail if certificate bundle does not exist
+      ansible.builtin.fail:
+        msg: >-
+          Certificate bundle for {{ hostname }} not found at
+          {{ certificates_ca_directory }}/bundles/{{ hostname }}.tar.gz.
+          Run 'foremanctl certificate-bundle --hostname {{ hostname }}' first.
+      when: not _bundle_stat.stat.exists
+
+    - name: Fetch certificate bundle to controller
+      ansible.builtin.fetch:
+        src: "{{ certificates_ca_directory }}/bundles/{{ hostname }}.tar.gz"
+        dest: "{{ obsah_state_path }}/{{ hostname }}.tar.gz"
+        flat: true
+
+    - name: Add proxy host to inventory
+      ansible.builtin.add_host:
+        name: "{{ hostname }}"
+        groups: proxy
+        ansible_connection: ssh
+        ansible_host: "{{ hostname }}"
+        inventory_dir: "{{ inventory_dir }}"
+
+- name: Transfer proxy certificate bundle and oauth credentials to proxy host
+  hosts: proxy
+  become: true
+  vars_files:
+    - "../../vars/foreman.yml"
+  tasks:
+    - name: Check SSH connectivity and authentication to proxy
+      ansible.builtin.ping:
+
+    - name: Copy certificate bundle to proxy
+      ansible.builtin.copy:
+        src: "{{ obsah_state_path }}/{{ hostname }}.tar.gz"
+        dest: "{{ obsah_state_path }}/{{ hostname }}.tar.gz"
+        mode: "0600"
+        owner: root
+        group: root
+
+    - name: Copy OAuth consumer key to proxy
+      ansible.builtin.copy:
+        src: "{{ foreman_oauth_consumer_key_file }}"
+        dest: "{{ obsah_state_path }}/foreman-oauth-consumer-key"
+        mode: "0600"
+        owner: root
+        group: root
+
+    - name: Copy OAuth consumer secret to proxy
+      ansible.builtin.copy:
+        src: "{{ foreman_oauth_consumer_secret_file }}"
+        dest: "{{ obsah_state_path }}/foreman-oauth-consumer-secret"
+        mode: "0600"
+        owner: root
+        group: root

--- a/src/roles/pre_install/tasks/foreman-proxy-content.yaml
+++ b/src/roles/pre_install/tasks/foreman-proxy-content.yaml
@@ -1,0 +1,19 @@
+---
+- name: Read OAuth consumer key from file
+  ansible.builtin.slurp:
+    src: "{{ obsah_state_path }}/foreman-oauth-consumer-key"
+  register: _oauth_key_file
+
+- name: Set OAuth consumer key
+  ansible.builtin.set_fact:
+    foreman_proxy_oauth_consumer_key: "{{ _oauth_key_file.content | b64decode | trim }}"
+
+- name: Read OAuth consumer secret from file
+  ansible.builtin.slurp:
+    src: "{{ obsah_state_path }}/foreman-oauth-consumer-secret"
+  register: _oauth_secret_file
+
+- name: Set OAuth consumer secret
+  ansible.builtin.set_fact:
+    foreman_proxy_oauth_consumer_secret: "{{ _oauth_secret_file.content | b64decode | trim }}"
+

--- a/src/roles/pre_install/tasks/main.yaml
+++ b/src/roles/pre_install/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- name: Include flavor tasks
+  ansible.builtin.include_tasks: "{{ flavor }}.yaml"
+
 - name: Deploy debug_tools
   ansible.builtin.include_role:
     name: debug_tools


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Deploying a smart proxy requires a certificate bundle and OAuth credentials that live on the Foreman server. Previously there was no dedicated step to transfer these to the proxy host before running deploy-proxy, leaving users to handle that manually.


#### What are the changes introduced in this pull request?

* Add foremanctl prepare-proxy  <fqdn> command — validates that a certificate bundle exists on the Foreman server, then copies it along with the OAuth consumer key and secret to the proxy host over SSH
* Add src/playbooks/prepare-proxy/prepare-proxy.yaml — two-play playbook: first play runs on the Foreman host to validate and fetch the certificate bundle; second play connects to the proxy over SSH to transfer the bundle and OAuth credentials
* Add src/playbooks/prepare-proxy/metadata.obsah.yaml — exposes the command via obsah with a required --hostname parameter
* Move OAuth credential reading into src/roles/pre_install/tasks/foreman-proxy-content.yaml and include it conditionally for the foreman-proxy-content flavor

#### How to test this pull request

Steps to reproduce:

* Deploy a Foreman server with foremanctl deploy
* Generate a certificate bundle for the proxy: foremanctl certificate-bundle  <proxy-fqdn>
* Ensure SSH key-based access from the Foreman server to the proxy host is configured
* Run foremanctl prepare-proxy <proxy-fqdn> and verify it completes without errors
* Run foremanctl deploy-proxy  --flavor foreman-proxy-content --certificate-bundle /root/proxy.example.com.tar.gz --foreman-fqdn quadlet.example.com and verify the OAuth credentials are picked up correctly from the transferred files

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
