### PR TITLE
Add Registration smart proxy feature (SAT-44972)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -444,6 +444,7 @@ jobs:
             --auth-bundle $(pwd)/.var/lib/foremanctl/proxy.example.com.tar.gz \
             --foreman-fqdn quadlet.example.com \
             --templates-url http://proxy.example.com:8000 \
+            --registration-url https://loadbalancer.example.com:8443 \
             --add-feature bmc
       - name: Run tests
         run: |

--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -136,6 +136,8 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--bmc-redfish-verify-ssl` | Verify SSL certificates for Redfish BMC connections | `--foreman-proxy-bmc-redfish-verify-ssl` |
 | `--add-feature templates` | Enable Templates feature on Smart Proxy | `--foreman-proxy-templates` |
 | `--templates-url` | URL that hosts will use to contact the proxy for provisioning templates | `--foreman-proxy-templates-url` |
+| `--add-feature registration` | Enable Registration feature | `--foreman-proxy-registration` |
+| `--registration-url` | URL that hosts use to reach the registration endpoint | `--foreman-proxy-registration-url` |
 
 ### Unmapped
 
@@ -212,8 +214,6 @@ There are multiple use cases from the users perspective that dictate what parame
 | `--foreman-proxy-realm-keytab` | | | |
 | `--foreman-proxy-realm-principal` | | | |
 | `--foreman-proxy-realm-provider` | | | |
-| `--foreman-proxy-registration` | | | |
-| `--foreman-proxy-registration-url` | | | |
 | `--puppet-server` | | puppet | server |
 | `--puppet-server-ca` | | puppet | server_ca |
 | `--puppet-dns-alt-names` | | puppet | dns_alt_names |

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -84,3 +84,9 @@ templates:
   description: Templates feature for foreman-proxy
   foreman_proxy:
     plugin_name: templates
+registration:
+  description: Host registration feature for foreman-proxy
+  foreman_proxy:
+    plugin_name: registration
+  dependencies:
+    - templates

--- a/src/playbooks/_foreman_proxy/metadata.obsah.yaml
+++ b/src/playbooks/_foreman_proxy/metadata.obsah.yaml
@@ -13,3 +13,6 @@ variables:
   foreman_proxy_templates_url:
     parameter: --templates-url
     help: URL that hosts will use to contact the proxy for provisioning templates.
+  foreman_proxy_registration_url:
+    parameter: --registration-url
+    help: URL that hosts use to reach the registration endpoint (e.g. https://loadbalancer.example.com).

--- a/src/roles/foreman_proxy/templates/settings.d/registration.yml.j2
+++ b/src/roles/foreman_proxy/templates/settings.d/registration.yml.j2
@@ -1,0 +1,5 @@
+---
+:enabled: https
+{% if foreman_proxy_registration_url is defined %}
+:registration_url: {{ foreman_proxy_registration_url }}
+{% endif %}

--- a/src/vars/flavors/foreman-proxy-content.yml
+++ b/src/vars/flavors/foreman-proxy-content.yml
@@ -6,6 +6,7 @@ flavor_features:
   - content/ansible
   - content/python
   - templates
+  - registration
 
 pulp_mirror: true
 pulp_rhsm_url: "https://{{ ansible_facts['fqdn'] }}/rhsm"

--- a/tests/feature/foreman-proxy/base_test.py
+++ b/tests/feature/foreman-proxy/base_test.py
@@ -35,6 +35,11 @@ def test_foreman_proxy_features(curl_request, proxy_base_url, enabled_features):
         assert "ansible" in features
     else:
         assert "ansible" not in features
+    if 'registration' in enabled_features:
+        assert "registration" in features
+        assert "templates" in features
+    else:
+        assert "registration" not in features
 
 
 def test_foreman_proxy_service(server):
@@ -90,3 +95,15 @@ def test_templates_endpoint_responds(curl_request, proxy_base_url, server_fqdn):
     data = json.loads(cmd.stdout)
     assert 'templateServer' in data
     assert server_fqdn in data['templateServer']
+
+
+@pytest.mark.feature('registration')
+def test_registration_url(obsah_params):
+    registration_url = obsah_params.get('foreman_proxy_registration_url')
+    assert registration_url == 'https://loadbalancer.example.com:8443'
+
+
+@pytest.mark.feature('registration')
+def test_registration_endpoint(proxy_v2_features):
+    assert 'registration' in proxy_v2_features
+    assert proxy_v2_features['registration'].get('state') == 'running'


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Adds the Registration smart proxy feature for foremanctl (SAT-44972). Registration proxies host registration requests through an external smart proxy to Foreman, enabling hosts to register via their nearest proxy.

Depends on 
* https://github.com/Katello/katello/pull/11807 (Katello-side registration proxy support).
* https://github.com/theforeman/foreman/pull/11124 (finding colocated smart proxies)

#### What are the changes introduced in this pull request?

* Adds `registration` feature to `features.yaml` with a dependency on `templates` (auto-enabled)
* HTTPS-only: `registration.yml.j2` sets `:enabled: https`
* Adds optional `--registration-url` parameter for load-balanced proxy setups
* Includes `registration` in the `foreman-proxy-content` flavor (external smart proxies only — not deployed on the main Foreman server)
* Updates `parameters.md` to document the new parameters
* Adds tests: feature presence check in `test_foreman_proxy_features` and config file verification in `test_registration_enabled`

#### How to test this pull request

#### Set up your external smart proxy

Make sure `foremanctl` is updated to current

On Foreman server:
```
./foremanctl auth-bundle $PROXY_FQDN
scp /var/lib/foremanctl/certs/bundles/$PROXY_FQDN.tar.gz $PROXY_FQDN:/root/
```

On your external smart proxy machine:

```
./foremanctl deploy-proxy --foreman-fqdn "$FOREMAN_FQDN" --flavor foreman-proxy-content --auth-bundle ~/$PROXY_FQDN.tar.gz
```

* Verify `registration` appears in the smart proxy features list
* Verify `/etc/foreman-proxy/settings.d/registration.yml` contains `:enabled: https`
* Optionally pass `--registration-url https://loadbalancer.example.com` and verify the setting

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (if applicable)