### PR TITLE
Mark slow tests to allow for quicker iteration

### DIFF
--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -139,9 +139,7 @@ These fixtures create a resource before the test and delete it afterward:
 
 ### Service test
 
-Check that a systemd unit is running and its port is reachable:
-
-For example:
+Check that a systemd unit is running and its port is reachable using testinfra's [service](https://testinfra.readthedocs.io/en/latest/modules.html#testinfra.modules.service.Service) and [addr](https://testinfra.readthedocs.io/en/latest/modules.html#testinfra.modules.addr.Addr) modules:
 
 ```python
 def test_service_running(server):

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -66,6 +66,12 @@ pytest tests/postgresql_test.py
 pytest tests/foreman_test.py::test_foreman_service
 ```
 
+You can also run tests with [markers](#markers). To skip all tests marked as slow:
+
+```bash
+pytest -m "not slow"
+```
+
 > [!NOTE]
 > Running `pytest` directly requires `.tmp/ssh-config` to exist. Run `./forge test` at least once to generate it.
 
@@ -145,6 +151,19 @@ def test_service_running(server):
 def test_service_port(server):
     assert server.addr("localhost").port(6379).is_reachable
 ```
+
+### Markers
+
+Pytest's [markers](https://docs.pytest.org/en/stable/how-to/mark.html) are powerful tools. Especially when using the [custom markers](https://docs.pytest.org/en/stable/example/markers.html#mark-examples).
+
+List all available markers:
+```bash
+pytest --markers
+```
+
+The `slow` mark can be used to mark tests that take a non-trivial amount of time. While slow is always subjective, it can mean more than a few seconds to some. Certainly more than a minute.
+
+A more advanced use is [feature guarding](#feature-guarding).
 
 ### Feature guarding
 

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,2 +1,6 @@
 [pytest]
 addopts = ["--import-mode=importlib"]
+
+markers = [
+  "slow: mark test as slow.",
+]

--- a/tests/target_lifecycle_test.py
+++ b/tests/target_lifecycle_test.py
@@ -1,8 +1,12 @@
 import time
 
+import pytest
+
 TARGET_ACTIVE_RETRIES = 90
 TARGET_ACTIVE_DELAY = 10
 CURL_CMD = "curl --silent --output /dev/null"
+
+pytestmark = pytest.mark.slow
 
 
 def _wait_for_target_active(server, target="foreman.target"):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

While working on https://github.com/theforeman/foremanctl/pull/511 I wanted to quickly run tests again and again. The full service restart is slow and not really something I was interested in.

#### What are the changes introduced in this pull request?

You can now skip slow tests with:

    pytest -k "not slow"

#### How to test this pull request

Steps to reproduce:

* Watch CI and verify it still runs the slow tests
* Manually run pytest to skip the slow tests

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)