### PR TITLE
Revert "Don't generate sosreports when running with fapolicyd"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,10 +172,10 @@ jobs:
           name: smoker-${{ env.ARTIFACT_SUFFIX }}
           path: "/home/runner/smoker/report/"
       - name: Generate sos reports
-        if: ${{ always() && matrix.security != 'fapolicyd' }}
+        if: ${{ always() }}
         run: ./forge sos
       - name: Archive sos reports
-        if: ${{ always() && matrix.security != 'fapolicyd' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: sosreport-${{ env.ARTIFACT_SUFFIX }}


### PR DESCRIPTION

#### Why are you introducing these changes? (Problem description, related links)

This reverts commit a50989c529d3cc3fd510d6ea5918b7acb6954314.

fapolicyd 1.6-2 is in EL9, fixing the issue

#### What are the changes introduced in this pull request?

*

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
