### PR TITLE
Simplify test infrastructure

### DIFF
--- a/development/playbooks/test/metadata.obsah.yaml
+++ b/development/playbooks/test/metadata.obsah.yaml
@@ -5,3 +5,7 @@ help: |
 variables:
   pytest_args:
     help: Pass arguments to pytest.
+  fast:
+    help: Skip tests marked as slow.
+    parameter: --fast
+    action: store_true

--- a/development/playbooks/test/test.yaml
+++ b/development/playbooks/test/test.yaml
@@ -16,7 +16,7 @@
   tasks:
     - name: Run pytest
       ansible.builtin.command:
-        cmd: "python -m pytest --durations=10 -vv {{ pytest_args | default() }}"
+        cmd: "python -m pytest --durations=10 -vv {{ '-m \"not slow\"' if fast | default(false) else '' }} {{ pytest_args | default() }}"
       args:
         chdir: "{{ inventory_dir }}/../"
       changed_when: false

--- a/development/playbooks/test/test.yaml
+++ b/development/playbooks/test/test.yaml
@@ -14,33 +14,6 @@
   hosts:
     - localhost
   tasks:
-    - name: Ensure .tmp directory exists
-      ansible.builtin.file:
-        path: "{{ inventory_dir }}/../.tmp"
-        state: directory
-        mode: "0755"
-
-    - name: Generate ssh_config from ansible inventory
-      ansible.builtin.copy:
-        dest: "{{ inventory_dir }}/../.tmp/ssh-config"
-        content: |
-          {% for host in groups['all'] %}
-          Host {{ host }}
-            HostName {{ hostvars[host]['ansible_host'] | default(host) }}
-            User {{ hostvars[host]['ansible_user'] | default('vagrant') }}
-            Port {{ hostvars[host]['ansible_port'] | default('22') }}
-            UserKnownHostsFile /dev/null
-            StrictHostKeyChecking no
-            PasswordAuthentication no
-          {% if hostvars[host]['ansible_ssh_private_key_file'] is defined %}
-            IdentityFile {{ hostvars[host]['ansible_ssh_private_key_file'] }}
-          {% endif %}
-            IdentitiesOnly yes
-            LogLevel FATAL
-
-          {% endfor %}
-        mode: "0644"
-
     - name: Run pytest
       ansible.builtin.command:
         cmd: "python -m pytest --durations=10 -vv {{ pytest_args | default() }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import uuid
@@ -17,6 +18,7 @@ from requests.adapters import HTTPAdapter
 
 SSH_CONFIG = './.tmp/ssh-config'
 OBSAH_STATE = os.environ.get('OBSAH_STATE', '.var/lib/foremanctl')
+OBSAH_INVENTORY = os.environ.get('OBSAH_INVENTORY', 'inventories/')
 PARAMETERS_FILE = os.path.join(OBSAH_STATE, 'parameters.yaml')
 FLAVOR_TESTS_DIR = py.path.local(__file__).dirpath() / 'flavor'
 FLAVOR_TESTS_DIR_OVERRIDES = {
@@ -87,6 +89,39 @@ def user_enabled_features(pytestconfig):
 @pytest.fixture(scope="module")
 def available_features(pytestconfig):
     return pytestconfig.user_parameters.available_features
+
+
+@pytest.fixture(scope="session", autouse=True)
+def generate_ssh_config():
+    if not os.path.exists(OBSAH_INVENTORY):
+        return
+    try:
+        result = subprocess.run(
+            ['ansible-inventory', '--list', '--inventory', OBSAH_INVENTORY],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return
+    inv = json.loads(result.stdout)
+    hostvars = inv.get('_meta', {}).get('hostvars', {})
+    if not hostvars:
+        return
+    os.makedirs(os.path.dirname(SSH_CONFIG), exist_ok=True)
+    with open(SSH_CONFIG, 'w') as f:
+        for host, vars in hostvars.items():
+            if vars.get('ansible_connection') == 'local':
+                continue
+            f.write(f"Host {host}\n")
+            f.write(f"  HostName {vars.get('ansible_host', host)}\n")
+            f.write(f"  User {vars.get('ansible_user', 'vagrant')}\n")
+            f.write(f"  Port {vars.get('ansible_port', 22)}\n")
+            f.write("  UserKnownHostsFile /dev/null\n")
+            f.write("  StrictHostKeyChecking no\n")
+            f.write("  PasswordAuthentication no\n")
+            if key := vars.get('ansible_ssh_private_key_file'):
+                f.write(f"  IdentityFile {key}\n")
+            f.write("  IdentitiesOnly yes\n")
+            f.write("  LogLevel FATAL\n\n")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Simplify the `forge test` command and allow running non-slow marked tests.

#### What are the changes introduced in this pull request?

* Move ssh-config generation from `forge test` into a session-scoped autouse
  pytest fixture (`generate_ssh_config` in `tests/conftest.py`). The fixture
  reads the static inventory (defaulting to `inventories/local_vagrant`,
  overridable via `OBSAH_INVENTORY`) and writes `.tmp/ssh-config` before any
  test runs, so pytest can be invoked directly without going through forge.

#### How to test this pull request

Steps to reproduce:

* Confirm `forge test` still works (now a thin wrapper around pytest):
  ```
  ./forge test
  ```

* Run fast tests:
  ```
  ./forge test --fast
  ```

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
