### PR TITLE
Add non-root container user validation

### DIFF
--- a/tests/container_user_test.py
+++ b/tests/container_user_test.py
@@ -1,0 +1,32 @@
+import shlex
+
+
+def test_all_containers_run_nonroot(server):
+    """Verify all running containers use non-root users."""
+    
+    result = server.run("podman ps --format '{{.Names}}'")
+    assert result.succeeded, result.stderr
+
+    container_names = result.stdout.split()
+    assert container_names, "No running containers found"
+
+    root_containers = []
+
+    for container_name in container_names:
+        result = server.run(
+            f"podman inspect {shlex.quote(container_name)} "
+            "--format '{{.ImageName}}|{{.Config.User}}'"
+        )
+        assert result.succeeded, f"Failed to inspect container {container_name}: {result.stderr}"
+
+        image_name, configured_user = result.stdout.strip().split("|", maxsplit=1)
+        user = configured_user.split(":", maxsplit=1)[0].lower()
+
+        if user in {"", "0", "root"}:
+            root_containers.append(
+                f"{container_name} (image={image_name}, Config.User={configured_user or '<empty>'})"
+            )
+
+    assert not root_containers, (
+        "Running containers configured to use root:\n" + "\n".join(root_containers)
+    )

--- a/tests/container_user_test.py
+++ b/tests/container_user_test.py
@@ -1,15 +1,21 @@
 import shlex
 
+EXPECTED_ROOT_IMAGES = {
+    "quay.io/foreman/pulp:foreman-nightly",
+    "quay.io/iop/puptoo:foreman-3.18",
+    "quay.io/iop/yuptoo:foreman-3.18",
+}
 
-def test_all_containers_run_nonroot(server):
-    """Verify all running containers use non-root users."""
-    
+
+def test_root_containers_match_expected(server):
+    """Verify that root containers match the temporary known-broken baseline."""
     result = server.run("podman ps --format '{{.Names}}'")
     assert result.succeeded, result.stderr
 
     container_names = result.stdout.split()
     assert container_names, "No running containers found"
 
+    expected_root_containers = []
     root_containers = []
 
     for container_name in container_names:
@@ -17,16 +23,30 @@ def test_all_containers_run_nonroot(server):
             f"podman inspect {shlex.quote(container_name)} "
             "--format '{{.ImageName}}|{{.Config.User}}'"
         )
-        assert result.succeeded, f"Failed to inspect container {container_name}: {result.stderr}"
+        assert result.succeeded, (
+            f"Failed to inspect container {container_name}: {result.stderr}"
+        )
 
         image_name, configured_user = result.stdout.strip().split("|", maxsplit=1)
         user = configured_user.split(":", maxsplit=1)[0].lower()
 
-        if user in {"", "0", "root"}:
-            root_containers.append(
-                f"{container_name} (image={image_name}, Config.User={configured_user or '<empty>'})"
-            )
+        container_details = (
+            f"{container_name} "
+            f"(image={image_name}, "
+            f"Config.User={configured_user or '<empty>'})"
+        )
 
-    assert not root_containers, (
-        "Running containers configured to use root:\n" + "\n".join(root_containers)
+        if image_name in EXPECTED_ROOT_IMAGES:
+            expected_root_containers.append(container_details)
+
+        if user in {"", "0", "root"}:
+            root_containers.append(container_details)
+
+    expected_output = "\n".join(sorted(expected_root_containers)) or "<none>"
+    actual_output = "\n".join(sorted(root_containers)) or "<none>"
+
+    assert sorted(expected_root_containers) == sorted(root_containers), (
+        "Root containers differ from the expected temporary baseline:\n"
+        f"Expected:\n{expected_output}\n"
+        f"Actual:\n{actual_output}"
     )


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The [SAT-47250](https://redhat.atlassian.net/browse/SAT-47250) identified container images configured to run as root, and foremanctl deploys images from multiple repositories, including images whose build pipelines are outside its control. So this adds deployment-level regression coverage to ensure that every running container is explicitly configured to use a non-root user.

#### What are the changes introduced in this pull request?

* add a foremanctl test that discovers all running containers using `podman ps`
* inspect each container’s image and configured user using `podman inspect`

#### How to test this pull request

steps to reproduce:

* deploy a foremanctl test environment.
* run the focused test: `./forge test --pytest-args="tests/container_user_test.py -vv"`
* verify that the test:
    * passes when all running containers have a non-root `Config.User`.
    * fails and reports the container name, image, and configured user when any running container uses root.

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
