### PR TITLE
Run pre_install role in mock-installer

### DIFF
--- a/development/playbooks/mock-installer/mock-installer.yaml
+++ b/development/playbooks/mock-installer/mock-installer.yaml
@@ -4,4 +4,5 @@
     - quadlet
   become: true
   roles:
+    - pre_install
     - mock_foreman_installer


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

pre_install ensures things like the right PostgreSQL repos are available, which is required for the migration tests to succeed

otherwise the installation of `foreman-installer` pulls in PostgreSQL 13 clients, and backup tests fail as they require postgresql 16

See e.g. https://github.com/theforeman/foremanctl/actions/runs/29394054376/job/87283471606?pr=659

#### What are the changes introduced in this pull request?

*

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
