### PR TITLE
Introduce --test-target to more explicitly declare where tests run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -447,7 +447,7 @@ jobs:
             --add-feature bmc
       - name: Run tests
         run: |
-          ./forge test --pytest-args="--server-hostname=proxy"
+          ./forge test --pytest-args="--test-target=proxy"
       - name: Generate sos reports
         if: ${{ always() }}
         run: ./forge sos

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -40,14 +40,14 @@ def expected_databases(enabled_features, flavor):
 
 
 @pytest.fixture(scope="module")
-def backup_result(server, server_hostname):
+def backup_result(server, test_target):
     server.run(f"rm -rf {BACKUP_DIR}")
 
     result = server.run(f"mkdir -p {BACKUP_DIR}")
     assert result.rc == 0, f"Failed to create backup directory on VM: {result.stderr}"
 
     result = subprocess.run(
-        ['./foremanctl', 'backup', BACKUP_DIR, '--target-host', server_hostname],
+        ['./foremanctl', 'backup', BACKUP_DIR, '--target-host', test_target],
         capture_output=True, text=True,
     )
     returncode = result.returncode

--- a/tests/certificates_test.py
+++ b/tests/certificates_test.py
@@ -103,8 +103,8 @@ def test_ca_bundle_verifies_server_certificate(server, certificates):
     assert "OK" in cmd.stdout
 
 
-def test_ca_key_unencrypted(server, server_hostname, certificates):
-    if server_hostname == 'proxy':
+def test_ca_key_unencrypted(server, test_target, certificates):
+    if test_target == 'proxy':
         pytest.skip("no ca key on proxy")
     f = server.file(certificates['ca_key'])
     assert f.exists
@@ -119,8 +119,8 @@ def test_ca_key_password_file_absent(server, certificates):
     assert not server.file(ca_pwd).exists
 
 
-def test_ca_key_matches_ca_certificate(server, server_hostname, certificates):
-    if server_hostname == 'proxy':
+def test_ca_key_matches_ca_certificate(server, test_target, certificates):
+    if test_target == 'proxy':
         pytest.skip("no ca key on proxy")
     key_pub = server.run(f"openssl pkey -in {certificates['ca_key']} -pubout")
     cert_pub = server.run(f"openssl x509 -in {certificates['ca_certificate']} -noout -pubkey")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,8 @@ class UserParameters:
 
 
 def pytest_addoption(parser):
-    parser.addoption("--server-hostname", action="store", default="quadlet", help="Hostname of the server VM to test against")
+    parser.addoption("--test-target", action="store", default="quadlet", help="Hostname of the system to test against")
+    parser.addoption("--server-hostname", action="store", default="quadlet", help="Hostname of the Foreman server")
 
 
 @pytest.fixture(scope="module")
@@ -74,6 +75,11 @@ def available_features(pytestconfig):
 @pytest.fixture(scope="module")
 def fixture_dir():
     return py.path.local(__file__).realpath() / '..' / 'fixtures'
+
+
+@pytest.fixture(scope="module")
+def test_target(pytestconfig):
+    return pytestconfig.getoption("test_target")
 
 
 @pytest.fixture(scope="module")
@@ -131,10 +137,10 @@ def default_certificates(certificate_source):
 
 
 @pytest.fixture(scope="module")
-def quadlet_client_certificate():
-    # this intentionally uses get_paramiko_host directly, as we want the cert of the quadlet box
-    # not the one "server" points at, as that can be the proxy
-    quadlet = get_paramiko_host('quadlet')
+def quadlet_client_certificate(server_hostname):
+    # this intentionally uses get_paramiko_host directly, as we want the cert of the real server box
+    # not the one the "server" fixture points at, as that can be the proxy
+    quadlet = get_paramiko_host(server_hostname)
     hostname = quadlet.run("hostname -f").stdout.strip()
     cert = quadlet.file(f"/var/lib/foremanctl/certs/certs/{hostname}-client.crt").content_string
     key = quadlet.file(f"/var/lib/foremanctl/certs/private/{hostname}-client.key").content_string
@@ -151,8 +157,8 @@ def get_paramiko_host(hostname):
 
 
 @pytest.fixture(scope="module")
-def server(server_hostname):
-    yield get_paramiko_host(server_hostname)
+def server(test_target):
+    yield get_paramiko_host(test_target)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Using `--server-hostname` always felt wrong, as we're not actually changing the hostname of the (Foreman) server, just the system we're running the tests against.

#### What are the changes introduced in this pull request?

* Introduce `--test-target` which now declares what the `server` fixture points at
* The old `--server-hostname` remains if we ever need to change the *server* name
* Tests still use the `server` fixture, refactoring this is left for later

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
