### PR TITLE
New param --valkey-log-level for Valkye logs

### DIFF
--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -13,6 +13,7 @@
     - "../../../src/vars/images.yml"
     - "../../../src/vars/database.yml"
     - "../../../src/vars/foreman.yml"
+    - "../../../src/vars/logging.yml"
     - "../../../src/vars/base.yaml"
   pre_tasks:
     - name: Set development postgresql databases

--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -79,7 +79,7 @@ There are multiple use cases from the users perspective that dictate what parame
 | Parameter | Description |
 | ----------| ----------- |
 | `--log-level` | Default log level for all services. Accepted values: `debug`, `info`, `warn`, `error`, `fatal`. Defaults to `info`. |
-| `--valkey-log-level` | Log level for Valkey. Uses Valkey's native levels. Overrides `--log-level`. Accepted values: `debug`, `verbose`, `notice`, `warning`. Defaults to `notice`. |
+| `--valkey-log-level` | Log level for Valkey. Uses Valkey's native levels. Overrides `--log-level`. Accepted values: `debug`, `verbose`, `notice`, `warning` & `nothing`. Defaults to `notice`. |
 
 ##### Mapped
 

--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -79,6 +79,7 @@ There are multiple use cases from the users perspective that dictate what parame
 | Parameter | Description |
 | ----------| ----------- |
 | `--log-level` | Default log level for all services. Accepted values: `debug`, `info`, `warn`, `error`, `fatal`. Defaults to `info`. |
+| `--valkey-log-level` | Log level for Valkey. Uses Valkey's native levels. Overrides `--log-level`. Accepted values: `debug`, `verbose`, `notice`, `warning`. Defaults to `notice`. |
 
 ##### Mapped
 

--- a/src/playbooks/_logging/metadata.obsah.yaml
+++ b/src/playbooks/_logging/metadata.obsah.yaml
@@ -17,3 +17,10 @@ variables:
       - warn
       - error
       - fatal
+  valkey_log_level:
+    help: Log level for Valkey. Defaults to the global log level (mapped to Valkey's native levels).
+    choices:
+      - debug
+      - verbose
+      - notice
+      - warning

--- a/src/playbooks/_logging/metadata.obsah.yaml
+++ b/src/playbooks/_logging/metadata.obsah.yaml
@@ -18,9 +18,10 @@ variables:
       - error
       - fatal
   valkey_log_level:
-    help: Log level for Valkey. Defaults to the global log level (mapped to Valkey's native levels).
+    help: Log level for Valkey.
     choices:
       - debug
       - verbose
       - notice
       - warning
+      - nothing

--- a/src/roles/valkey/handlers/main.yml
+++ b/src/roles/valkey/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart valkey
+  ansible.builtin.systemd:
+    name: valkey
+    state: restarted

--- a/src/roles/valkey/tasks/main.yaml
+++ b/src/roles/valkey/tasks/main.yaml
@@ -20,7 +20,7 @@
     state: quadlet
     network: host
     sdnotify: true
-    command: ["run-valkey", "--supervised", "systemd"]
+    command: ["run-valkey", "--supervised", "systemd", "--loglevel", "{{ valkey_log_level }}"]
     volumes:
       - /var/lib/valkey:/data:rw,Z
     quadlet_options:
@@ -29,6 +29,7 @@
         WantedBy=default.target foreman.target
         [Unit]
         PartOf=foreman.target
+  notify: Restart valkey
 
 - name: Run daemon reload
   ansible.builtin.systemd:

--- a/src/vars/logging.yml
+++ b/src/vars/logging.yml
@@ -3,3 +3,6 @@ log_level: info
 
 foreman_log_level: "{{ log_level }}"
 foreman_proxy_log_level: "{{ log_level }}"
+# Valkey log level is a bit different, we need to map the log-level to the valkey-log-level
+# https://github.com/valkey-io/valkey/blob/8.1/valkey.conf#L390-L397
+valkey_log_level: "{{ {'debug': 'debug', 'info': 'notice', 'warn': 'warning', 'error': 'warning', 'fatal': 'warning'}[log_level] }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

To allow users to configure log levels for the Valkey service.

#### What are the changes introduced in this pull request?

* New parameter `--valkye-log-level`

#### How to test this pull request

Steps to reproduce:

```
foremanctl deploy --valkey-log-level debug
# Accepted values: `debug`, `verbose`, `notice`, `warning`.

journalctl -f -u valkey.service
```

#### Checklist
* IMO tests are not needed
* `parameters.md` updated
