### PR TITLE
Bind Valkey to localhost only

### DIFF
--- a/src/roles/valkey/tasks/main.yaml
+++ b/src/roles/valkey/tasks/main.yaml
@@ -20,7 +20,7 @@
     state: quadlet
     network: host
     sdnotify: true
-    command: ["run-valkey", "--supervised", "systemd", "--loglevel", "{{ valkey_log_level }}"]
+    command: ["run-valkey", "--supervised", "systemd", "--loglevel", "{{ valkey_log_level }}", "--bind", "127.0.0.1", "-::1"]
     volumes:
       - /var/lib/valkey:/data:rw,Z
     quadlet_options:

--- a/tests/valkey_test.py
+++ b/tests/valkey_test.py
@@ -15,3 +15,9 @@ def test_redis_service_absent(server):
 def test_valkey_port(server):
     valkey = server.addr(VALKEY_HOST)
     assert valkey.port(VALKEY_PORT).is_reachable
+
+
+def test_valkey_listens_on_localhost_only(server):
+    result = server.run(f"ss -tlnH sport = :{VALKEY_PORT}")
+    assert f'127.0.0.1:{VALKEY_PORT}' in result.stdout
+    assert f'0.0.0.0:{VALKEY_PORT}' not in result.stdout


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Valkey listens on all interfaces (0.0.0.0:6379) by default when using `network: host`. While firewalld blocks external access, if the firewall is misconfigured or disabled, Valkey becomes directly accessible from outside the host:

Before fix (with firewall stopped):
```
# nmap -p6379 quadlet.example.com
Starting Nmap 7.98 ( https://nmap.org ) at 2026-08-05 17:03 +0530
Nmap scan report for  quadlet.example.com (10.0.167.101)
Host is up (0.28s latency).

PORT     STATE  SERVICE
6379/tcp open redis

Nmap done: 1 IP address (1 host up) scanned in 1.15 seconds
```
All Valkey consumers (Foreman, Candlepin, Pulp) connect via localhost, so there is no reason for Valkey to listen on external interfaces.
Ref: https://valkey.io/topics/security/ recommends binding to localhost when accessed locally only.

#### What are the changes introduced in this pull request?

* Add --bind 127.0.0.1 to the Valkey container command to restrict listening to localhost only
* Add tests verifying Valkey only listens on localhost, when firewalld is stopped

#### How to test this pull request

1. Deploy with the change
    ./foremanctl deploy
2. Verify Valkey only listens on localhost
    ss -tlnp | grep 6379 (Expected: 127.0.0.1:6379 (not 0.0.0.0:6379))
3. Verify services still work with "hammer ping"

4. Verify not exposed even without firewall
     systemctl stop firewalld
     ss -tlnp | grep 6379 (Expected: still 127.0.0.1:6379)
     nmap -p6379 <server-fqdn>  # from external host, Expected: filtered or closed
     systemctl start firewalld


Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
