### PR TITLE
Correctly regenerate the CA certificate when renew-ca was passed

### DIFF
--- a/src/roles/certificates/tasks/ca.yml
+++ b/src/roles/certificates/tasks/ca.yml
@@ -52,13 +52,14 @@
         privatekey_passphrase: "{{ certificates_ca_password }}"
         provider: selfsigned
         selfsigned_not_after: "+{{ certificates_ca_validity_days }}d"
+        force: "{{ certificates_renew_ca | bool }}"
 
     - name: 'Copy CA as server CA certificate'
       ansible.builtin.copy:
         src: "{{ certificates_ca_directory_certs }}/ca.crt"
         dest: "{{ certificates_ca_directory_certs }}/server-ca.crt"
         remote_src: true
-        force: false
+        force: "{{ certificates_renew_ca | bool }}"
         mode: '0444'
 
     - name: 'Create CA bundle'
@@ -66,5 +67,5 @@
         src: "{{ certificates_ca_directory_certs }}/ca.crt"
         dest: "{{ certificates_ca_directory_certs }}/ca-bundle.crt"
         remote_src: true
-        force: false
+        force: "{{ certificates_renew_ca | bool }}"
         mode: '0444'


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The old implementation would gate that the CA is not regenerated when only parameters change (like common name), but did not ensure that a CA can actually be regenerated with the same parameters.

Fixes: 3f28b92f630ec321d66dcde5de7ddc8845d4d207

#### What are the changes introduced in this pull request?

* Use the force, Luke!

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
