### PR TITLE
update fdw in iop_inventory

### DIFF
--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -241,17 +241,15 @@
         h.display_name,
         h.created_on as created,
         h.modified_on as updated,
-        h.last_check_in + INTERVAL '29 hours' AS stale_timestamp,
-        h.last_check_in + INTERVAL '7 days' AS stale_warning_timestamp,
-        h.last_check_in + INTERVAL '30 days' AS culled_timestamp,
+        h.stale_timestamp,
+        h.stale_warning_timestamp,
+        h.deletion_timestamp AS culled_timestamp,
         h.tags_alt as tags,
         h.system_profile_facts as system_profile,
-        h.insights_id,
+        (h.canonical_facts ->> 'insights_id')::uuid as insights_id,
         h.reporter,
         h.per_reporter_staleness,
         h.org_id,
-        h.groups,
-        h.last_check_in
+        h.groups
       FROM hbi.hosts h
-      LEFT JOIN hbi.system_profiles_static sps ON sps.org_id = h.org_id AND sps.host_id = h.id
-      WHERE h.insights_id != '00000000-0000-0000-0000-000000000000';
+      WHERE (h.canonical_facts->'insights_id' IS NOT NULL);

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -232,7 +232,6 @@
     login_host: localhost
     # TODO(RHINENG-26911): remove this view once Cyndi decommission completes
     # across all IoP services.
-    # Staleness intervals are hardcoded HBI defaults (29h, 7d, 30d).
     # Per-org custom staleness from hbi.staleness is not supported.
     query: |
       CREATE OR REPLACE VIEW "inventory"."hosts" AS SELECT

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -250,6 +250,7 @@
         h.reporter,
         h.per_reporter_staleness,
         h.org_id,
-        h.groups
+        h.groups,
+        h.last_check_in
       FROM hbi.hosts h
       WHERE (h.canonical_facts->'insights_id' IS NOT NULL);

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -245,7 +245,7 @@
         h.last_check_in + INTERVAL '7 days' AS stale_warning_timestamp,
         h.last_check_in + INTERVAL '30 days' AS culled_timestamp,
         h.tags_alt as tags,
-        jsonb_build_object('operating_system', sps.operating_system, 'host_type', sps.host_type, 'owner_id', sps.owner_id) as system_profile,
+        h.system_profile_facts as system_profile,
         h.insights_id,
         h.reporter,
         h.per_reporter_staleness,


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The VIEW inventory.hosts should match between:

- foremanctl - [foremanctl/src/roles/iop_inventory/tasks/main.yaml at master · theforeman/foremanctl](https://github.com/theforeman/foremanctl/blob/master/src/roles/iop_inventory/tasks/main.yaml) 
- insights-host-inventory foreman-3.18 - [insights-host-inventory/jobs/add_inventory_view.py at foreman-3.18 · RedHatInsights/insights-host-inventory](https://github.com/RedHatInsights/insights-host-inventory/blob/foreman-3.18/jobs/add_inventory_view.py) 
- insights-host-inventory foreman-3.16 - [insights-host-inventory/jobs/add_inventory_view.py at foreman-3.16 · RedHatInsights/insights-host-inventory](https://github.com/RedHatInsights/insights-host-inventory/blob/foreman-3.16/jobs/add_inventory_view.py)

#### What are the changes introduced in this pull request?

* `system_profile_facts as system_profile` instead of computing it from columns which are NULL

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
