### PR TITLE
Add candlepin tuning

### DIFF
--- a/src/roles/candlepin/defaults/main.yml
+++ b/src/roles/candlepin/defaults/main.yml
@@ -19,3 +19,6 @@ candlepin_database_ssl: false
 candlepin_database_ssl_mode: disable
 candlepin_database_ssl_ca: # noqa: no-empty-defaults
 candlepin_database_ssl_ca_path: /etc/candlepin/certs/db-ca.crt
+
+candlepin_java_opts_xms: 1g
+candlepin_java_opts_xmx: 4g

--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -32,7 +32,7 @@
   containers.podman.podman_secret:
     state: present
     name: candlepin-tomcat-conf
-    data: "{{ lookup('ansible.builtin.template', 'tomcat.conf') }}"
+    data: "{{ lookup('ansible.builtin.template', 'tomcat.conf.j2') }}"
     labels:
       filename: tomcat.conf
       app: tomcat

--- a/src/roles/candlepin/templates/tomcat.conf.j2
+++ b/src/roles/candlepin/templates/tomcat.conf.j2
@@ -28,7 +28,7 @@ CATALINA_HOME="/usr/share/tomcat"
 CATALINA_TMPDIR="/var/cache/tomcat/temp"
 
 # You can pass some parameters to java here if you wish to
-JAVA_OPTS="-Xms1024m -Xmx4096m -Dcom.redhat.fips=false --enable-native-access=ALL-UNNAMED"
+JAVA_OPTS="-Xms{{ candlepin_java_opts_xms }} -Xmx{{ candlepin_java_opts_xmx }} -Dcom.redhat.fips=false --enable-native-access=ALL-UNNAMED"
 
 # You can change your tomcat locale here
 

--- a/src/vars/tuning/extra-extra-large.yml
+++ b/src/vars/tuning/extra-extra-large.yml
@@ -8,3 +8,5 @@ httpd_max_request_workers: 1024
 postgresql_max_connections: 1000
 postgresql_shared_buffers: 32GB
 postgresql_effective_cache_size: 64GB
+
+candlepin_java_opts_xmx: 8g

--- a/src/vars/tuning/extra-large.yml
+++ b/src/vars/tuning/extra-large.yml
@@ -8,3 +8,5 @@ httpd_max_request_workers: 1024
 postgresql_max_connections: 1000
 postgresql_shared_buffers: 16GB
 postgresql_effective_cache_size: 32GB
+
+candlepin_java_opts_xmx: 8g


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Candlepin JVM heap is hardcoded in tomcat.conf. It should scale with the tuning profile like other components (httpd, PostgreSQL).

#### What are the changes introduced in this pull request?

  - Templatized -Xms/-Xmx in tomcat.conf using candlepin_xms/candlepin_xmx variables
  - Role defaults: 1g/4g (matches puppet-candlepin (https://github.com/theforeman/puppet-candlepin/blob/072f08a/manifests/init.pp#L216))
  - Extra-large and extra-extra-large override candlepin_xmx: 8g (matches foreman-installer
  (https://github.com/theforeman/foreman-installer/blob/0448d5d/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml#L5))

#### How to test this pull request

  1. foremanctl deploy --tuning default
  2. podman exec candlepin cat /proc/1/cmdline | tr '\0' ' ' → verify -Xms1g -Xmx4g
  3. foremanctl deploy --tuning extra-large (32+ cores, 128GB+) → verify -Xms1g -Xmx8g

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
