### PR TITLE
Fix SELinux context on httpd MPM event.conf

### DIFF
--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -74,6 +74,7 @@
     src: event.conf.j2
     dest: /etc/httpd/conf.modules.d/event.conf
     mode: "0644"
+    setype: httpd_config_t
   notify:
     - Restart httpd
 
@@ -95,6 +96,7 @@
     src: foreman-vhost.conf.j2
     dest: /etc/httpd/conf.d/{{ 'foreman' if httpd_with_foreman else 'pulpcore' }}.conf
     mode: "0644"
+    setype: httpd_config_t
   notify:
     - Restart httpd
 
@@ -103,6 +105,7 @@
     src: foreman-ssl-vhost.conf.j2
     dest: /etc/httpd/conf.d/{{ 'foreman-ssl' if httpd_with_foreman else 'pulpcore-ssl' }}.conf
     mode: "0644"
+    setype: httpd_config_t
   notify:
     - Restart httpd
 

--- a/tests/httpd_test.py
+++ b/tests/httpd_test.py
@@ -136,6 +136,13 @@ def test_httpd_event_conf_contains_threads_per_child(server):
     assert event_conf.contains("ThreadsPerChild")
 
 
+def test_httpd_selinux_context(server):
+    cmd = server.run("ls -1Z /etc/httpd/*.d/*.conf")
+    assert cmd.succeeded
+    incorrect = [line for line in cmd.stdout.splitlines() if line and ":httpd_config_t:" not in line]
+    assert not incorrect, "Incorrect SELinux context (expected httpd_config_t):\n" + "\n".join(incorrect)
+
+
 def test_httpd_config_syntax(server):
     cmd = server.run("httpd -t")
     assert cmd.succeeded


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
After a foremanctl deploy, /etc/httpd/conf.modules.d/event.conf was labeled etc_t instead of httpd_config_t. 
RPM-shipped files in that directory were fine; only the Ansible-templated event.conf was wrong.

Fixes: SAT-47294

#### What are the changes introduced in this pull request?

* Set setype: httpd_config_t on the MPM event template task so the file gets the correct label on create and on re-runs.
* Added a test to verify the selinux context of http configs

#### How to test this pull request

Steps to reproduce:

* foremanctl deploy 
* Check the event.conf selinux context under Apache modules config: `ls -1Z /etc/httpd/conf.modules.d/event.conf`

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
