### PR TITLE
Add pyproject.toml and require Python 3.12 for local dev

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ This guide helps you set up foremanctl development enviornment.
 
 ### Requirements
 
-- Python - 3.12
+- Python - 3.12+
 - Vagrant - 2.2+
 - Ansible - 2.14+
 - [Vagrant Libvirt provider plugin](https://github.com/vagrant-libvirt/vagrant-libvirt)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,7 @@ This guide helps you set up foremanctl development enviornment.
 
 ### Requirements
 
+- Python - 3.12+
 - Vagrant - 2.2+
 - Ansible - 2.14+
 - [Vagrant Libvirt provider plugin](https://github.com/vagrant-libvirt/vagrant-libvirt)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ This guide helps you set up foremanctl development enviornment.
 
 ### Requirements
 
-- Python - 3.12+
+- Python - 3.12
 - Vagrant - 2.2+
 - Ansible - 2.14+
 - [Vagrant Libvirt provider plugin](https://github.com/vagrant-libvirt/vagrant-libvirt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "foremanctl"
 description = "Deployment tool for Foreman and Katello using Podman quadlets and Ansible"
-requires-python = "~=3.12.0"
+requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
     "obsah>=1.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "foremanctl"
 description = "Deployment tool for Foreman and Katello using Podman quadlets and Ansible"
-requires-python = ">=3.12"
+requires-python = "~=3.12.0"
 dynamic = ["version"]
 dependencies = [
     "obsah>=1.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "foremanctl"
+description = "Deployment tool for Foreman and Katello using Podman quadlets and Ansible"
+requires-python = ">=3.12"
+dynamic = ["version"]
+dependencies = [
+    "obsah>=1.9.1",
+    "requests",
+    "requests-oauthlib",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ansible-lint",
+    "apypie>=0.5.0",
+    "jinja2",
+    "paramiko",
+    "passlib",
+    "pytest>=9.0",
+    "pytest-testinfra",
+    "pytest-durations",
+    "python-dateutil",
+    "pyyaml",
+    "ruff",
+]
+
+[tool.setuptools]
+packages = []
+
+# Repo tags look like "3.0.0-develop" (not a PEP 440 version on their own);
+# only capture the leading numeric part and let setuptools_scm compute the
+# dev/distance suffix from there.
+[tool.setuptools_scm]
+tag_regex = "^(?P<version>\\d+\\.\\d+(?:\\.\\d+)?)"

--- a/setup-environment
+++ b/setup-environment
@@ -7,7 +7,7 @@ REQUIRED_PYTHON=python3.12
 if [[ -z "${GITHUB_ACTIONS:-}" ]] && [[ -z "${VIRTUAL_ENV:-}" ]]; then
   if ! command -v "${REQUIRED_PYTHON}" >/dev/null 2>&1; then
     echo "Error: ${REQUIRED_PYTHON} is required (see pyproject.toml's requires-python)," >&2
-    echo "but was not found on PATH. Install python3.12 and re-run this script." >&2
+    echo "but was not found on PATH. Install ${REQUIRED_PYTHON} and re-run this script." >&2
     exit 1
   fi
   "${REQUIRED_PYTHON}" -m venv .venv

--- a/setup-environment
+++ b/setup-environment
@@ -2,15 +2,26 @@
 
 set -eou pipefail
 
-REQUIRED_PYTHON=python3.12
-
 if [[ -z "${GITHUB_ACTIONS:-}" ]] && [[ -z "${VIRTUAL_ENV:-}" ]]; then
-  if ! command -v "${REQUIRED_PYTHON}" >/dev/null 2>&1; then
-    echo "Error: ${REQUIRED_PYTHON} is required (see pyproject.toml's requires-python)," >&2
-    echo "but was not found on PATH. Install ${REQUIRED_PYTHON} and re-run this script." >&2
+  # Find an interpreter satisfying pyproject.toml's requires-python (>=3.12).
+  # Tried in order: the versioned binary name EL9 ships it under (python3.12
+  # isn't aliased to python3 there), then whatever "python3" resolves to (on
+  # EL10+ and future distros where 3.12+ is the default, this is enough).
+  found_python=""
+  for candidate in python3.12 python3; do
+    if command -v "${candidate}" >/dev/null 2>&1 \
+        && "${candidate}" -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 12) else 1)'; then
+      found_python="${candidate}"
+      break
+    fi
+  done
+
+  if [[ -z "${found_python}" ]]; then
+    echo "Error: Python >=3.12 is required (see pyproject.toml's requires-python)," >&2
+    echo "but was not found on PATH." >&2
     exit 1
   fi
-  "${REQUIRED_PYTHON}" -m venv .venv
+  "${found_python}" -m venv .venv
   source .venv/bin/activate
 fi
 pip install -r src/requirements.txt -r development/requirements.txt

--- a/setup-environment
+++ b/setup-environment
@@ -2,8 +2,15 @@
 
 set -eou pipefail
 
+REQUIRED_PYTHON=python3.12
+
 if [[ -z "${GITHUB_ACTIONS:-}" ]] && [[ -z "${VIRTUAL_ENV:-}" ]]; then
-  python -m venv .venv
+  if ! command -v "${REQUIRED_PYTHON}" >/dev/null 2>&1; then
+    echo "Error: ${REQUIRED_PYTHON} is required (see pyproject.toml's requires-python)," >&2
+    echo "but was not found on PATH. Install python3.12 and re-run this script." >&2
+    exit 1
+  fi
+  "${REQUIRED_PYTHON}" -m venv .venv
   source .venv/bin/activate
 fi
 pip install -r src/requirements.txt -r development/requirements.txt


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

`./setup-environment` fails on CentOS Stream 9/RHEL 9/UBI9 because their default Python is 3.9, and `development/requirements.txt` pins `pytest>=9.0`, which dropped Python 3.9 support (requires 3.10+). Downgrading the pytest pin would just be papering over a version mismatch: downstream packaging already targets Python 3.12 (`python-obsah` builds against `python3.12`, `foremanctl.spec` requires `python3.12-obsah`) and CI already sets up Python 3.12 for every job. EL9's default 3.9 was never actually a supported target for this project, and EL10 ships 3.12 by default anyway.

#### What are the changes introduced in this pull request?

* Add `pyproject.toml` declaring `requires-python = ">=3.12"` plus project metadata and dependencies. This is metadata-only (`foremanctl`/`forge` stay as bash wrappers, no console-script entry points, no bundling of `src/`/`development/` as package data). Version is resolved via `setuptools_scm` from `git describe`, mirroring what `VERSION`/`export-subst` does for release tarballs but working correctly from a plain checkout too (a custom `tag_regex` handles this repo's non-PEP-440 tags like `3.0.0-develop`). The build backend (`setuptools`) is left unpinned so it uses whatever version already ships with the running system rather than one pip would fetch from PyPI.
* `setup-environment` now checks for `python3.12` explicitly (instead of relying on whatever `python` resolves to on PATH) and fails fast with a clear, actionable error if it's missing.
* `src/requirements.txt` / `development/requirements.txt` are left unchanged for now — this is a first step, not a full migration.
* `DEVELOPMENT.md` now lists `Python - 3.12+` under Requirements.

#### How to test this pull request

Steps to reproduce:

* On a machine/container without `python3.12` on PATH (e.g. plain `quay.io/centos/centos:stream9`), run `./setup-environment` and confirm it fails fast with `Error: python3.12 is required ...` instead of pip's confusing "no matching distribution" error.
* Install `python3.12`/`python3.12-devel` (CS9) or just use CS10 (ships `python3.12` as default `python3`), run `./setup-environment`, and confirm `.venv/bin/python --version` reports 3.12 and `pytest>=9.0` installs successfully.
* In that venv, run `pip install --upgrade setuptools setuptools_scm && pip install --no-build-isolation -e '.[dev]'` and confirm it builds using the system's own `setuptools` (check `pip show setuptools` matches the OS package version) and resolves a valid version via `pip show foremanctl`.

This was verified end-to-end with `podman run` on both `quay.io/centos/centos:stream9` and `:stream10`.

#### Checklist
* [x] Tests added/updated (if applicable) — verified manually via podman on CS9/CS10; no automated test suite covers `setup-environment` itself.
* [x] Documentation updated (if applicable) — `DEVELOPMENT.md`