### PR TITLE
Add ostree content type support

### DIFF
--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -110,6 +110,7 @@ There are multiple use cases from the users perspective that dictate what parame
 | Parameter | Description | foreman-installer Parameters |
 | --------- | ----------- | ---------------------------- |
 | `--add-feature bmc` | Enable BMC feature | `--foreman-proxy-bmc` |
+| `--add-feature content/ostree` | Enable OSTree content type | `--foreman-proxy-content-enable-ostree` |
 | `--bmc-ipmi-implementation` | IPMI implementation to use for BMC | `--foreman-proxy-bmc-default-provider` |
 | `--bmc-redfish-verify-ssl` | Verify SSL certificates for Redfish BMC connections | `--foreman-proxy-bmc-redfish-verify-ssl` |
 
@@ -162,7 +163,6 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--foreman-proxy-plugin-remote-execution-script-mode` | | foreman_proxy::plugin::remote_execution_script | mode |
 | `--foreman-proxy-plugin-openscap-ansible-module` | | foreman_proxy::plugin::openscap | ansible_module |
 | `--foreman-proxy-plugin-openscap-puppet-module` | | foreman_proxy::plugin::openscap | puppet_module |
-| `--foreman-proxy-content-enable-ostree` | | | |
 | `--foreman-proxy-http` | | | |
 | `--foreman-proxy-log` | | | |
 | `--foreman-proxy-log-level` | | | |

--- a/src/features.d/content.yaml
+++ b/src/features.d/content.yaml
@@ -24,3 +24,7 @@ content/python:
   internal: true
   dependencies:
     - pulp
+content/ostree:
+  description: OSTree content type for Pulp
+  dependencies:
+    - pulp


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

#### What are the changes introduced in this pull request?

* Adds support for enabling the ostree content type, which Katello supports.
  * The ostree type is optional.

There is some mention in the docs about the ostree plugin not migrating properly - I have not touched the migration mapping logic, but this should help unblock that.

#### How to test this pull request

Steps to reproduce:

* Deploy a machine and check that you can create ostree repos.

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)
