### PR TITLE
Only test for azure-rm and google features when enabled

### DIFF
--- a/tests/feature/foreman/compute_resources_test.py
+++ b/tests/feature/foreman/compute_resources_test.py
@@ -1,9 +1,25 @@
 import pytest
 
 
-@pytest.mark.parametrize("compute_resource", ['AzureRm', 'EC2', 'GCE', 'Libvirt', 'Openstack', 'Vmware'])
-def test_foreman_compute_resources(foremanapi, compute_resource):
+# TODO: Foreman really should have a dedicated API endpoint to expose this info
+@pytest.fixture
+def provider_description(foremanapi):
     create = foremanapi.resource('compute_resources').action('create')
     compute_resource_param = [param for param in create.params if param.name == 'compute_resource'][0]
     provider = [param for param in compute_resource_param.params if param.name == 'provider'][0]
-    assert compute_resource in provider.description
+    return provider.description
+
+
+@pytest.mark.parametrize("compute_resource", ['EC2', 'Libvirt', 'Openstack', 'Vmware'])
+def test_foreman_compute_resources_built_in(provider_description, compute_resource):
+    assert compute_resource in provider_description
+
+
+@pytest.mark.feature('azure-rm')
+def test_foreman_compute_resources_azure_rm(provider_description):
+    assert 'AzureRm' in provider_description
+
+
+@pytest.mark.feature('google')
+def test_foreman_compute_resources_google(provider_description):
+    assert 'GCE' in provider_description

--- a/tests/feature/foreman/plugins_test.py
+++ b/tests/feature/foreman/plugins_test.py
@@ -1,7 +1,16 @@
 import pytest
 
 
-@pytest.mark.parametrize("foreman_plugin", ['foreman_azure_rm', 'foreman_google'])
-def test_foreman_compute_resources(foremanapi, foreman_plugin):
-    plugins = [plugin['name'] for plugin in foremanapi.list('plugins')]
-    assert foreman_plugin in plugins
+@pytest.fixture
+def foreman_plugins(foremanapi):
+    return [plugin['name'] for plugin in foremanapi.list('plugins')]
+
+
+@pytest.mark.feature('azure-rm')
+def test_foreman_compute_resources_azure_rm(foreman_plugins):
+    assert 'foreman_azure_rm' in foreman_plugins
+
+
+@pytest.mark.feature('google')
+def test_foreman_compute_resources_google(foreman_plugins):
+    assert 'foreman_google' in foreman_plugins


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

While developing https://github.com/theforeman/foremanctl/pull/511 I wanted to deploy a plain Foreman without any plugin. I noticed these tests failed. These features are optional and they should only run when the features are present.

#### What are the changes introduced in this pull request?

* The compute resource tests are split into dedicated functions
* Where optional, the providers are properly marked by their feature.

#### How to test this pull request

Steps to reproduce:

* Deploy without azure-rm and google; verify all the test suite passes
* Deploy with azure-rm and google; verify all the test suite passes and it runs all tests

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)