### PR TITLE
Test foreman.target stops and starts IOP services

### DIFF
--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -4,6 +4,7 @@ jinja2
 paramiko
 passlib
 ruff
+pytest-subtests
 pytest-testinfra
 pytest-durations
 python-dateutil

--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -4,7 +4,6 @@ jinja2
 paramiko
 passlib
 ruff
-pytest-subtests
 pytest-testinfra
 pytest-durations
 python-dateutil

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -1,0 +1,41 @@
+import time
+
+import pytest
+
+TARGET_ACTIVE_RETRIES = 90
+TARGET_ACTIVE_DELAY = 10
+
+pytestmark = pytest.mark.slow
+
+
+def _wait_for_target_active(server, target="foreman.target"):
+    for _ in range(TARGET_ACTIVE_RETRIES):
+        if server.service(target).is_running:
+            return
+        time.sleep(TARGET_ACTIVE_DELAY)
+    raise AssertionError(f"{target} did not become active after lifecycle operation")
+
+
+def _wait_for_no_iop_containers(server, retries=30, delay=2):
+    for _ in range(retries):
+        result = server.run("podman ps --filter name=iop --format '{{.Names}}'")
+        if not result.stdout.strip():
+            return
+        time.sleep(delay)
+    raise AssertionError(f"IOP containers still running after stop: {result.stdout}")
+
+
+def test_foreman_target_stop_starts_iop_services(server):
+    result = server.run("systemctl stop foreman.target")
+    assert result.rc == 0, f"Failed to stop foreman.target: {result.stderr}"
+    assert not server.service("foreman.target").is_running
+
+    _wait_for_no_iop_containers(server)
+
+    result = server.run("systemctl start foreman.target")
+    assert result.rc == 0, f"Failed to start foreman.target: {result.stderr}"
+    _wait_for_target_active(server)
+    assert server.service("foreman.target").is_running
+
+    result = server.run("podman ps --filter name=iop --filter status=running --format '{{.Names}}'")
+    assert result.stdout.strip(), "No IOP containers running after start"

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -1,4 +1,4 @@
-def test_iop_services_part_of_foreman_target(server):
+def test_iop_services_part_of_foreman_target(server, subtests):
     result = server.run(
         "systemctl list-units 'iop-core-*' 'iop-service-*'"
         " --type=service --no-legend --all --plain"
@@ -11,4 +11,5 @@ def test_iop_services_part_of_foreman_target(server):
         service = server.service(service_name)
         if service.systemd_properties.get("TriggeredBy"):
             continue
-        assert "foreman.target" in service.systemd_properties.get("PartOf")
+        with subtests.test(service_name):
+            assert "foreman.target" in service.systemd_properties.get("PartOf")

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -8,13 +8,10 @@ def test_iop_services_part_of_foreman_target(server):
     assert services, "No IOP services found"
 
     missing = []
-    for service in services:
-        # Skip timer-triggered services (cleanup, vmaas-sync)
-        triggered_by = server.run(f"systemctl show {service} -p TriggeredBy --value")
-        if triggered_by.stdout.strip():
+    for service_name in services:
+        service = server.service(service_name)
+        if service.systemd_properties.get("TriggeredBy"):
             continue
-        result = server.run(f"systemctl show {service} -p PartOf --value")
-        if "foreman.target" not in result.stdout:
-            missing.append(service)
+        assert "foreman.target" in service.systemd_properties.get("PartOf")
 
     assert not missing, f"IOP services not PartOf foreman.target: {missing}"

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -1,4 +1,4 @@
-def test_iop_services_part_of_foreman_target(server, subtests):
+def test_iop_services_part_of_foreman_target(server):
     result = server.run(
         "systemctl list-units 'iop-core-*' 'iop-service-*'"
         " --type=service --no-legend --all --plain"
@@ -11,5 +11,4 @@ def test_iop_services_part_of_foreman_target(server, subtests):
         service = server.service(service_name)
         if service.systemd_properties.get("TriggeredBy"):
             continue
-        with subtests.test(service_name):
-            assert "foreman.target" in service.systemd_properties.get("PartOf")
+        assert "foreman.target" in service.systemd_properties.get("PartOf")

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -1,41 +1,20 @@
-import time
+def test_iop_services_part_of_foreman_target(server):
+    result = server.run(
+        "systemctl list-units 'iop-core-*' 'iop-service-*'"
+        " --type=service --no-legend --all --plain"
+    )
+    assert result.rc == 0
+    services = [line.split()[0] for line in result.stdout.strip().splitlines()]
+    assert services, "No IOP services found"
 
-import pytest
+    missing = []
+    for service in services:
+        # Skip timer-triggered services (cleanup, vmaas-sync)
+        triggered_by = server.run(f"systemctl show {service} -p TriggeredBy --value")
+        if triggered_by.stdout.strip():
+            continue
+        result = server.run(f"systemctl show {service} -p PartOf --value")
+        if "foreman.target" not in result.stdout:
+            missing.append(service)
 
-TARGET_ACTIVE_RETRIES = 90
-TARGET_ACTIVE_DELAY = 10
-
-pytestmark = pytest.mark.slow
-
-
-def _wait_for_target_active(server, target="foreman.target"):
-    for _ in range(TARGET_ACTIVE_RETRIES):
-        if server.service(target).is_running:
-            return
-        time.sleep(TARGET_ACTIVE_DELAY)
-    raise AssertionError(f"{target} did not become active after lifecycle operation")
-
-
-def _wait_for_no_iop_containers(server, retries=30, delay=2):
-    for _ in range(retries):
-        result = server.run("podman ps --filter name=iop --format '{{.Names}}'")
-        if not result.stdout.strip():
-            return
-        time.sleep(delay)
-    raise AssertionError(f"IOP containers still running after stop: {result.stdout}")
-
-
-def test_foreman_target_stop_starts_iop_services(server):
-    result = server.run("systemctl stop foreman.target")
-    assert result.rc == 0, f"Failed to stop foreman.target: {result.stderr}"
-    assert not server.service("foreman.target").is_running
-
-    _wait_for_no_iop_containers(server)
-
-    result = server.run("systemctl start foreman.target")
-    assert result.rc == 0, f"Failed to start foreman.target: {result.stderr}"
-    _wait_for_target_active(server)
-    assert server.service("foreman.target").is_running
-
-    result = server.run("podman ps --filter name=iop --filter status=running --format '{{.Names}}'")
-    assert result.stdout.strip(), "No IOP containers running after start"
+    assert not missing, f"IOP services not PartOf foreman.target: {missing}"

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -3,7 +3,7 @@ def test_iop_services_part_of_foreman_target(server, subtests):
         "systemctl list-units 'iop-core-*' 'iop-service-*'"
         " --type=service --no-legend --all --plain"
     )
-    assert result.rc == 0
+    assert result.succeeded
     services = [line.split()[0] for line in result.stdout.strip().splitlines()]
     assert services, "No IOP services found"
 

--- a/tests/feature/iop/test_target_lifecycle.py
+++ b/tests/feature/iop/test_target_lifecycle.py
@@ -1,4 +1,4 @@
-def test_iop_services_part_of_foreman_target(server):
+def test_iop_services_part_of_foreman_target(server, subtests):
     result = server.run(
         "systemctl list-units 'iop-core-*' 'iop-service-*'"
         " --type=service --no-legend --all --plain"
@@ -7,11 +7,9 @@ def test_iop_services_part_of_foreman_target(server):
     services = [line.split()[0] for line in result.stdout.strip().splitlines()]
     assert services, "No IOP services found"
 
-    missing = []
     for service_name in services:
         service = server.service(service_name)
         if service.systemd_properties.get("TriggeredBy"):
             continue
-        assert "foreman.target" in service.systemd_properties.get("PartOf")
-
-    assert not missing, f"IOP services not PartOf foreman.target: {missing}"
+        with subtests.test(service_name):
+            assert "foreman.target" in service.systemd_properties.get("PartOf")


### PR DESCRIPTION
Note: duplicate of #701 due to PTO.

## Summary
- Adds a test under `tests/feature/iop/` verifying that `systemctl stop foreman.target` brings down all IOP containers and `systemctl start foreman.target` brings them back.
- Auto-skipped when IOP is not enabled (feature guarding via conftest).
- Marked as `slow` since it involves a full stop/start cycle (~2 min).

## Context
Companion test for #592 which adds `PartOf=foreman.target` and `WantedBy=foreman.target` to all IOP quadlet units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)