### PR TITLE
Remove katello:migrate_deb_content_attributes_to_pulp3 from foreman-rake

### DIFF
--- a/src/roles/foreman/templates/foreman-rake.j2
+++ b/src/roles/foreman/templates/foreman-rake.j2
@@ -15,7 +15,6 @@ validate_actions() {
         "foreman_tasks:cleanup"
         "interfaces:clean"
         "katello:delete_orphaned_content"
-        "katello:migrate_deb_content_attributes_to_pulp3"
         "katello:upgrade_check"
         "ldap:refresh_usergroups"
         "orchestration:dhcp:add_missing"


### PR DESCRIPTION
Since https://github.com/theforeman/foreman-documentation/pull/5082 we no longer need to allow this action in foreman-rake.

#### What are the changes introduced in this pull request?

* removed the command from `foreman-rake` allow list

#### How to test this pull request

Steps to reproduce:

* Try to run the command and see that it is rejected.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
