### PR TITLE
Mark tests with the appropriate feature

### DIFF
--- a/tests/feature/foreman/base_test.py
+++ b/tests/feature/foreman/base_test.py
@@ -45,6 +45,7 @@ def test_foreman_status_cache(foreman_status):
     assert foreman_status['results']['foreman']['cache']['servers'][0]['status'] == 'ok'
 
 
+@pytest.mark.feature('katello')
 @pytest.mark.parametrize("katello_service", ['candlepin', 'candlepin_auth', 'foreman_tasks', 'katello_events', 'pulp3', 'pulp3_content'])
 def test_katello_services_status(foreman_status, katello_service):
     assert foreman_status['results']['katello']['services'][katello_service]['status'] == 'ok'

--- a/tests/feature/katello/candlepin_test.py
+++ b/tests/feature/katello/candlepin_test.py
@@ -1,8 +1,3 @@
-import pytest
-
-pytestmark = pytest.mark.feature('katello')
-
-
 def assert_secret_content(server, secret_name, secret_value):
     secret = server.run(f'podman secret inspect --format {"{{.SecretData}}"} --showsecret {secret_name}')
     assert secret.succeeded


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

As part of https://github.com/theforeman/foremanctl/pull/511 I've been looking at deploying Foreman without Katello. This properly marks tests so they're only executed when the katello feature is present.

#### What are the changes introduced in this pull request?

* It adds the katello feature marker to tests that require Katello

#### How to test this pull request

Steps to reproduce:

* Deploy Foreman with Katello and verify the tests still run

Deployment without Katello isn't supported yet, so no need to test that yet.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)