### PR TITLE
explicitly chown Foreman data volume on start

### DIFF
--- a/.ansible-lint-rules/explicit_volume_mode.py
+++ b/.ansible-lint-rules/explicit_volume_mode.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
 
 from ansiblelint.rules import AnsibleLintRule
 
 if TYPE_CHECKING:
     from ansiblelint.file_utils import Lintable
-
-_VOLUME_PATTERN = re.compile(r'^[^:]+:[^:]+:(rw|ro)(?:,[zZ])?$')
 
 
 class ExplicitVolumeModeRule(AnsibleLintRule):
@@ -50,4 +47,9 @@ class ExplicitVolumeModeRule(AnsibleLintRule):
 def _is_valid(spec: str) -> bool:
     if "{{" in spec:
         return True
-    return bool(_VOLUME_PATTERN.match(spec.strip().strip("'\"")))
+    parts = spec.strip().strip("'\"").split(":")
+    if len(parts) != 3:
+        return False
+    source, dest, optionstr = parts
+    options = optionstr.split(",")
+    return "rw" in options or "ro" in options

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -116,7 +116,7 @@
     network: host
     hostname: "{{ ansible_facts['hostname'] }}.local"
     volume:
-      - 'foreman-data-run:/var/run/foreman:rw,z'
+      - 'foreman-data-run:/var/run/foreman:rw,z,U'
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
       - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'
@@ -168,7 +168,7 @@
     network: host
     hostname: "{{ ansible_facts['hostname'] }}.local"
     volume:
-      - 'foreman-data-run:/var/run/foreman:rw,z'
+      - 'foreman-data-run:/var/run/foreman:rw,z,U'
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
       - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'
@@ -227,7 +227,7 @@
     hostname: "{{ ansible_facts['hostname'] }}.local"
     command: "foreman-rake {{ item.rake }}"
     volume:
-      - 'foreman-data-run:/var/run/foreman:rw,z'
+      - 'foreman-data-run:/var/run/foreman:rw,z,U'
     secrets:
       - 'foreman-database-url,type=env,target=DATABASE_URL'
       - 'foreman-encryption-key,type=env,target=ENCRYPTION_KEY'

--- a/tests/fixtures/ansible-lint/roles/test_explicit_volume_mode_pass/tasks/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_explicit_volume_mode_pass/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+- name: Container with rw and Z and U
+  containers.podman.podman_container:
+    name: test-rw-z
+    image: example.com/test:latest
+    volumes:
+      - /var/log/test:/var/log/test:rw,Z,U
+
+- name: Container with Z and rw and U
+  containers.podman.podman_container:
+    name: test-rw-z
+    image: example.com/test:latest
+    volumes:
+      - /var/log/test:/var/log/test:Z,rw,U
+
 - name: Container with rw and Z
   containers.podman.podman_container:
     name: test-rw-z


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

https://github.com/theforeman/foreman-oci-images/pull/70 made the UID/GID of the foreman user static, but on upgrades the previous version might have had a different ID, resulting in permission errors.

#### What are the changes introduced in this pull request?

* Explicitly chown the data volume on container start

#### How to test this pull request

Steps to reproduce:

* CI (upgrade test)

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
