### PR TITLE
Remove foreman.yml from deploy-proxy vars_files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -439,7 +439,9 @@ jobs:
           ./foremanctl deploy-proxy \
             --flavor foreman-proxy-content \
             --certificate-bundle $(pwd)/.var/lib/foremanctl/proxy.example.com.tar.gz \
-            --foreman-fqdn quadlet.example.com
+            --foreman-fqdn quadlet.example.com \
+            --oauth-consumer-key $(cat .var/lib/foremanctl/foreman-oauth-consumer-key) \
+            --oauth-consumer-secret $(cat .var/lib/foremanctl/foreman-oauth-consumer-secret)
       - name: Run tests
         run: |
           ./forge test --pytest-args="--server-hostname=proxy"

--- a/src/playbooks/deploy-proxy/deploy-proxy.yaml
+++ b/src/playbooks/deploy-proxy/deploy-proxy.yaml
@@ -12,7 +12,6 @@
     - "../../vars/images.yml"
     - "../../vars/tuning/{{ tuning }}.yml"
     - "../../vars/database.yml"
-    - "../../vars/foreman.yml"
     - "../../vars/logging.yml"
     - "../../vars/base.yaml"
   roles:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The deploy-proxy playbook loads foreman.yml in vars_files, but no variables from this file are used during proxy deployment. OAuth credentials are supplied via CLI parameters (--oauth-consumer-key, --oauth-consumer-secret).

Loading foreman.yml triggers ansible.builtin.password lookups that generate unused credentials on the proxy host. This causes confusion during debugging, the files on disk don't even match the actual OAuth values in use by the deployment:
```
[root@foreman-proxy ~]# cat /var/lib/foremanctl/foreman-oauth-consumer-key
DjqGRElrn1XLTgSEOVo4RPajSbWtft5t
[root@foreman-proxy ~]# cat /var/lib/foremanctl/parameters.yaml
flavor: foreman-proxy-content
..
foreman_proxy_oauth_consumer_key: qzJAvqKFlY73aBIeS4zqkpf2g9mVJGYT
```

#### What are the changes introduced in this pull request?

* Remove foreman.yml from deploy-proxy playbook vars_files

#### How to test this pull request

Steps to reproduce:

- Deploy a proxy: ./foremanctl deploy-proxy --flavor foreman-proxy-content --certificate-bundle <bundle> --foreman-fqdn <fqdn> --oauth-consumer-key <key> --oauth-consumer-secret <secret>
- Verify /var/lib/foremanctl/foreman-oauth-consumer-key is not created on the proxy host
- Verify proxy registers successfully with Foreman

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
