### PR TITLE
Rename name of Microsoft Azure plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,7 @@ jobs:
           ./foremanctl deploy \
             --add-feature hammer \
             --add-feature foreman-proxy \
-            --add-feature azure-rm \
+            --add-feature azure \
             --add-feature google \
             --add-feature remote-execution \
             --add-feature ansible \
@@ -266,7 +266,7 @@ jobs:
           ./foremanctl deploy \
             --add-feature hammer \
             --add-feature foreman-proxy \
-            --add-feature azure-rm \
+            --add-feature azure \
             --add-feature google \
             --add-feature remote-execution
       - name: Stop services
@@ -349,7 +349,7 @@ jobs:
             --tuning development \
             --add-feature hammer \
             --add-feature foreman-proxy \
-            --add-feature azure-rm \
+            --add-feature azure \
             --add-feature google \
             --add-feature remote-execution \
             --add-feature webhooks

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -25,8 +25,8 @@ google:
   hammer: foreman_google
   foreman:
     plugin_name: foreman_google
-azure-rm:
-  description: Azure Resource Manager plugin for Foreman
+azure:
+  description: Microsoft Azure plugin for Foreman
   hammer: foreman_azure_rm
   foreman:
     plugin_name: foreman_azure_rm

--- a/tests/feature/foreman/compute_resources_test.py
+++ b/tests/feature/foreman/compute_resources_test.py
@@ -15,7 +15,7 @@ def test_foreman_compute_resources_built_in(provider_description, compute_resour
     assert compute_resource in provider_description
 
 
-@pytest.mark.feature('azure-rm')
+@pytest.mark.feature('azure')
 def test_foreman_compute_resources_azure_rm(provider_description):
     assert 'AzureRm' in provider_description
 

--- a/tests/feature/foreman/plugins_test.py
+++ b/tests/feature/foreman/plugins_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.feature('azure-rm')
+@pytest.mark.feature('azure')
 def test_foreman_compute_resources_azure_rm(foreman_plugins):
     assert 'foreman_azure_rm' in foreman_plugins
 


### PR DESCRIPTION
The docs call this plugin "Microsoft Azure". Only Foreman/Katello WebUI calls it, on Settings > About > Available Providers, "Azure Resource Manager".

Refs PR 5069 in foreman-documentation

#### Why are you introducing these changes? (Problem description, related links)

A long time ago, we renamed it in the docs from "Microsoft Azure Resource Manager" to "Microsoft Azure", partly due to the unwieldy name.

#### What are the changes introduced in this pull request?

* Rename the name (not ID etc) of the plugin

#### How to test this pull request

Steps to reproduce:

* ?

#### Checklist

* [ ] Tests added/updated (if applicable) -> No, no idea if necessary. grep indicated that there's no need in _this_ repo.
* [ ] Documentation updated (if applicable) -> does not apply IMO
