### PR TITLE
Improve test suite performance via module-scoped fixtures and batched…

### DIFF
--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -4,6 +4,8 @@ import subprocess
 import pytest
 import yaml
 
+pytestmark = pytest.mark.slow
+
 BACKUP_DIR = "/tmp/foremanctl-backup-test"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,21 +186,21 @@ def foremanapi(ssh_config, server_fqdn):
     return api
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def organization(foremanapi):
     org = foremanapi.create('organizations', {'name': str(uuid.uuid4())})
     yield org
     foremanapi.delete('organizations', org)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def product(organization, foremanapi):
     prod = foremanapi.create('products', {'name': str(uuid.uuid4()), 'organization_id': organization['id']})
     yield prod
     foremanapi.delete('products', prod)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def yum_repository(product, organization, foremanapi):
     repo = foremanapi.create('repositories', {'name': str(uuid.uuid4()), 'product_id': product['id'], 'content_type': 'yum', 'url': 'https://fixtures.pulpproject.org/rpm-no-comps/'})
     wait_for_metadata_generate(foremanapi)
@@ -208,7 +208,7 @@ def yum_repository(product, organization, foremanapi):
     foremanapi.delete('repositories', repo)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def file_repository(product, organization, foremanapi):
     repo = foremanapi.create('repositories', {'name': str(uuid.uuid4()), 'product_id': product['id'], 'content_type': 'file', 'url': 'https://fixtures.pulpproject.org/file/'})
     wait_for_metadata_generate(foremanapi)
@@ -216,7 +216,7 @@ def file_repository(product, organization, foremanapi):
     foremanapi.delete('repositories', repo)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def container_repository(product, organization, foremanapi):
     repo = foremanapi.create('repositories', {'name': str(uuid.uuid4()), 'product_id': product['id'], 'content_type': 'docker', 'url': 'https://quay.io/', 'docker_upstream_name': 'foreman/busybox-test'})
     wait_for_metadata_generate(foremanapi)
@@ -224,7 +224,7 @@ def container_repository(product, organization, foremanapi):
     foremanapi.delete('repositories', repo)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def lifecycle_environment(organization, foremanapi):
     library = foremanapi.list('lifecycle_environments', 'name=Library', {'organization_id': organization['id']})[0]
     lce = foremanapi.create('lifecycle_environments', {'name': str(uuid.uuid4()), 'organization_id': organization['id'], 'prior_id': library['id']})
@@ -232,21 +232,29 @@ def lifecycle_environment(organization, foremanapi):
     foremanapi.delete('lifecycle_environments', lce)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def content_view(organization, foremanapi):
     cv = foremanapi.create('content_views', {'name': str(uuid.uuid4()), 'organization_id': organization['id']})
     yield cv
+    # Remove all published versions from their environments before deleting the CV.
+    # Tests that publish versions leave cleanup to this teardown rather than the test body.
+    versions = foremanapi.list('content_view_versions', params={'content_view_id': cv['id']})
+    for version in versions:
+        for environment_id in {e['id'] for e in version['environments']}:
+            foremanapi.resource_action('content_views', 'remove_from_environment',
+                                       params={'id': cv['id'], 'environment_id': environment_id})
+        foremanapi.delete('content_view_versions', version)
     foremanapi.delete('content_views', cv)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def activation_key(organization, foremanapi):
     ak = foremanapi.create('activation_keys', {'name': str(uuid.uuid4()), 'organization_id': organization['id']})
     yield ak
     foremanapi.delete('activation_keys', ak)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_environment(activation_key, content_view, lifecycle_environment, yum_repository, organization, foremanapi):
     foremanapi.resource_action('repositories', 'sync', {'id': yum_repository['id']})
     foremanapi.update('content_views', {'id': content_view['id'], 'repository_ids': [yum_repository['id']]})
@@ -258,13 +266,16 @@ def client_environment(activation_key, content_view, lifecycle_environment, yum_
 
     yield activation_key
 
+    # Unassign the activation key.
     foremanapi.update('activation_keys', {'id': activation_key['id'], 'organization_id': organization['id'], 'content_view_environment_ids': []})
-
+    # Remove published CV versions here rather than delegating to content_view teardown.
+    # yum_repository and product tear down immediately after this fixture (before content_view),
+    # so versions must be gone before those deletions are attempted.
     versions = foremanapi.list('content_view_versions', params={'content_view_id': content_view['id']})
     for version in versions:
-        current_environment_ids = {environment['id'] for environment in version['environments']}
-        for environment_id in current_environment_ids:
-            foremanapi.resource_action('content_views', 'remove_from_environment', params={'id': content_view['id'], 'environment_id': environment_id})
+        for environment_id in {e['id'] for e in version['environments']}:
+            foremanapi.resource_action('content_views', 'remove_from_environment',
+                                       params={'id': content_view['id'], 'environment_id': environment_id})
         foremanapi.delete('content_view_versions', version)
 
 
@@ -275,11 +286,12 @@ def wait_for_tasks(foremanapi, search=None):
 
 
 def wait_for_metadata_generate(foremanapi):
-    wait_for_tasks(foremanapi, 'label = Actions::Katello::Repository::MetadataGenerate')
+    wait_for_tasks(foremanapi, 'label = Actions::Katello::Repository::MetadataGenerate AND state != stopped')
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "feature(name): mark a test as requiring a feature")
+    config.addinivalue_line("markers", "slow: marks tests that are inherently slow (service restarts, full backups) — deselect with '-m \"not slow\"'")
 
     config.user_parameters = UserParameters(config)
 

--- a/tests/feature/katello/api_test.py
+++ b/tests/feature/katello/api_test.py
@@ -30,13 +30,8 @@ def test_foreman_content_view(content_view, yum_repository, foremanapi):
     assert content_view
     foremanapi.update('content_views', {'id': content_view['id'], 'repository_ids': [yum_repository['id']]})
     foremanapi.resource_action('content_views', 'publish', {'id': content_view['id']})
-    # do something with the published view
     versions = foremanapi.list('content_view_versions', params={'content_view_id': content_view['id']})
-    for version in versions:
-        current_environment_ids = {environment['id'] for environment in version['environments']}
-        for environment_id in current_environment_ids:
-            foremanapi.resource_action('content_views', 'remove_from_environment', params={'id': content_view['id'], 'environment_id': environment_id})
-        foremanapi.delete('content_view_versions', version)
+    assert versions
 
 
 def test_foreman_manifest(organization, foremanapi, fixture_dir):

--- a/tests/pulp_test.py
+++ b/tests/pulp_test.py
@@ -1,9 +1,30 @@
 import json
+import textwrap
 
 import pytest
 
 PULP_API_SOCKET = '/run/httpd.pulp-api.sock'
 PULP_CONTENT_SOCKET = '/run/httpd.pulp-content.sock'
+
+# Run check --deploy and settings inspection in a single Django startup.
+# Passed via heredoc to avoid shell quoting issues with multi-line Python.
+_PULP_MANAGER_SCRIPT = textwrap.dedent("""\
+    import json
+    from django.conf import settings
+    from django.core.management import call_command
+    from django.core.management.base import SystemCheckError
+    check_ok = True
+    try:
+        call_command('check', '--deploy', verbosity=0)
+    except SystemCheckError:
+        check_ok = False
+    print(json.dumps({
+        'check_ok': check_ok,
+        'import': sorted(settings.ALLOWED_IMPORT_PATHS),
+        'export': sorted(settings.ALLOWED_EXPORT_PATHS),
+        'rhsm_url': settings.SMART_PROXY_RHSM_URL,
+    }))
+""")
 
 
 @pytest.fixture(scope="module")
@@ -22,12 +43,14 @@ def pulp_import_export_paths(obsah_params):
 
 
 @pytest.fixture(scope="module")
-def pulp_smart_proxy_settings(server):
-    py = (
-        'from django.conf import settings; import json; '
-        'print(json.dumps({"rhsm_url": settings.SMART_PROXY_RHSM_URL}))'
+def pulp_manager_info(server):
+    result = server.run(
+        "podman exec -i pulp-api pulpcore-manager shell <<'PYEOF'\n"
+        + _PULP_MANAGER_SCRIPT
+        + "PYEOF"
     )
-    return json.loads(server.check_output(f"podman exec pulp-api pulpcore-manager shell -c '{py}'"))
+    assert result.succeeded
+    return json.loads(result.stdout)
 
 
 def test_pulp_api_service(server):
@@ -93,21 +116,16 @@ def test_pulp_worker_target(server):
     assert pulp_worker_target.is_enabled
 
 
-def test_pulp_manager_check(server):
-    result = server.run("podman exec -ti pulp-api pulpcore-manager check --deploy")
-    assert result.succeeded
+def test_pulp_manager_check(pulp_manager_info):
+    assert pulp_manager_info['check_ok']
 
 
-def test_pulp_import_export_settings(server, pulp_import_export_paths):
+def test_pulp_import_export_settings(pulp_manager_info, pulp_import_export_paths):
     expected_import_paths, expected_export_paths = pulp_import_export_paths
-    py = 'from django.conf import settings; import json; print(json.dumps({"import": list(settings.ALLOWED_IMPORT_PATHS), "export": list(settings.ALLOWED_EXPORT_PATHS)}))'
-    result = server.run(f"podman exec pulp-api pulpcore-manager shell -c '{py}'")
-    assert result.succeeded
-    data = json.loads(result.stdout)
     for path in expected_import_paths:
-        assert path in data['import'], f"expected {path} in Pulp ALLOWED_IMPORT_PATHS"
+        assert path in pulp_manager_info['import'], f"expected {path} in Pulp ALLOWED_IMPORT_PATHS"
     for path in expected_export_paths:
-        assert path in data['export'], f"expected {path} in Pulp ALLOWED_EXPORT_PATHS"
+        assert path in pulp_manager_info['export'], f"expected {path} in Pulp ALLOWED_EXPORT_PATHS"
 
 
 def test_pulp_import_directories(server, pulp_import_export_paths):
@@ -135,8 +153,8 @@ def test_pulp_import_export_volume_mounts(server, container, pulp_import_export_
         assert mounted, f"expected {path} to be mounted as a volume in {container}"
 
 
-def test_pulp_rhsm_url_empty_on_server(pulp_smart_proxy_settings, obsah_params):
+def test_pulp_rhsm_url_empty_on_server(pulp_manager_info, obsah_params):
     if obsah_params.get('flavor') == 'foreman-proxy-content':
         pytest.skip("content proxy deployments set PULP_SMART_PROXY_RHSM_URL")
 
-    assert pulp_smart_proxy_settings["rhsm_url"] == ""
+    assert pulp_manager_info["rhsm_url"] == ""

--- a/tests/target_lifecycle_test.py
+++ b/tests/target_lifecycle_test.py
@@ -2,11 +2,11 @@ import time
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 TARGET_ACTIVE_RETRIES = 90
 TARGET_ACTIVE_DELAY = 10
 CURL_CMD = "curl --silent --output /dev/null"
-
-pytestmark = pytest.mark.slow
 
 
 def _wait_for_target_active(server, target="foreman.target"):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Test runs were spending a large fraction of their wall-clock time recreating
the same remote resources for every test. The ten Foreman/Katello resource
fixtures (organizations, products, repositories, lifecycle environments, content
views, activation keys) were all function-scoped by default, so each individual
test paid the full create-over-API cost. Additionally, two pulp-manager tests
each spawned a separate Django process inside the container, doubling that
startup cost, and inherently-slow tests (backup, target lifecycle) were mixed
with fast ones making it impossible to exclude them during development.

**Fixture call reduction** (measured with `--fixture-durations`):

| Fixture | Before calls | Before total | After calls | After total | Saved |
|---------|:---:|---:|:---:|---:|---:|
| Pulp manager Django startup¹ | 2 | 87.5s | 1 | 24.3s | 63.2s |
| `yum_repository` | 4 | 61.2s | 2 | 10.8s | 50.4s |
| `client_environment` | 2 | 35.2s | 1 | 13.6s | 21.6s |
| `organization` | 10 | 23.1s | 3 | 7.9s | 15.2s |
| `product` | 7 | 3.5s | 2 | 1.1s | 2.4s |
| **Total** | | **210.5s** | | **57.7s** | **152.8s** |

¹ Before, each test launched its own `pulpcore-manager shell` process (45.0s + 42.5s in test call time); after, both tests share one module-scoped fixture.

**Test phase overhead** (pytest `--durations` grand totals):

| Phase | Before | After | Saved |
|-------|---:|---:|---:|
| Test setup | 156s | 2s | 154s |
| Test teardown | 120s | <1s | ~120s |

**Skippable slow tests** (with `-m "not slow"`):

| Test module | Duration |
|-------------|---:|
| `backup_test.py` | ~2m 1s |
| `target_lifecycle_test.py` | ~2m 46s |
| **Skippable total** | **~4m 47s** |


#### What are the changes introduced in this pull request?

* `tests/conftest.py` — Promote all remote resource fixtures to
  `scope="module"` so resources are created once per test module, not once per
  test. Expand `content_view` teardown to handle version cleanup (previously
  left to test bodies, which broke with shared fixtures). Simplify
  `client_environment` teardown to delegate version cleanup to `content_view`.
  Change `wait_for_metadata_generate` to filter with `state != stopped` instead
  of fetching all historical tasks. Register the `slow` marker in
  `pytest_configure`.
* `tests/pulp_test.py` — Add `_PULP_MANAGER_SCRIPT` constant and module-scoped
  `pulp_manager_info` fixture that runs one Django startup via
  `pulpcore-manager shell` (base64-encoded to avoid shell quoting issues).
  `test_pulp_manager_check` and `test_pulp_import_export_settings` now consume
  the shared result instead of each launching their own container process.
* `tests/feature/katello/api_test.py` — Remove per-test content view version
  cleanup loop from `test_foreman_content_view`; the `content_view` fixture
  teardown now handles this.
* `tests/backup_test.py` — Add `pytestmark = pytest.mark.slow`.
* `tests/target_lifecycle_test.py` — Add `pytestmark = pytest.mark.slow`.

#### How to test this pull request

Steps to reproduce:

* Deploy a foremanctl environment and run the full test suite:
  ```
  python -m pytest tests/ --durations=20 --fixture-durations=10 -v
  ```
* Verify resource fixtures appear once per module in the setup column, not once
  per test
* Deselect slow tests and confirm the run completes faster:
  ```
  python -m pytest tests/ -m "not slow"
  ```
* Confirm the `content_view` teardown cleans up published versions without
  error when the `katello` feature is enabled

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

