### PR TITLE
Use /usr/bin/env bash instead of /bin/bash/ 

### DIFF
--- a/foremanctl
+++ b/foremanctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OBSAH_NAME=foremanctl
 OBSAH_BASE=$(dirname $(readlink -f $0))

--- a/forge
+++ b/forge
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OBSAH_NAME=forge
 OBSAH_BASE=$(dirname $(readlink -f $0))

--- a/setup-environment
+++ b/setup-environment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

there a systems which hasn't /bin/bash (in my case, NixOS) so /usr/bin/env bash should be OS agnostic

#### What are the changes introduced in this pull request?

* change for the files foremanctl, forge, setup-environment shebang to /usr/bin/env bash
