### PR TITLE
never use a proxy when performing the candlepin health check

### DIFF
--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -97,7 +97,7 @@
         After=valkey.service postgresql.service
         [Service]
         TimeoutStartSec=300
-    healthcheck: curl --fail --insecure https://localhost:23443/candlepin/status
+    healthcheck: curl --fail --insecure --noproxy localhost https://localhost:23443/candlepin/status
     sdnotify: healthy
 
 - name: Run daemon reload to make Quadlet create the service files


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

some environments declare a global proxy, and that usually can't reach our "localhost".

#### What are the changes introduced in this pull request?

*

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
