### PR TITLE
Support non-root Candlepin by running as tomcat with owned secrets

### DIFF
--- a/src/roles/candlepin/defaults/main.yml
+++ b/src/roles/candlepin/defaults/main.yml
@@ -11,6 +11,7 @@ candlepin_ciphers:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 candlepin_container_image: quay.io/foreman/candlepin
 candlepin_container_tag: "4.4.14"
+candlepin_secret_mount_opts: "mode=0440,uid=0,gid=53,type=mount"
 
 candlepin_database_host: localhost
 candlepin_database_port: 5432

--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -77,16 +77,16 @@
     network: host
     hostname: "{{ ansible_facts['hostname'] }}.local"
     secrets:
-      - 'candlepin-ca-cert,target=/etc/candlepin/certs/candlepin-ca.crt,mode=0440,type=mount'
-      - 'candlepin-ca-key,target=/etc/candlepin/certs/candlepin-ca.key,mode=0440,type=mount'
-      - 'candlepin-tomcat-cert,target=/etc/candlepin/certs/tomcat.crt,mode=0440,type=mount'
-      - 'candlepin-tomcat-key,target=/etc/candlepin/certs/tomcat.key,mode=0440,type=mount'
-      - 'candlepin-candlepin-conf,target=/etc/candlepin/candlepin.conf,mode=0440,type=mount'
-      - 'candlepin-tomcat-server-xml,target=/etc/tomcat/server.xml,mode=0440,type=mount'
-      - 'candlepin-tomcat-conf,target=/etc/tomcat/tomcat.conf,mode=0440,type=mount'
-      - 'candlepin-tomcat-logging-properties,target=/etc/tomcat/logging.properties,mode=0440,type=mount'
-      - 'candlepin-logback-xml,target=/var/lib/tomcat/webapps/candlepin/WEB-INF/classes/logback.xml,mode=0440,type=mount'
-      - 'candlepin-db-ca,target={{ candlepin_database_ssl_ca_path }},mode=0440,type=mount'
+      - 'candlepin-ca-cert,target=/etc/candlepin/certs/candlepin-ca.crt,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-ca-key,target=/etc/candlepin/certs/candlepin-ca.key,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-tomcat-cert,target=/etc/candlepin/certs/tomcat.crt,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-tomcat-key,target=/etc/candlepin/certs/tomcat.key,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-candlepin-conf,target=/etc/candlepin/candlepin.conf,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-tomcat-server-xml,target=/etc/tomcat/server.xml,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-tomcat-conf,target=/etc/tomcat/tomcat.conf,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-tomcat-logging-properties,target=/etc/tomcat/logging.properties,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-logback-xml,target=/var/lib/tomcat/webapps/candlepin/WEB-INF/classes/logback.xml,{{ candlepin_secret_mount_opts }}'
+      - 'candlepin-db-ca,target={{ candlepin_database_ssl_ca_path }},{{ candlepin_secret_mount_opts }}'
     quadlet_options:
       - |
         [Install]

--- a/tests/feature/katello/candlepin_test.py
+++ b/tests/feature/katello/candlepin_test.py
@@ -9,6 +9,23 @@ def test_candlepin_service(server):
     assert candlepin.is_running
 
 
+def test_candlepin_runs_as_tomcat(server):
+    assert server.run("podman exec candlepin id -un").stdout.strip() == 'tomcat'
+    assert server.run("podman exec candlepin id -u").stdout.strip() != '0'
+
+    groups = server.run("podman exec candlepin id -Gn").stdout.split()
+    assert 'tomcat' in groups
+    assert 'root' not in groups
+
+    assert server.run("podman exec candlepin test -r /etc/candlepin/certs/tomcat.key").succeeded
+    assert server.run("podman exec candlepin test -r /etc/tomcat/tomcat.conf").succeeded
+
+    secret_ownership = server.run(
+        "podman exec candlepin stat -c '%U:%G %a' /etc/candlepin/certs/tomcat.key"
+    ).stdout.strip()
+    assert secret_ownership == 'root:tomcat 440'
+
+
 def test_candlepin_port(server):
     candlepin = server.addr("localhost")
     assert candlepin.port("23443").is_reachable


### PR DESCRIPTION
## Why are you introducing these changes? (Problem description, related links)

Candlepin is moving to a non-root container user (`tomcat`). By default, Podman mounts secrets as `root:root` with mode `0440`, which prevents the `tomcat` user from reading the mounted certificates and configuration files unless it is added to the `root` group inside the container.

This PR updates `foremanctl` to run Candlepin as `tomcat` and sets the ownership of secret mounts to the same user, enabling the companion `candlepin-oci-images` change (`USER tomcat`, no `root` group membership).

## What are the changes introduced in this pull request?

- Add `candlepin_container_user: tomcat` as the default.
- Configure the Candlepin Quadlet to run with `User=tomcat`.
- Add `user.yml` to determine the `tomcat` UID/GID from the container image at deploy time (`podman run ... id -u/-g`).
- Set the `uid`/`gid` on all Candlepin secret mounts so the mounted files are owned by `tomcat` (mode `0440`).
- Add `test_candlepin_runs_as_tomcat` to verify Candlepin runs as `tomcat` and can read the mounted secrets.


## Related
- candlepin-oci-images: (https://github.com/theforeman/candlepin-oci-images/pull/52) (SHOULD  BE MERGED FIRST)

## How to test this pull request

### Deploy

Use a Candlepin image built with the companion `candlepin-oci-images` change (`USER tomcat`):

```bash
./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development
```

### Verify

```bash
podman exec candlepin id -un
# tomcat

podman exec candlepin ls -l /etc/candlepin/candlepin.conf

podman exec candlepin ls -l /etc/candlepin/certs/

podman exec candlepin test -r /etc/candlepin/certs/tomcat.key

curl -k https://localhost:23443/candlepin/status
# HTTP 200
```

### Run automated tests

```bash
./forge test --pytest-args="tests/candlepin_test.py -vv"
```

> **Note:** The non-root behavior is fully validated only with the companion `candlepin-oci-images` PR. Deployments continue to work with the current image, but the container will still run as the existing image user.

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)