### PR TITLE
Remove --remove-feature hint from invalid feature error message

### DIFF
--- a/src/roles/check_features/tasks/main.yaml
+++ b/src/roles/check_features/tasks/main.yaml
@@ -6,9 +6,6 @@
     fail_msg: |
       ERROR: Unknown feature(s) requested: {{ found_invalid_features | join(', ') }}
 
-      To remove them, run:
-        foremanctl deploy {% for feature in found_invalid_features %}--remove-feature={{ feature }} {% endfor %}
-
       Run 'foremanctl features' to list all available features.
   vars:
     found_invalid_features: "{{ features | invalid_features }}"

--- a/tests/features_test.py
+++ b/tests/features_test.py
@@ -31,5 +31,4 @@ def test_invalid_feature_rejected():
     assert result.returncode == 2
 
     assert 'Unknown feature(s) requested: invalid-feature' in result.stdout
-    assert '--remove-feature=invalid' in result.stdout
     assert "Run 'foremanctl features' to list all available features." in result.stdout


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
[obsah@c45f246](https://github.com/theforeman/obsah/commit/c45f2469ec7066442b80004ff2ef56b0a88507fe) changed parameter persistence to only happen after a successful playbook run. Previously, parameters were written to parameters.yaml before the playbook executed, so passing an unknown feature via --add-feature would persist the invalid value to disk, causing a persistent failure loop on subsequent runs. The error message therefore instructed users to run foremanctl deploy --remove-feature=<feature> to recover.
#### What are the changes introduced in this pull request?

* Remove the "To remove them, run: foremanctl deploy --remove-feature=..." instruction from the check_features role assertion failure message.
* Drop the corresponding test assertion that --remove-feature=invalid appears in the output of test_invalid_feature_rejected.

#### How to test this pull request

Steps to reproduce:

* Run ./foremanctl deploy --add-feature invalid-feature and confirm the error message no longer suggests running --remove-feature.
* Confirm that parameters.yaml is not written (or not updated with the invalid feature) after the failed run.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
