### PR TITLE
Fix libvirt dependency

### DIFF
--- a/development/roles/foreman_development/defaults/main.yaml
+++ b/development/roles/foreman_development/defaults/main.yaml
@@ -160,6 +160,7 @@ foreman_development_packages:
   - libxslt-devel
   - libcurl-devel
   - libffi-devel
+  - libvirt-devel
   - gcc-c++
   - make
   - rubygem-bundler

--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -23,11 +23,19 @@
     name: nodejs
     state: present
 
-- name: Enable CodeReady Builder repository
+- name: Ensure the crb repository is enabled
   community.general.rhsm_repository:
-    name: "codeready-builder-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+    name: crb
     state: enabled
-  when: ansible_distribution == 'RedHat'
+  when:
+    - ansible_facts['distribution'] != "RedHat"
+
+- name: Ensure the crb repository is enabled
+  community.general.rhsm_repository:
+    name: "codeready-builder-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
+    state: enabled
+  when:
+    - ansible_facts['distribution'] == "RedHat"
 
 - name: Install development packages
   ansible.builtin.package:

--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -180,7 +180,7 @@
 
 - name: Install Ruby dependencies
   ansible.builtin.command:
-    cmd: bundle install --path .vendor --jobs 3 --without "libvirt:journald"
+    cmd: bundle install --path .vendor --jobs 3 --without "journald"
     chdir: "{{ foreman_development_foreman_dir }}"
   become: true
   become_user: "{{ foreman_development_user }}"

--- a/development/roles/foreman_development/tasks/main.yaml
+++ b/development/roles/foreman_development/tasks/main.yaml
@@ -24,13 +24,13 @@
     state: present
 
 - name: Ensure the crb repository is enabled
-  community.general.rhsm_repository:
+  community.general.dnf_config_manager:
     name: crb
     state: enabled
   when:
     - ansible_facts['distribution'] != "RedHat"
 
-- name: Ensure the crb repository is enabled
+- name: Ensure the CodeReady Builder repository is enabled
   community.general.rhsm_repository:
     name: "codeready-builder-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
     state: enabled


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Foreman and Foreman's dev setup document assumes that libvirt is installed in the system. Without libvirt, Foreman's test suite fails to run (specifically https://github.com/theforeman/foreman/blob/develop/test/integration/host_js_test.rb#L4 - the require immediately stops the suite).

#### What are the changes introduced in this pull request?

* adds libvirt-devel to foreman_development_packages
* changes bundle install command in foreman_development role to include libvirt gem group

#### How to test this pull request

Steps to reproduce:

* libvirt-devel is present, fog-libvirt (+ ruby-libvirt) are installed on a fresh system

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
