### PR TITLE
Add webhooks feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
             --add-feature google \
             --add-feature remote-execution \
             --add-feature bmc \
+            --add-feature webhooks \
             ${{ matrix.iop == 'enabled' && '--add-feature iop' || '' }}
       - name: Run tests
         run: |
@@ -349,7 +350,8 @@ jobs:
             --add-feature foreman-proxy \
             --add-feature azure-rm \
             --add-feature google \
-            --add-feature remote-execution
+            --add-feature remote-execution \
+            --add-feature webhooks
       - name: Run tests
         run: |
           ./forge test

--- a/src/features.yaml
+++ b/src/features.yaml
@@ -66,3 +66,8 @@ bmc:
   description: Power management for bare metal hosts (IPMI, Redfish)
   foreman_proxy:
     plugin_name: bmc
+webhooks:
+  description: Webhooks plugin for Foreman
+  foreman:
+    plugin_name: foreman_webhooks
+  hammer: foreman_webhooks

--- a/tests/feature/foreman/plugins_test.py
+++ b/tests/feature/foreman/plugins_test.py
@@ -14,3 +14,8 @@ def test_foreman_compute_resources_azure_rm(foreman_plugins):
 @pytest.mark.feature('google')
 def test_foreman_compute_resources_google(foreman_plugins):
     assert 'foreman_google' in foreman_plugins
+
+
+@pytest.mark.feature('webhooks')
+def test_foreman_webhooks(foreman_plugins):
+    assert 'foreman_webhooks' in foreman_plugins


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
It was supported by the old installer, but isn't supported by foremanctl yet.

#### What are the changes introduced in this pull request?

Add webhooks feature. So far it only deals with the foreman_webhooks plugin and it's hammer counterpart. Shellhooks is intentionally left out of scope of this PR.

#### How to test this pull request

Steps to reproduce:

At a bare minimum: `./foremanctl features | grep -i webhooks`

To test fully:
1. `./foremanctl deploy --add-feature webhooks`
2. Wait for it to deploy
3. Create a webhook that fires on domain creation
4. Create a domain
5. Observe the webhook being delivered

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

#### Requires
- https://github.com/theforeman/foreman-oci-images/pull/72
