### PR TITLE
Revert "Downgrade openssl on CentOS Stream 9 VMs in CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,12 +105,6 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start --vms "quadlet client ${{ matrix.database == 'external' && 'database' || '' }}"
-      - name: Downgrade openssl
-        if: matrix.box == 'centos/stream9'
-        run: |
-          for vm in quadlet client ${{ matrix.database == 'external' && 'database' || '' }}; do
-            vagrant ssh "$vm" -- sudo dnf downgrade -y openssl openssl-libs
-          done
       - name: Configure remote-database
         if: matrix.database == 'external'
         run: |
@@ -210,9 +204,6 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start
-      - name: Downgrade openssl
-        run: |
-          vagrant ssh quadlet -- sudo dnf downgrade -y openssl openssl-libs
       - name: Configure repositories
         run: |
           ./forge setup-repositories
@@ -255,9 +246,6 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start
-      - name: Downgrade openssl
-        run: |
-          vagrant ssh quadlet -- sudo dnf downgrade -y openssl openssl-libs
       - name: Configure repositories
         run: |
           ./forge setup-repositories
@@ -337,11 +325,6 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start --vms "quadlet client"
-      - name: Downgrade openssl
-        run: |
-          for vm in quadlet client; do
-            vagrant ssh "$vm" -- sudo dnf downgrade -y openssl openssl-libs
-          done
       - name: Configure repositories
         run: |
           ./forge setup-repositories
@@ -421,11 +404,6 @@ jobs:
       - name: Start VMs
         run: |
           ./forge vms start --vms "quadlet proxy"
-      - name: Downgrade openssl
-        run: |
-          for vm in quadlet proxy; do
-            vagrant ssh "$vm" -- sudo dnf downgrade -y openssl openssl-libs
-          done
       - name: Run image pull
         run: |
           ./foremanctl pull-images


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

This reverts commit 99e1c65724171fc169c8aec6212d06cbb065c993.

OpenSSL 3.5.7-2 is in EL9, fixing the regression

#### What are the changes introduced in this pull request?

*

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
