### PR TITLE
Always use the certs from the quadlet machine in the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -443,7 +443,8 @@ jobs:
             --auth-bundle $(pwd)/.var/lib/foremanctl/proxy.example.com.tar.gz \
             --foreman-fqdn quadlet.example.com \
             --templates-listen-on http \
-            --templates-url http://proxy.example.com:8000
+            --templates-url http://proxy.example.com:8000 \
+            --add-feature bmc
       - name: Run tests
         run: |
           ./forge test --pytest-args="--server-hostname=proxy"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,17 @@ def default_certificates(certificate_source):
 
 
 @pytest.fixture(scope="module")
+def quadlet_client_certificate():
+    # this intentionally uses get_paramiko_host directly, as we want the cert of the quadlet box
+    # not the one "server" points at, as that can be the proxy
+    quadlet = get_paramiko_host('quadlet')
+    hostname = quadlet.run("hostname -f").stdout.strip()
+    cert = quadlet.file(f"/var/lib/foremanctl/certs/certs/{hostname}-client.crt").content_string
+    key = quadlet.file(f"/var/lib/foremanctl/certs/private/{hostname}-client.key").content_string
+    return (cert, key)
+
+
+@pytest.fixture(scope="module")
 def database_mode(obsah_params):
     return obsah_params.get('database_mode', 'internal')
 
@@ -344,13 +355,17 @@ def proxy_base_url(server_fqdn):
 
 
 @pytest.fixture(scope="module")
-def curl_request(server, certificates, server_fqdn):
+def curl_request(server, certificates, quadlet_client_certificate, server_fqdn):
+    cert, key = quadlet_client_certificate
+    server.run(f"echo '{cert}' > /tmp/quadlet.crt")
+    server.run(f"echo '{key}' > /tmp/quadlet.key")
+
     def _request(path, base_url=None, method=None, data=None, headers=None, return_body=False):
         url = f"{base_url or f'https://{server_fqdn}'}/{path}"
         curl_opts = (
             f"--cacert {certificates['server_ca_certificate']} "
-            f"--cert {certificates['client_certificate']} "
-            f"--key {certificates['client_key']} "
+            f"--cert /tmp/quadlet.crt "
+            f"--key /tmp/quadlet.key "
             f"--silent "
         )
         if not return_body:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,20 +135,24 @@ def database_mode(obsah_params):
     return obsah_params.get('database_mode', 'internal')
 
 
+def get_paramiko_host(hostname):
+    return testinfra.get_host(f'paramiko://{hostname}', sudo=True, ssh_config=SSH_CONFIG)
+
+
 @pytest.fixture(scope="module")
 def server(server_hostname):
-    yield testinfra.get_host(f'paramiko://{server_hostname}', sudo=True, ssh_config=SSH_CONFIG)
+    yield get_paramiko_host(server_hostname)
 
 
 @pytest.fixture(scope="module")
 def client(client_hostname):
-    yield testinfra.get_host(f'paramiko://{client_hostname}', sudo=True, ssh_config=SSH_CONFIG)
+    yield get_paramiko_host(client_hostname)
 
 
 @pytest.fixture(scope="module")
 def database(database_mode, server):
     if database_mode == 'external':
-        yield testinfra.get_host('paramiko://database', sudo=True, ssh_config=SSH_CONFIG)
+        yield get_paramiko_host('database')
     else:
         yield server
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Our tests talk to the Smart Proxy API (see #519 and the BMC change in this PR), which requires auth. In the case of an external proxy deployment, the certs that were used were of the proxy, but that is not allowed to auth against itself.

#### What are the changes introduced in this pull request?

* Fetch the certs from the quadlet machine and use those

#### How to test this pull request

Steps to reproduce:

* See the BMC feature test work on external proxy

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
