### PR TITLE
use login_db instead of db when using the postgresql modules

### DIFF
--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -1,5 +1,6 @@
 collections:
-  - community.postgresql
+  - name: community.postgresql
+    version: ">=4.0.0"
   - community.crypto
   - community.general
   - ansible.posix

--- a/src/roles/check_database_index/tasks/main.yml
+++ b/src/roles/check_database_index/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if amcheck extension is installed
   community.postgresql.postgresql_query:
-    db: "{{ check_database_index_database }}"
+    login_db: "{{ check_database_index_database }}"
     login_host: "{{ database_host }}"
     login_port: "{{ database_port }}"
     login_user: postgres
@@ -18,7 +18,7 @@
   block:
     - name: Execute amcheck integrity check
       community.postgresql.postgresql_query:
-        db: "{{ check_database_index_database }}"
+        login_db: "{{ check_database_index_database }}"
         login_host: "{{ database_host }}"
         login_port: "{{ database_port }}"
         login_user: postgres

--- a/src/roles/check_duplicate_permissions/tasks/main.yaml
+++ b/src/roles/check_duplicate_permissions/tasks/main.yaml
@@ -2,7 +2,7 @@
 # TODO: Remove this role one release after https://projects.theforeman.org/issues/38465 is addressed.
 - name: Query for duplicate permissions
   community.postgresql.postgresql_query:
-    db: "{{ foreman_database_name }}"
+    login_db: "{{ foreman_database_name }}"
     login_user: "{{ foreman_database_user }}"
     login_password: "{{ foreman_database_password }}"
     login_host: "{{ foreman_database_host }}"

--- a/src/roles/check_foreman_tasks/tasks/main.yaml
+++ b/src/roles/check_foreman_tasks/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Query foreman tasks for errors
   community.postgresql.postgresql_query:
-    db: "{{ foreman_database_name }}"
+    login_db: "{{ foreman_database_name }}"
     login_user: "{{ foreman_database_user }}"
     login_password: "{{ foreman_database_password }}"
     login_host: "{{ foreman_database_host }}"

--- a/src/roles/check_host_facts_count/tasks/main.yaml
+++ b/src/roles/check_host_facts_count/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Query hosts for facts count
   community.postgresql.postgresql_query:
-    db: "{{ foreman_database_name }}"
+    login_db: "{{ foreman_database_name }}"
     login_user: "{{ foreman_database_user }}"
     login_password: "{{ foreman_database_password }}"
     login_host: "{{ foreman_database_host }}"

--- a/src/roles/iop_fdw/tasks/main.yaml
+++ b/src/roles/iop_fdw/tasks/main.yaml
@@ -7,13 +7,13 @@
 - name: Enable postgres_fdw extension on target database
   community.postgresql.postgresql_ext:
     name: postgres_fdw
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
 
 - name: Check if foreign server exists
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: "SELECT srvname FROM pg_foreign_server WHERE srvname = %s"
@@ -24,7 +24,7 @@
 
 - name: Create foreign server for target database
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |
@@ -39,7 +39,7 @@
 
 - name: Check if user mapping exists for service user
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: "SELECT umuser FROM pg_user_mappings WHERE srvname = %s AND usename = %s"
@@ -51,7 +51,7 @@
 
 - name: Create user mapping for service user
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |
@@ -65,7 +65,7 @@
 
 - name: Check if user mapping exists for postgres user
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: "SELECT umuser FROM pg_user_mappings WHERE srvname = %s AND usename = 'postgres'"
@@ -76,7 +76,7 @@
 
 - name: Create user mapping for postgres user
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |
@@ -90,14 +90,14 @@
 
 - name: Grant usage on foreign server
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: "GRANT USAGE ON FOREIGN SERVER {{ iop_fdw_foreign_server_name }} TO {{ iop_fdw_database_user }}"
 
 - name: Create local view schema
   community.postgresql.postgresql_schema:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     name: "{{ iop_fdw_local_view_schema }}"
     owner: "{{ iop_fdw_database_user }}"
     login_user: postgres
@@ -105,7 +105,7 @@
 
 - name: Create local schema for foreign tables
   community.postgresql.postgresql_schema:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     name: "{{ iop_fdw_local_source_schema }}"
     owner: "{{ iop_fdw_database_user }}"
     login_user: postgres
@@ -113,7 +113,7 @@
 
 - name: Check if foreign table exists
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: "SELECT foreign_table_name FROM information_schema.foreign_tables WHERE foreign_table_schema = %s AND foreign_table_name = %s"
@@ -125,7 +125,7 @@
 
 - name: Import foreign schema
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |
@@ -137,7 +137,7 @@
 
 - name: Create local view pointing to foreign table
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |
@@ -146,7 +146,7 @@
 
 - name: Grant select on foreign table to service user
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_database_name }}"
+    login_db: "{{ iop_fdw_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |
@@ -157,7 +157,7 @@
 
 - name: Grant permissions on remote database view to remote user
   community.postgresql.postgresql_query:
-    db: "{{ iop_fdw_remote_database_name }}"
+    login_db: "{{ iop_fdw_remote_database_name }}"
     login_user: postgres
     login_host: "{{ iop_fdw_database_host }}"
     query: |

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -207,14 +207,14 @@
 - name: Enable postgres_fdw extension on inventory database
   community.postgresql.postgresql_ext:
     name: postgres_fdw
-    db: "{{ iop_inventory_database_name }}"
+    login_db: "{{ iop_inventory_database_name }}"
     login_user: postgres
     login_password: "{{ postgresql_admin_password }}"
     login_host: localhost
 
 - name: Create inventory schema in inventory database
   community.postgresql.postgresql_schema:
-    db: "{{ iop_inventory_database_name }}"
+    login_db: "{{ iop_inventory_database_name }}"
     name: inventory
     owner: "{{ iop_inventory_database_user }}"
     login_user: postgres
@@ -223,7 +223,7 @@
 
 - name: Create inventory.hosts view in inventory database
   community.postgresql.postgresql_query:
-    db: "{{ iop_inventory_database_name }}"
+    login_db: "{{ iop_inventory_database_name }}"
     login_user: postgres
     login_password: "{{ postgresql_admin_password }}"
     login_host: localhost


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

the db alias is deprecated and will be removed in a future version

#### What are the changes introduced in this pull request?

* `s/db:/login_db:/`

#### How to test this pull request

CI

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
