### PR TITLE
store the CA private key unencrypted

### DIFF
--- a/src/roles/candlepin/tasks/certs.yml
+++ b/src/roles/candlepin/tasks/certs.yml
@@ -9,16 +9,11 @@
   notify:
     - Restart candlepin
 
-- name: Decrypt Candlepin CA key
-  ansible.builtin.command: openssl pkey -in "{{ candlepin_ca_key }}" -passin "file:{{ candlepin_ca_key_password }}"
-  register: _candlepin_ca_key
-  changed_when: false
-
 - name: Create the podman secret for Candlepin CA key
   containers.podman.podman_secret:
     state: present
     name: candlepin-ca-key
-    data: "{{ _candlepin_ca_key.stdout }}"
+    path: "{{ candlepin_ca_key }}"
     labels:
       app: candlepin
   notify:

--- a/src/roles/certificates/tasks/ca.yml
+++ b/src/roles/certificates/tasks/ca.yml
@@ -4,25 +4,45 @@
     path: "{{ certificates_ca_directory_certs }}/ca.crt"
   register: _certificates_ca_cert
 
+- name: 'Check for an existing CA key'
+  ansible.builtin.stat:
+    path: "{{ certificates_ca_directory_keys }}/ca.key"
+  register: _certificates_existing_ca_key
+
+- name: 'Detect whether the existing CA key is password-encrypted'
+  ansible.builtin.command:
+    cmd: "grep -q ENCRYPTED {{ certificates_ca_directory_keys }}/ca.key"
+  register: _certificates_ca_key_encrypted
+  changed_when: false
+  failed_when: false
+  when: _certificates_existing_ca_key.stat.exists
+
+- name: 'Decrypt a legacy password-encrypted CA key in place'
+  community.crypto.openssl_privatekey_convert:
+    src_path: "{{ certificates_ca_directory_keys }}/ca.key"
+    src_passphrase: "{{ certificates_ca_password }}"
+    dest_path: "{{ certificates_ca_directory_keys }}/ca.key"
+    format: pkcs8
+    mode: '0600'
+  when:
+    - _certificates_existing_ca_key.stat.exists
+    - (_certificates_ca_key_encrypted.rc | default(1)) == 0
+  no_log: true
+
+- name: 'Remove the obsolete CA key password file'
+  ansible.builtin.file:
+    path: "{{ certificates_ca_directory_keys }}/ca.pwd"
+    state: absent
+
 - name: 'Generate CA'
   when:
     - (not _certificates_ca_cert.stat.exists or certificates_ca_renew)
   block:
-    - name: 'Create CA key password file'
-      ansible.builtin.copy:
-        content: "{{ certificates_ca_password }}"
-        dest: "{{ certificates_ca_directory_keys }}/ca.pwd"
-        owner: root
-        group: root
-        mode: '0600'
-      no_log: true
-
     - name: 'Create CA private key'
       community.crypto.openssl_privatekey:
         path: "{{ certificates_ca_directory_keys }}/ca.key"
         type: "{{ certificates_algorithm_type }}"
         size: "{{ certificates_algorithm_size }}"
-        passphrase: "{{ certificates_ca_password }}"
         owner: root
         group: root
         mode: '0600'
@@ -31,7 +51,6 @@
       community.crypto.openssl_csr:
         path: "{{ certificates_ca_directory_requests }}/ca.csr"
         privatekey_path: "{{ certificates_ca_directory_keys }}/ca.key"
-        privatekey_passphrase: "{{ certificates_ca_password }}"
         common_name: "{{ certificates_ca_subject }}"
         use_common_name_for_san: false
         basic_constraints:
@@ -49,7 +68,6 @@
         path: "{{ certificates_ca_directory_certs }}/ca.crt"
         csr_path: "{{ certificates_ca_directory_requests }}/ca.csr"
         privatekey_path: "{{ certificates_ca_directory_keys }}/ca.key"
-        privatekey_passphrase: "{{ certificates_ca_password }}"
         provider: selfsigned
         selfsigned_not_after: "+{{ certificates_ca_validity_days }}d"
         force: "{{ certificates_ca_renew | bool }}"

--- a/src/roles/certificates/tasks/issue.yml
+++ b/src/roles/certificates/tasks/issue.yml
@@ -32,7 +32,6 @@
         provider: ownca
         ownca_path: "{{ certificates_ca_directory_certs }}/ca.crt"
         ownca_privatekey_path: "{{ certificates_ca_directory_keys }}/ca.key"
-        ownca_privatekey_passphrase: "{{ certificates_ca_password }}"
         ownca_not_after: "+{{ certificates_validity_days }}d"
         force: "{{ certificates_renew | bool }}"
 
@@ -63,6 +62,5 @@
     provider: ownca
     ownca_path: "{{ certificates_ca_directory }}/certs/ca.crt"
     ownca_privatekey_path: "{{ certificates_ca_directory }}/private/ca.key"
-    ownca_privatekey_passphrase: "{{ certificates_ca_password }}"
     ownca_not_after: "+{{ certificates_validity_days }}d"
     force: "{{ certificates_renew | bool }}"

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -8,7 +8,6 @@ certificates_ca_password: "{{ lookup('ansible.builtin.password', certificates_ca
 candlepin_oauth_secret_file: "{{ obsah_state_path }}/candlepin-oauth-secret"
 candlepin_oauth_secret: "{{ lookup('ansible.builtin.password', candlepin_oauth_secret_file, chars=['ascii_letters', 'digits'], length=32) }}"
 
-candlepin_ca_key_password: "{{ ca_key_password }}"
 candlepin_ca_key: "{{ ca_key }}"
 candlepin_ca_certificate: "{{ ca_certificate }}"
 candlepin_tomcat_key: "{{ localhost_key }}"

--- a/src/vars/certificates.yml
+++ b/src/vars/certificates.yml
@@ -1,7 +1,6 @@
 ---
 certificates_ca_directory: /var/lib/foremanctl/certs
 certificates_server_aliases: "{{ server_aliases | default([]) }}"
-ca_key_password: "{{ certificates_ca_directory }}/private/ca.pwd"
 ca_certificate: "{{ certificates_ca_directory }}/certs/ca.crt"
 ca_key: "{{ certificates_ca_directory }}/private/ca.key"
 server_certificate: "{{ certificates_ca_directory }}/certs/{{ ansible_facts['fqdn'] }}.crt"

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -189,10 +189,6 @@ def test_foremanctl_state_archive_contents(server, backup_result):
 
     assert len(file_list) > 0, "Archive should contain at least one file"
 
-    # Check for certificates-ca-password which should be present in all deployments
-    assert 'certificates-ca-password' in archive_contents, \
-        "Archive should contain certificates-ca-password (generated during deployment)"
-
 
 def test_pulp_content_archived(server, backup_result):
     backup_dir = backup_result['backup_dir']

--- a/tests/certificates_test.py
+++ b/tests/certificates_test.py
@@ -103,6 +103,32 @@ def test_ca_bundle_verifies_server_certificate(server, certificates):
     assert "OK" in cmd.stdout
 
 
+def test_ca_key_unencrypted(server, server_hostname, certificates):
+    if server_hostname == 'proxy':
+        pytest.skip("no ca key on proxy")
+    f = server.file(certificates['ca_key'])
+    assert f.exists
+    assert f.mode == 0o600
+    assert 'ENCRYPTED' not in f.content_string
+    cmd = server.run(f"openssl pkey -in {certificates['ca_key']} -noout")
+    assert cmd.succeeded
+
+
+def test_ca_key_password_file_absent(server, certificates):
+    ca_pwd = certificates['ca_key'].rsplit('/', 1)[0] + '/ca.pwd'
+    assert not server.file(ca_pwd).exists
+
+
+def test_ca_key_matches_ca_certificate(server, server_hostname, certificates):
+    if server_hostname == 'proxy':
+        pytest.skip("no ca key on proxy")
+    key_pub = server.run(f"openssl pkey -in {certificates['ca_key']} -pubout")
+    cert_pub = server.run(f"openssl x509 -in {certificates['ca_certificate']} -noout -pubkey")
+    assert key_pub.succeeded
+    assert cert_pub.succeeded
+    assert key_pub.stdout == cert_pub.stdout
+
+
 @pytest.mark.parametrize("cert_key,expected_mode", [
     ('server_certificate', 0o444),
     ('server_ca_certificate', 0o444),

--- a/tests/migration_test.py
+++ b/tests/migration_test.py
@@ -33,10 +33,12 @@ def test_certificate_directories(server, migrated_environment, subdir):
     assert d.mode == 0o755
 
 
-def test_ca_password_file(server, migrated_environment):
-    f = server.file("/var/lib/foremanctl/certs/private/ca.pwd")
-    assert f.exists
-    assert f.mode == 0o600
+def test_ca_key_unencrypted(server, migrated_environment):
+    assert not server.file("/var/lib/foremanctl/certs/private/ca.pwd").exists
+    key = server.file("/var/lib/foremanctl/certs/private/ca.key")
+    assert key.exists
+    assert key.mode == 0o600
+    assert "ENCRYPTED" not in key.content_string
 
 
 def test_ca_password_persisted(migrated_environment, obsah_state_path):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The CA private key is stored encrypted, but that password is in ca.pwd next to the key, and Candlepin is handed a decrypted copy. So there is no real benefit. 

Followup to #602 

#### What are the changes introduced in this pull request?

* Store key in an unencrypted way
* Remove ca_key_password and candlepin_ca_key_password variables
* migrate existing deployments in place

#### How to test this pull request

Steps to reproduce:

* on initial deployment: 
-> check that the ca.key is unencrypted
* on upgrade
-> deploy, see that key is NOW unencrypted

#### Checklist
* [X] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
