### PR TITLE
Fix Candlepin TLS cipher list for the OpenSSL FFM connector

### DIFF
--- a/src/roles/candlepin/defaults/main.yml
+++ b/src/roles/candlepin/defaults/main.yml
@@ -5,10 +5,7 @@ candlepin_tls_versions:
   - "TLSv1.2"
   - "TLSv1.3"
 candlepin_ciphers:
-  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - "PROFILE=SYSTEM"
 candlepin_container_image: quay.io/foreman/candlepin
 candlepin_container_tag: "4.4.14"
 candlepin_secret_mount_opts: "mode=0440,uid=0,gid=53,type=mount"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

To be able to merge https://github.com/theforeman/candlepin-oci-images/pull/66 :smile: 

#### What are the changes introduced in this pull request?

Candlepin 5.0's Tomcat uses the new OpenSSL FFM connector, which fails to handle the IANA-style cipher names (TLS_ECDHE_...) we were using, leaving the connector with no usable ciphers and every TLS handshake failing. Switch to the legacy OpenSSL cipher naming (ECDHE-ECDSA-AES256-GCM-SHA384, ...) to make it work.

#### How to test this pull request

Verified locally with foremanctl deploy against the Candlepin 5.0.2/ el10 build ([candlepin-oci-images#66](https://github.com/theforeman/candlepin-oci-images/pull/66)): Candlepin now reports (healthy) and /candlepin/status responds 200 consistently.

Steps to reproduce:

Apply the following diff and run with forge:

```bash
diff --git a/src/roles/candlepin/defaults/main.yml b/src/roles/candlepin/defaults/main.yml
index 3d4b139..c2be48a 100644
--- a/src/roles/candlepin/defaults/main.yml
+++ b/src/roles/candlepin/defaults/main.yml
@@ -5,10 +5,10 @@ candlepin_tls_versions:
   - "TLSv1.2"
   - "TLSv1.3"
 candlepin_ciphers:
-  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+ - "PROFILE=SYSTEM"
 candlepin_container_image: quay.io/foreman/candlepin
 candlepin_container_tag: "4.4.14"
 candlepin_secret_mount_opts: "mode=0440,uid=0,gid=53,type=mount"
diff --git a/src/vars/images.yml b/src/vars/images.yml
index 0782530..8dc47ec 100644
--- a/src/vars/images.yml
+++ b/src/vars/images.yml
@@ -2,8 +2,8 @@ images_quadlet_dir: /etc/containers/systemd
 images_registry_auth_file: /etc/foreman/registry-auth.json
 
 container_tag_stream: "nightly"
-candlepin_container_image: quay.io/foreman/candlepin
-candlepin_container_tag: "foreman-{{ container_tag_stream }}"
+candlepin_container_image: quay.io/foreman/stage/candlepin
+candlepin_container_tag: "pull-request-66"
 foreman_container_image: quay.io/foreman/foreman
 foreman_container_tag: "{{ container_tag_stream }}"
 foreman_proxy_container_image: "quay.io/foreman/foreman-proxy"

```

