### PR TITLE
Add chromedriver dependencies to development packages

### DIFF
--- a/development/roles/foreman_development/defaults/main.yaml
+++ b/development/roles/foreman_development/defaults/main.yaml
@@ -165,3 +165,6 @@ foreman_development_packages:
   - rubygem-bundler
   - rubygem-irb
   - postgresql
+  - libxcb
+  - nss
+  - nspr


### PR DESCRIPTION
Added libxcb, nss, and nspr that chromedriver requires.

#### Why are you introducing these changes? (Problem description, related links)

Fresh pull of the deploy-foreman-development is unable to run tests due to missing chromedriver's dependencies.

#### What are the changes introduced in this pull request?

* adds libxcb, nss, and nspr packages to foreman_development_packages

#### How to test this pull request

Steps to reproduce:

* fresh system (RHEL 9.8) is able to start chromedriver

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
