### PR TITLE
Support offline restore on proxy deployments

### DIFF
--- a/src/playbooks/restore/metadata.obsah.yaml
+++ b/src/playbooks/restore/metadata.obsah.yaml
@@ -17,6 +17,10 @@ variables:
     action: store_true
     persist: false
 
+  target_host:
+    help: Target host to restore (defaults to quadlet)
+    persist: false
+
   force:
     help: Force restore on existing system (bypasses safety check)
     action: store_true

--- a/src/playbooks/restore/restore.yaml
+++ b/src/playbooks/restore/restore.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Restore from a backup
-  hosts: quadlet
+  hosts: "{{ target_host | default('quadlet') }}"
   become: true
   gather_facts: true
   vars_files:
@@ -10,6 +10,49 @@
   roles:
     - restore
 
-- name: Deploy services after restore
+- name: Load restored parameters for deploy
+  hosts: "{{ target_host | default('quadlet') }}"
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Read restored parameters
+      ansible.builtin.slurp:
+        path: "{{ obsah_state_path }}/parameters.yaml"
+      register: restore_params_raw
+      failed_when: false
+      when: not validate | default(false)
+
+    - name: Parse restored parameters
+      ansible.builtin.set_fact:
+        restore_params: "{{ restore_params_raw.content | b64decode | from_yaml }}"
+      when:
+        - not validate | default(false)
+        - restore_params_raw is succeeded
+
+    - name: Set restored features
+      ansible.builtin.set_fact:
+        restore_enabled_features: "{{ restore_backup_metadata.enabled_features | default([]) }}"
+      when: restore_backup_metadata is defined
+
+    - name: Set proxy deploy parameters
+      ansible.builtin.set_fact:
+        foreman_name: "{{ restore_params.foreman_name }}"
+        foreman_proxy_oauth_consumer_key: "{{ restore_params.foreman_proxy_oauth_consumer_key }}"
+        foreman_proxy_oauth_consumer_secret: "{{ restore_params.foreman_proxy_oauth_consumer_secret }}"
+      when:
+        - restore_params is defined
+        - restore_enabled_features | default([]) | has_feature('foreman-proxy')
+        - not (restore_enabled_features | default([]) | has_feature('foreman'))
+
+- name: Deploy services after restore (foreman-proxy)
+  import_playbook: ../deploy-proxy/deploy-proxy.yaml
+  when:
+    - not validate | default(false)
+    - restore_enabled_features | default([]) | has_feature('foreman-proxy')
+    - not (restore_enabled_features | default([]) | has_feature('foreman'))
+
+- name: Deploy services after restore (server)
   import_playbook: ../deploy/deploy.yaml
-  when: not validate | default(false)
+  when:
+    - not validate | default(false)
+    - restore_enabled_features | default([]) | has_feature('foreman')

--- a/src/roles/restore/tasks/restore_databases.yaml
+++ b/src/roles/restore/tasks/restore_databases.yaml
@@ -27,7 +27,7 @@
       dump_file: "{{ restore_backup_metadata.database_mapping[item.name] }}.dump"
       database: "{{ item.database }}"
       user: "{{ item.user }}"
-  loop: "{{ databases }}"
+  loop: "{{ databases | selectattr('name', 'in', restore_backup_metadata.databases) | list }}"
   loop_control:
     label: "{{ item.name }}"
   when: item.name in restore_backup_metadata.database_mapping


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Support offline restore on proxies. Built on top of offline restore commit hence marking draft.

#### What are the changes introduced in this pull request?

* Adds some proxy specific logic to offline restore to be able to run against proxy deployments.

#### How to test this pull request

1. Set up a proxy
2. Run foremanctl backup /tmp/backup --target-host proxy
3. Run foremanctl restore /tmp/backup/backup_dir --target-host proxy --force

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
