### PR TITLE
Increase ping endpoint timeout to avoid false failures during startup

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -318,6 +318,7 @@
   ansible.builtin.uri:
     url: '{{ foreman_url }}/api/v2/ping'
     ca_path: '{{ foreman_ca_certificate }}'
+    timeout: 120
   until: foreman_status.status == 200
   retries: 60
   delay: 5
@@ -337,6 +338,7 @@
   ansible.builtin.uri:
     url: '{{ foreman_url }}/api/v2/ping'
     ca_path: '{{ foreman_ca_certificate }}'
+    timeout: 120
   until:
     - foreman_tasks_status.status == 200
     - foreman_tasks_status.json['results']['katello']['services']['foreman_tasks']['status'] == 'ok'


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
The default URI module timeout of 30 seconds is sometimes not enough for getting results back from ping api. I have run into this mostly with rh_cloud and IOP services enabled.
#### What are the changes introduced in this pull request?

* Increase ping API timeout to 120 secs for long running call.

#### How to test this pull request
Make sure the tasks `Wait for Foreman service to be accessible` and `Wait for Foreman tasks to be ready` that run during deploy pass. I have generally seen these timeout during deploy with IOP enabled which causes /ping to take longer than 30 secs to respond.