### PR TITLE
Fix httpd proxy backend precedence in deploy-dev playbook

### DIFF
--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -4,7 +4,6 @@
   become: true
   vars:
     flavor: katello
-    httpd_foreman_backend: "http://localhost:3000"
     pulp_register_foreman_proxy: false
   vars_files:
     - "../../../src/vars/defaults.yml"
@@ -14,6 +13,7 @@
     - "../../../src/vars/database.yml"
     - "../../../src/vars/foreman.yml"
     - "../../../src/vars/base.yaml"
+    - "../../vars/devel.yaml"
   pre_tasks:
     - name: Set development postgresql databases
       ansible.builtin.set_fact:

--- a/development/vars/devel.yaml
+++ b/development/vars/devel.yaml
@@ -1,0 +1,2 @@
+---
+httpd_foreman_backend: "http://localhost:3000"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The deploy-dev playbook sets `httpd_foreman_backend: "http://localhost:3000"` in the play-level `vars:` block, but `src/vars/base.yaml` (loaded via `vars_files:`) overrides it with the Unix socket path. In Ansible's variable precedence, `vars_files` beats `vars`, so httpd was always configured to proxy to a nonexistent Unix socket instead of TCP port 3000, resulting in 503 errors.

This was latent since `eedbe40` (March 2025) when Unix socket support was added to `base.yaml`, but went unnoticed because the `vars:` block originally appeared *below* `vars_files:` in the YAML, and the ordering happened to make the override work. [#623](https://github.com/theforeman/foremanctl/pull/623) ("Move flavor default into playbook vars", July 6 2026) moved `vars:` above `vars_files:`, which broke the accidental ordering and surfaced the bug.

#### What are the changes introduced in this pull request?

* Add `development/vars/devel.yaml` with dev-specific variable overrides (currently `httpd_foreman_backend`)
* Load it last in `vars_files` so it overrides `base.yaml` at the same precedence level
* Remove the ineffective override from play-level `vars:`

#### How to test this pull request

* Deploy using `./forge deploy-dev --target-host localhost`
* Verify `/etc/httpd/conf.d/foreman.conf` contains `ProxyPass / http://localhost:3000/` (not a Unix socket path)
* Confirm no 503 errors when accessing Foreman through httpd

#### Checklist
* [x] Tests added/updated (if applicable) - No new tests needed; existing httpd functional tests cover this once [#715](https://github.com/theforeman/foremanctl/pull/715) enables running tests against dev deployments
* [ ] Documentation updated (if applicable) - No documentation changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)