### PR TITLE
Restore Python 3.9 compatibility

### DIFF
--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -4,7 +4,8 @@ jinja2
 paramiko
 passlib
 ruff
-pytest>=9.0
+pytest>=9.0 ; python_version >= "3.10"
+pytest-subtests ; python_version < "3.10"
 pytest-testinfra
 pytest-durations
 python-dateutil


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

While writing e7fab366c55de531db4fa45052c7f1b5956060a5 I missed that pytest 9 started to require Python 3.10, as pointed out in https://github.com/theforeman/foremanctl/pull/717. This uses the separate package on older versions.

#### What are the changes introduced in this pull request?

* Updates requirements to have a wider compatiblity

#### How to test this pull request

Steps to reproduce:

* Run on Python 3.10+ and verify the subtests run correctly using pytest 9+
* Run on Python 3.9 and verify the subtests run correctly using pytest-subtess

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)