### PR TITLE
assert /rhsm on the proxy gives 200

### DIFF
--- a/tests/flavor/foreman-proxy-content/httpd_test.py
+++ b/tests/flavor/foreman-proxy-content/httpd_test.py
@@ -16,7 +16,7 @@ def test_https_pulp_api_with_client_cert(curl_request):
 def test_https_rhsm_proxy(curl_request):
     cmd = curl_request("rhsm")
     assert cmd.succeeded
-    assert cmd.stdout not in ('404', '502', '503')
+    assert cmd.stdout == '200'
 
 
 def test_https_pulp_content_proxy(curl_request):


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

`/rhsm/` works unauthenticated to get info about Candlepin and we can use that to ensure #471 works correctly via a proxy too

#### What are the changes introduced in this pull request?

* assert http status 200 

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
