### PR TITLE
Expand pulpcore registry route to handle flatpak index

### DIFF
--- a/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
+++ b/src/roles/httpd/templates/foreman-ssl-vhost.conf.j2
@@ -61,15 +61,15 @@
   ProxyPass /pulp_ansible/galaxy/ {{ httpd_pulp_api_backend }}/pulp_ansible/galaxy/
   ProxyPassReverse /pulp_ansible/galaxy/ {{ httpd_pulp_api_backend }}/pulp_ansible/galaxy/
 
-  <Location "/pulpcore_registry/v2/">
+  <Location "/pulpcore_registry">
     RequestHeader unset REMOTE_USER
     RequestHeader unset REMOTE-USER
     RequestHeader set REMOTE-USER "admin" "expr=%{SSL_CLIENT_S_DN_CN} == '{{ ansible_facts['fqdn'] }}'"
     {% for httpd_pulp_trusted_host in httpd_pulp_trusted_hosts %}
     RequestHeader set REMOTE-USER "admin" "expr=%{SSL_CLIENT_S_DN_CN} == '{{ httpd_pulp_trusted_host }}'"
     {% endfor %}
-    ProxyPass {{ httpd_pulp_api_backend }}/v2/
-    ProxyPassReverse {{ httpd_pulp_api_backend }}/v2/
+    ProxyPass {{ httpd_pulp_api_backend }}
+    ProxyPassReverse {{ httpd_pulp_api_backend }}
   </Location>
 
   ProxyPass /pulp/container/ {{ httpd_pulp_content_backend }}/pulp/container/


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The apache config for pulpcore_registry should not be scoped to v2 since that ignore flatpak index at pulpcore_registry/index/static. This is consistent with rpm installs with https://github.com/theforeman/puppet-pulpcore/blob/69143ce8198a64f2dbe743481b2b750c00f5cfc9/manifests/plugin/container.pp#L6 
#### What are the changes introduced in this pull request?

* Expand pulpcore registry location block to handle pulpcore_registry/index/static path along with the other /v2/ endpoints.

#### How to test this pull request
Run foremanctl deploy and then go to foreman_url/pulpcore_registry/index/static?label:org.flatpak.ref:exists=1&tag=latest
Steps to reproduce:

* Go to foreman_url/pulpcore_registry/index/static?label:org.flatpak.ref:exists=1&tag=latest before the change and you'll see an error.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
