### PR TITLE
Deploy foreman-certs from source instead of unmerged PR COPR build

### DIFF
--- a/development/playbooks/mock-installer/mock-installer.yaml
+++ b/development/playbooks/mock-installer/mock-installer.yaml
@@ -4,5 +4,6 @@
     - quadlet
   become: true
   roles:
+    - setup_repositories
     - pre_install
     - mock_foreman_installer

--- a/development/playbooks/setup-repositories/setup-repositories.yaml
+++ b/development/playbooks/setup-repositories/setup-repositories.yaml
@@ -3,29 +3,5 @@
   hosts:
     - quadlet
   become: true
-  tasks:
-    - name: Setup Puppet repositories
-      ansible.builtin.include_role:
-        name: theforeman.operations.openvox_repositories
-      vars:
-        foreman_openvox_repositories_version: "8"
-      when:
-        - ansible_distribution_major_version == '9'
-
-    - name: Setup Foreman repositories
-      ansible.builtin.include_role:
-        name: theforeman.operations.foreman_repositories
-      vars:
-        foreman_repositories_version: nightly
-        foreman_repositories_katello_version: nightly
-      when:
-        - ansible_distribution_major_version == '9'
-
-    - name: Enable hammer-el10 copr
-      community.general.copr:
-        host: copr.fedorainfracloud.org
-        state: enabled
-        name: evgeni/hammer-el10
-        chroot: rhel-10-x86_64
-      when:
-        - ansible_distribution_major_version == '10'
+  roles:
+    - setup_repositories

--- a/development/roles/mock_foreman_installer/files/foreman-certs
+++ b/development/roles/mock_foreman_installer/files/foreman-certs
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'kafo'
+
+CONFIG_DIR = '/usr/share/foreman-installer/foreman-certs/scenarios.d/'.freeze
+
+@result = Kafo::KafoConfigure.run
+exit((@result.nil? || @result.exit_code == 2) ? 0 : @result.exit_code)

--- a/development/roles/mock_foreman_installer/files/foreman-certs-answers.yaml
+++ b/development/roles/mock_foreman_installer/files/foreman-certs-answers.yaml
@@ -1,0 +1,6 @@
+certs:
+  generate: true
+  regenerate: true
+  deploy: false
+  group: root
+certs::generate: true

--- a/development/roles/mock_foreman_installer/files/foreman-certs.yaml
+++ b/development/roles/mock_foreman_installer/files/foreman-certs.yaml
@@ -1,0 +1,27 @@
+---
+:answer_file: "/usr/share/foreman-installer/foreman-certs/scenarios.d/foreman-certs-answers.yaml"
+:color_of_background: :dark
+:colors: true
+:custom: {}
+:description: Generate Foreman certificates
+:dont_save_answers: true
+:enabled: true
+:facts: {}
+:hook_dirs: []
+:installer_dir: "/usr/share/foreman-installer/foreman-certs"
+:log_dir: "/var/log/foreman-installer"
+:log_level: :debug
+:log_name: foreman-certs.log
+:low_priority_modules: []
+:mapping: {}
+:module_dirs: "/usr/share/foreman-installer/modules"
+:name: foreman-certs
+:no_prefix: true
+:order:
+  - certs
+  - certs:generate
+:parser_cache_path: "/usr/share/foreman-installer/parser_cache/foreman-certs.yaml"
+:skip_puppet_version_check: false
+:store_dir: ''
+:verbose: false
+:verbose_log_level: debug

--- a/development/roles/mock_foreman_installer/tasks/main.yml
+++ b/development/roles/mock_foreman_installer/tasks/main.yml
@@ -27,7 +27,7 @@
     dest: /usr/share/foreman-installer/foreman-certs/scenarios.d/foreman-certs-answers.yaml
     mode: '0644'
 
-- name: Install puppet-strings gem
+- name: Install openvox-strings gem
   ansible.builtin.command: /opt/puppetlabs/puppet/bin/gem install openvox-strings
   changed_when: false
 

--- a/development/roles/mock_foreman_installer/tasks/main.yml
+++ b/development/roles/mock_foreman_installer/tasks/main.yml
@@ -1,16 +1,36 @@
 ---
-- name: Enable foreman-installer PR 935 Copr repo
-  community.general.copr:
-    host: copr.fedorainfracloud.org
-    state: enabled
-    name: packit/theforeman-foreman-installer-935
-    chroot: rhel-9-x86_64
-
 - name: Install foreman-installer package
   ansible.builtin.package:
     name: foreman-installer-katello
 
-# utilize https://github.com/theforeman/foreman-installer/pull/935
+- name: Create foreman-certs scenarios directory
+  ansible.builtin.file:
+    path: /usr/share/foreman-installer/foreman-certs/scenarios.d
+    state: directory
+    mode: '0755'
+
+- name: Deploy foreman-certs binary
+  ansible.builtin.copy:
+    src: foreman-certs
+    dest: /usr/sbin/foreman-certs
+    mode: '0755'
+
+- name: Deploy foreman-certs scenario config
+  ansible.builtin.copy:
+    src: foreman-certs.yaml
+    dest: /usr/share/foreman-installer/foreman-certs/scenarios.d/foreman-certs.yaml
+    mode: '0644'
+
+- name: Deploy foreman-certs answers file
+  ansible.builtin.copy:
+    src: foreman-certs-answers.yaml
+    dest: /usr/share/foreman-installer/foreman-certs/scenarios.d/foreman-certs-answers.yaml
+    mode: '0644'
+
+- name: Install puppet-strings gem
+  ansible.builtin.command: /opt/puppetlabs/puppet/bin/gem install openvox-strings
+  changed_when: false
+
 - name: Generate certs
   ansible.builtin.command: foreman-certs --apache true --foreman true --candlepin true --iop true
   changed_when: false

--- a/development/roles/setup_repositories/tasks/main.yml
+++ b/development/roles/setup_repositories/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Setup Puppet repositories
+- name: Setup OpenVox repositories
   ansible.builtin.include_role:
     name: theforeman.operations.openvox_repositories
   vars:

--- a/development/roles/setup_repositories/tasks/main.yml
+++ b/development/roles/setup_repositories/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Setup Puppet repositories
+  ansible.builtin.include_role:
+    name: theforeman.operations.openvox_repositories
+  vars:
+    foreman_openvox_repositories_version: "8"
+  when:
+    - ansible_distribution_major_version == '9'
+
+- name: Setup Foreman repositories
+  ansible.builtin.include_role:
+    name: theforeman.operations.foreman_repositories
+  vars:
+    foreman_repositories_version: nightly
+    foreman_repositories_katello_version: nightly
+  when:
+    - ansible_distribution_major_version == '9'
+
+- name: Enable hammer-el10 copr
+  community.general.copr:
+    host: copr.fedorainfracloud.org
+    state: enabled
+    name: evgeni/hammer-el10
+    chroot: rhel-10-x86_64
+  when:
+    - ansible_distribution_major_version == '10'


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

foreman-installer PR #935 adds the `foreman-certs` command but is not yet merged, so the mock-installer role was pinned to a COPR build of that PR. This is fragile — COPR builds are ephemeral and tied to a specific PR state. The binary and its Kafo scenario config can be deployed as role files instead, relying only on the nightly `foreman-installer-katello` package for puppet, modules, and `kafo-export-params`.

Additionally, repository setup was inlined in the `setup-repositories` playbook and not reusable, requiring `forge setup-repositories` to be run before `forge mock-installer`.

https://github.com/theforeman/foreman-installer/pull/935

#### What are the changes introduced in this pull request?

* Remove the COPR repo task from `mock_foreman_installer`
* Add `files/foreman-certs`, `files/foreman-certs.yaml`, and `files/foreman-certs-answers.yaml` to the role — equivalent to what `rake install` produces for the `foreman-certs` scenario in PR #935
* Install `puppet-strings` into Puppet's gem environment before running `foreman-certs` (required by `kafo-export-params` for parser cache generation)
* Extract repository setup into `development/roles/setup_repositories` and refactor `setup-repositories.yaml` to delegate to it
* Add `setup_repositories` as the first role in `mock-installer.yaml` so `forge mock-installer` is self-contained

#### How to test this pull request

Steps to reproduce:

* Run `./forge mock-installer` on a fresh VM without running `./forge setup-repositories` first
* Verify certificates are generated in `/root/ssl-build/`
* Verify `/etc/foreman-installer/scenarios.d/` contains the fixture files
* Verify `/usr/sbin/foreman-certs` is present and executable

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
