### PR TITLE
Symlink foreman-test script to /usr/local/bin

### DIFF
--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -106,6 +106,12 @@
     git_repository_secondary_remote_owner: "{{ foreman_development_github_username }}"
   when: foreman_development_manage_repos | default(true)
 
+- name: Symlink foreman-test to PATH
+  ansible.builtin.file:
+    state: link
+    src: "{{ foreman_development_foreman_dir }}/script/foreman-test"
+    dest: /usr/local/bin/foreman-test
+
 - name: Create database configuration
   ansible.builtin.template:
     src: database.yml.j2


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Foreman merged a generic plugin test runner script (`script/foreman-test`) in [theforeman/foreman#10963](https://github.com/theforeman/foreman/pull/10963). This script replaces ad-hoc per-plugin test wrappers like `ktest` with a unified tool that works across all plugins. In the development VM, the script lives inside the Foreman checkout and isn't on PATH, so developers have to invoke it with a full path.

#### What are the changes introduced in this pull request?

* Add a symlink from `/usr/local/bin/foreman-test` to the `script/foreman-test` inside the Foreman checkout, placed right after the git repository clone step in the `foreman_development` role.

#### How to test this pull request

Steps to reproduce:

* Deploy a development environment: `./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development`
* SSH into the VM and verify the symlink exists: `ls -la /usr/local/bin/foreman-test`
* Run `foreman-test --help` from any directory and confirm it prints usage information

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
