### PR TITLE
Fix --certificate-renew-ca to --certificate-ca-renew in docs

### DIFF
--- a/docs/user/certificates.md
+++ b/docs/user/certificates.md
@@ -130,7 +130,7 @@ foremanctl deploy --certificate-renew
 To regenerate the CA certificate itself, use:
 
 ```bash
-foremanctl deploy --certificate-renew-ca
+foremanctl deploy --certificate-ca-renew
 ```
 
 > [!WARNING]


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The parameter was renamed from `--certificate-renew-ca` to `--certificate-ca-renew` in #672 for consistency, but the documentation in `docs/user/certificates.md` was not updated to reflect the new name.

#### What are the changes introduced in this pull request?

Update the example command in the certificates doc from the old `--certificate-renew-ca` to the correct `--certificate-ca-renew`.

#### How to test this pull request

Verify that `foremanctl deploy --help | grep renew` shows `--certificate-ca-renew` (not `--certificate-renew-ca`).

#### Checklist

- [ ] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)

Made with [Cursor](https://cursor.com)