### PR TITLE
Add role-scoped-variables ansible-lint rule

### DIFF
--- a/.ansible-lint-rules/role_scoped_variables.py
+++ b/.ansible-lint-rules/role_scoped_variables.py
@@ -1,0 +1,136 @@
+"""Implementation of role-scoped-variables rule."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from jinja2 import Environment, TemplateSyntaxError, nodes
+from jinja2.meta import find_undeclared_variables
+
+from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.yaml_utils import nested_items_path
+
+if TYPE_CHECKING:
+    from ansiblelint.file_utils import Lintable
+
+_JINJA_ENV = Environment()
+
+_IMPLICIT_JINJA_KEYS = frozenset({"when", "failed_when", "changed_when", "until"})
+
+ANSIBLE_BUILTINS = frozenset({
+    "item",
+    "omit",
+    "inventory_hostname",
+    "inventory_hostname_short",
+    "inventory_dir",
+    "inventory_file",
+    "groups",
+    "group_names",
+    "hostvars",
+    "play_hosts",
+    "playbook_dir",
+    "role_path",
+    "role_name",
+    "environment",
+})
+
+ALLOWED_GLOBALS = frozenset({
+    "obsah_state_path",
+})
+
+_IGNORED_TASK_KEYS = ("block", "ansible.builtin.block", "ansible.legacy.block")
+
+
+def _find_call_targets(ast_node: nodes.Template) -> set[str]:
+    """Find names used as function calls, not variable references."""
+    targets: set[str] = set()
+    for call in ast_node.find_all(nodes.Call):
+        if isinstance(call.node, nodes.Name):
+            targets.add(call.node.name)
+    return targets
+
+
+def _extract_jinja_vars(text: str, *, implicit: bool = False) -> set[str]:
+    """Extract variable references from a Jinja2 string, excluding function calls."""
+    if implicit:
+        text = "{{ " + text + " }}"
+    elif "{{" not in text and "{%" not in text:
+        return set()
+    try:
+        ast = _JINJA_ENV.parse(text)
+        return find_undeclared_variables(ast) - _find_call_targets(ast)
+    except TemplateSyntaxError:
+        return set()
+
+
+def _is_allowed(var: str, role_prefix: str) -> bool:
+    """Check if a variable reference is allowed inside this role."""
+    if var.startswith(role_prefix) or var.lstrip("_").startswith(role_prefix):
+        return True
+    if var.startswith("_"):
+        return True
+    if var.startswith("ansible_"):
+        return True
+    if var in ANSIBLE_BUILTINS:
+        return True
+    if var in ALLOWED_GLOBALS:
+        return True
+    return False
+
+
+class RoleScopedVariablesRule(AnsibleLintRule):
+    """Role task files must only reference role-scoped variables."""
+
+    id = "role-scoped-variables"
+    description = (
+        "Variables referenced inside a role's tasks must be prefixed with "
+        "the role name, be Ansible built-ins, or be on the allowed globals "
+        "list. Shared variables should be mapped to role-prefixed names in "
+        "the playbook that invokes the role."
+    )
+    severity = "MEDIUM"
+    tags = ["idiom"]
+    version_added = "custom"
+
+    def matchtask(
+        self, task: dict[str, Any], file: Lintable | None = None,
+    ) -> bool | str:
+        """Flag tasks that reference variables not scoped to their role."""
+        if not file or not file.role:
+            return False
+
+        role_prefix = file.role + "_"
+        variables: set[str] = set()
+
+        local_vars: set[str] = set()
+        task_vars = task.get("vars", {})
+        if isinstance(task_vars, dict):
+            local_vars.update(task_vars.keys())
+
+        loop_control = task.get("loop_control", {})
+        if isinstance(loop_control, dict):
+            loop_var = loop_control.get("loop_var")
+            if isinstance(loop_var, str):
+                local_vars.add(loop_var)
+
+        for key, value, path in nested_items_path(
+            task, ignored_keys=_IGNORED_TASK_KEYS,
+        ):
+            if isinstance(value, str):
+                implicit = key in _IMPLICIT_JINJA_KEYS or any(
+                    p in _IMPLICIT_JINJA_KEYS for p in path
+                )
+                variables.update(_extract_jinja_vars(value, implicit=implicit))
+
+        variables -= local_vars
+
+        violations = sorted(
+            v for v in variables if not _is_allowed(v, role_prefix)
+        )
+
+        if violations:
+            return (
+                f"Variables not scoped to role '{file.role}': "
+                + ", ".join(violations)
+            )
+        return False

--- a/development/playbooks/deploy-dev/deploy-dev.yaml
+++ b/development/playbooks/deploy-dev/deploy-dev.yaml
@@ -55,12 +55,19 @@
         foreman_development_oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
         foreman_development_oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"
         foreman_development_candlepin_oauth_secret: "{{ candlepin_oauth_secret }}"
+        foreman_development_httpd_server_ca_certificate: "{{ httpd_server_ca_certificate }}"
+        foreman_development_httpd_server_certificate: "{{ httpd_server_certificate }}"
+        foreman_development_httpd_server_key: "{{ httpd_server_key }}"
     - role: iop_core
       when:
         - "enabled_features | has_feature('iop')"
       vars:
         iop_core_foreman_oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
         iop_core_foreman_oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"
+        iop_core_postgresql_admin_password: "{{ postgresql_admin_password }}"
+        iop_core_inventory_database_name: "{{ iop_inventory_database_name }}"
+        iop_core_inventory_database_user: "{{ iop_inventory_database_user }}"
+        iop_core_inventory_database_password: "{{ iop_inventory_database_password }}"
   post_tasks:
     - name: Stop Foreman development service
       ansible.builtin.include_role:

--- a/development/roles/foreman_development/tasks/smart-proxy/main.yml
+++ b/development/roles/foreman_development/tasks/smart-proxy/main.yml
@@ -24,11 +24,11 @@
     mode: "0640"
     owner: "{{ foreman_development_user }}"
   loop:
-    - src: "{{ httpd_server_ca_certificate }}"
+    - src: "{{ foreman_development_httpd_server_ca_certificate }}"
       dest: "ca.crt"
-    - src: "{{ httpd_server_certificate }}"
+    - src: "{{ foreman_development_httpd_server_certificate }}"
       dest: "proxy.crt"
-    - src: "{{ httpd_server_key }}"
+    - src: "{{ foreman_development_httpd_server_key }}"
       dest: "proxy.key"
 
 - name: Create smart-proxy settings.d file from template

--- a/src/playbooks/backup/backup.yaml
+++ b/src/playbooks/backup/backup.yaml
@@ -21,5 +21,12 @@
     - role: backup
       vars:
         backup_database_mode: "{{ database_mode }}"
+        backup_database_host: "{{ database_host }}"
+        backup_database_port: "{{ database_port }}"
         backup_databases: "{{ all_databases }}"
         backup_pulp_storage_path: "{{ pulp_storage_path }}"
+        backup_enabled_features: "{{ enabled_features }}"
+        backup_skip_pulp_content: "{{ skip_pulp_content | default(false) }}"
+        backup_wait_for_tasks: "{{ wait_for_tasks | default(false) }}"
+        backup_task_wait_timeout: "{{ task_wait_timeout | default(3600) }}"
+        backup_postgresql_admin_password: "{{ postgresql_admin_password }}"

--- a/src/playbooks/checks/checks.yaml
+++ b/src/playbooks/checks/checks.yaml
@@ -12,3 +12,7 @@
     - role: checks
       vars:
         checks_databases: "{{ all_databases }}"
+        checks_database_mode: "{{ database_mode }}"
+        checks_database_host: "{{ database_host }}"
+        checks_database_port: "{{ database_port }}"
+        checks_postgresql_admin_password: "{{ postgresql_admin_password }}"

--- a/src/playbooks/deploy-proxy/deploy-proxy.yaml
+++ b/src/playbooks/deploy-proxy/deploy-proxy.yaml
@@ -19,6 +19,10 @@
     - role: checks
       vars:
         checks_databases: "{{ all_databases }}"
+        checks_database_mode: "{{ database_mode }}"
+        checks_database_host: "{{ database_host }}"
+        checks_database_port: "{{ database_port }}"
+        checks_postgresql_admin_password: "{{ postgresql_admin_password }}"
     - role: certificates
     - role: certificate_checks
       vars:
@@ -33,9 +37,17 @@
     - httpd
     - pulp
     - systemd_target
-    - foreman_proxy
+    - role: foreman_proxy
+      vars:
+        foreman_proxy_ca_certificate: "{{ ca_certificate }}"
+        foreman_proxy_server_certificate: "{{ server_certificate }}"
+        foreman_proxy_server_key: "{{ server_key }}"
+        foreman_proxy_server_ca_certificate: "{{ server_ca_certificate }}"
+        foreman_proxy_client_certificate: "{{ client_certificate }}"
+        foreman_proxy_client_key: "{{ client_key }}"
     - role: post_install
       vars:
+        post_install_flavor: "{{ flavor }}"
         post_install_foreman_ca_path: "{{ foreman_proxy_foreman_ca_certificate | default(omit) }}"
         post_install_foreman_oauth_consumer_key: "{{ foreman_proxy_oauth_consumer_key }}"
         post_install_foreman_oauth_consumer_secret: "{{ foreman_proxy_oauth_consumer_secret }}"

--- a/src/playbooks/deploy/deploy.yaml
+++ b/src/playbooks/deploy/deploy.yaml
@@ -20,6 +20,10 @@
     - role: checks
       vars:
         checks_databases: "{{ all_databases }}"
+        checks_database_mode: "{{ database_mode }}"
+        checks_database_host: "{{ database_host }}"
+        checks_database_port: "{{ database_port }}"
+        checks_postgresql_admin_password: "{{ postgresql_admin_password }}"
     - role: certificates
     - role: certificate_checks
       vars:
@@ -36,10 +40,22 @@
     - pulp
     - role: systemd_target
     - role: iop_core
+      vars:
+        iop_core_postgresql_admin_password: "{{ postgresql_admin_password }}"
+        iop_core_inventory_database_name: "{{ iop_inventory_database_name }}"
+        iop_core_inventory_database_user: "{{ iop_inventory_database_user }}"
+        iop_core_inventory_database_password: "{{ iop_inventory_database_password }}"
       when:
         - "enabled_features | has_feature('iop')"
         - database_mode == 'internal'
     - role: foreman_proxy
+      vars:
+        foreman_proxy_ca_certificate: "{{ ca_certificate }}"
+        foreman_proxy_server_certificate: "{{ server_certificate }}"
+        foreman_proxy_server_key: "{{ server_key }}"
+        foreman_proxy_server_ca_certificate: "{{ server_ca_certificate }}"
+        foreman_proxy_client_certificate: "{{ client_certificate }}"
+        foreman_proxy_client_key: "{{ client_key }}"
       when:
         - "enabled_features | has_feature('foreman-proxy')"
     - role: hammer
@@ -47,6 +63,7 @@
         - "enabled_features | has_feature('hammer')"
     - role: post_install
       vars:
+        post_install_flavor: "{{ flavor }}"
         post_install_foreman_ca_path: "{{ foreman_ca_certificate }}"
         post_install_foreman_oauth_consumer_key: "{{ foreman_oauth_consumer_key }}"
         post_install_foreman_oauth_consumer_secret: "{{ foreman_oauth_consumer_secret }}"

--- a/src/roles/backup/tasks/main.yaml
+++ b/src/roles/backup/tasks/main.yaml
@@ -63,7 +63,7 @@
 
     - name: Wait for PostgreSQL readiness
       ansible.builtin.command:
-        cmd: pg_isready -h {{ database_host }} -p {{ database_port }}
+        cmd: pg_isready -h {{ backup_database_host }} -p {{ backup_database_port }}
       register: backup_pg_ready
       retries: "{{ backup_postgresql_ready_retries }}"
       delay: "{{ backup_postgresql_ready_delay }}"
@@ -77,8 +77,8 @@
         db_entry:
           name: "{{ item.name }}"
           database: "{{ item.database }}"
-          host: "{{ database_host }}"
-          port: "{{ database_port }}"
+          host: "{{ backup_database_host }}"
+          port: "{{ backup_database_port }}"
           user: "{{ item.user }}"
           password: "{{ item.password }}"
       loop: "{{ backup_databases }}"
@@ -117,7 +117,7 @@
     - name: Backup pulp content
       ansible.builtin.include_tasks:
         file: pulp_content.yaml
-      when: not skip_pulp_content | default(false)
+      when: not backup_skip_pulp_content
 
     - name: Generate backup metadata
       ansible.builtin.include_tasks:

--- a/src/roles/backup/tasks/metadata.yaml
+++ b/src/roles/backup/tasks/metadata.yaml
@@ -44,7 +44,7 @@
       timestamp: "{{ backup_timestamp }}"
       databases: "{{ backup_databases_to_backup }}"
       database_mapping: "{{ backup_databases_config | items2dict(key_name='name', value_name='database') }}"
-      enabled_features: "{{ enabled_features | default([]) }}"
+      enabled_features: "{{ backup_enabled_features | default([]) }}"
       database_mode: "{{ backup_database_mode }}"
       container_images: "{{ backup_container_images_detailed | default([]) }}"
       backed_up_components: >-

--- a/src/roles/backup/tasks/preflight.yaml
+++ b/src/roles/backup/tasks/preflight.yaml
@@ -23,10 +23,10 @@
     oauth1_consumer_secret: "{{ backup_foreman_oauth_consumer_secret }}"
     ca_path: "{{ backup_foreman_ca_certificate }}"
     task: "{{ item }}"
-    timeout: "{{ task_wait_timeout | default(3600) }}"
+    timeout: "{{ backup_task_wait_timeout }}"
   loop: "{{ backup_foreman_tasks_check.resources | map(attribute='id') | list }}"
   when:
-    - wait_for_tasks | default(false)
+    - backup_wait_for_tasks
     - backup_foreman_running_tasks | int > 0
   changed_when: false
   no_log: true
@@ -37,7 +37,7 @@
       There are {{ backup_foreman_running_tasks }} running Foreman task(s).
       Please wait for these to complete or use --wait-for-tasks flag.
   when:
-    - not (wait_for_tasks | default(false))
+    - not (backup_wait_for_tasks)
     - backup_foreman_running_tasks | int > 0
 
 - name: Check for running Pulp tasks
@@ -73,7 +73,7 @@
   retries: "{{ backup_task_wait_retries }}"
   delay: "{{ backup_task_wait_delay }}"
   when:
-    - wait_for_tasks | default(false)
+    - backup_wait_for_tasks
     - backup_pulp_running_tasks | default(0) | int > 0
   changed_when: false
   no_log: true
@@ -84,7 +84,7 @@
       There are {{ backup_pulp_running_tasks }} running Pulp task(s).
       Please wait for these to complete or use --wait-for-tasks flag.
   when:
-    - not wait_for_tasks | default(false)
+    - not backup_wait_for_tasks
     - backup_pulp_running_tasks | default(0) | int > 0
 
 - name: Run database index integrity checks
@@ -92,6 +92,9 @@
     name: check_database_index
   vars:
     check_database_index_database: "{{ item.database }}"
+    check_database_index_database_host: "{{ backup_database_host }}"
+    check_database_index_database_port: "{{ backup_database_port }}"
+    check_database_index_admin_password: "{{ backup_postgresql_admin_password }}"
   loop: "{{ backup_databases }}"
   no_log: true
   when: backup_database_mode == 'internal'

--- a/src/roles/backup/tasks/pulp_content.yaml
+++ b/src/roles/backup/tasks/pulp_content.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Backup pulp content
-  when: not skip_pulp_content | default(false)
+  when: not backup_skip_pulp_content
   block:
     - name: Backup pulp content directory with encryption keys  # noqa: command-instead-of-module
       ansible.builtin.command:

--- a/src/roles/check_database_connection/tasks/check.yaml
+++ b/src/roles/check_database_connection/tasks/check.yaml
@@ -1,7 +1,7 @@
 - name: Store CA cert to a temporary file
   when:
-    - db_item.ssl_ca is defined
-    - db_item.ssl_ca is truthy
+    - _db_item.ssl_ca is defined
+    - _db_item.ssl_ca is truthy
   block:
     - name: Create temporary file
       ansible.builtin.tempfile:
@@ -12,35 +12,35 @@
     - name: Write CA cert to temporary file
       ansible.builtin.copy:
         dest: "{{ _check_database_connection_ca_cert.path }}"
-        src: "{{ db_item.ssl_ca }}"
+        src: "{{ _db_item.ssl_ca }}"
         mode: '0640'
 
-- name: Check database connectivity to {{ db_item.name }}
+- name: Check database connectivity to {{ _db_item.name }}
   community.postgresql.postgresql_ping:
-    login_host: "{{ db_item.host }}"
-    login_user: "{{ db_item.user }}"
-    login_password: "{{ db_item.password }}"
-    login_db: "{{ db_item.database }}"
+    login_host: "{{ _db_item.host }}"
+    login_user: "{{ _db_item.user }}"
+    login_password: "{{ _db_item.password }}"
+    login_db: "{{ _db_item.database }}"
     ca_cert: "{{ _check_database_connection_ca_cert.path | default(omit) }}"
-    ssl_mode: "{{ db_item.ssl_mode | default(omit) }}"
+    ssl_mode: "{{ _db_item.ssl_mode | default(omit) }}"
   register: check_database_connection_ping_result
   ignore_errors: true
 
 - name: Delete temporary CA cert file
   when:
-    - db_item.ssl_ca is defined
-    - db_item.ssl_ca is truthy
+    - _db_item.ssl_ca is defined
+    - _db_item.ssl_ca is truthy
   block:
     - name: Delete temporary file
       ansible.builtin.file:
         state: absent
         path: "{{ _check_database_connection_ca_cert.path }}"
 
-- name: Assert database is reachable for {{ db_item.name }}
+- name: Assert database is reachable for {{ _db_item.name }}
   ansible.builtin.assert:
     that:
       - check_database_connection_ping_result.is_available
     fail_msg: >
-      Cannot connect to {{ db_item.name }} database '{{ db_item.database }}' at {{ db_item.host }}.
+      Cannot connect to {{ _db_item.name }} database '{{ _db_item.database }}' at {{ _db_item.host }}.
       Please verify the database host, port, name, user, and password.
       Error: {{ check_database_connection_ping_result.conn_err_msg | default('No error message available.') }}

--- a/src/roles/check_database_connection/tasks/main.yaml
+++ b/src/roles/check_database_connection/tasks/main.yaml
@@ -4,6 +4,6 @@
   no_log: true
   loop: "{{ checks_databases }}"
   loop_control:
-    loop_var: db_item
-    label: "{{ db_item.name }}"
+    loop_var: _db_item
+    label: "{{ _db_item.name }}"
   when: database_mode == 'external'

--- a/src/roles/check_database_index/tasks/main.yml
+++ b/src/roles/check_database_index/tasks/main.yml
@@ -2,10 +2,10 @@
 - name: Check if amcheck extension is installed
   community.postgresql.postgresql_query:
     login_db: "{{ check_database_index_database }}"
-    login_host: "{{ database_host }}"
-    login_port: "{{ database_port }}"
+    login_host: "{{ check_database_index_database_host }}"
+    login_port: "{{ check_database_index_database_port }}"
     login_user: postgres
-    login_password: "{{ postgresql_admin_password }}"
+    login_password: "{{ check_database_index_admin_password }}"
     query: SELECT COUNT(*) as count FROM pg_extension WHERE extname = 'amcheck'
   register: check_database_index_amcheck_installed
   failed_when: false
@@ -19,10 +19,10 @@
     - name: Execute amcheck integrity check
       community.postgresql.postgresql_query:
         login_db: "{{ check_database_index_database }}"
-        login_host: "{{ database_host }}"
-        login_port: "{{ database_port }}"
+        login_host: "{{ check_database_index_database_host }}"
+        login_port: "{{ check_database_index_database_port }}"
         login_user: postgres
-        login_password: "{{ postgresql_admin_password }}"
+        login_password: "{{ check_database_index_admin_password }}"
         query: |
           SELECT bt_index_check(index => c.oid, heapallindexed => i.indisunique),
                  c.relname,

--- a/src/roles/check_system_requirements/tasks/main.yaml
+++ b/src/roles/check_system_requirements/tasks/main.yaml
@@ -1,18 +1,18 @@
 - name: Load tuning thresholds based on tuning
   ansible.builtin.include_vars:
     file: "../../vars/tuning/{{ tuning }}.yml"
-    name: tuning_vars
+    name: _tuning_vars
 
 - name: Check if system has enough CPU cores
   ansible.builtin.assert:
     that:
-      - ansible_facts['processor_nproc'] >= tuning_vars.min_cpu_cores
-    fail_msg: "System must have at least {{ tuning_vars.min_cpu_cores }} CPU cores, but only {{ ansible_facts['processor_nproc'] }} available."
+      - ansible_facts['processor_nproc'] >= _tuning_vars.min_cpu_cores
+    fail_msg: "System must have at least {{ _tuning_vars.min_cpu_cores }} CPU cores, but only {{ ansible_facts['processor_nproc'] }} available."
 
 # Check if it's actually 90% of the required. If a crash kernel is enabled
 # then the reported total memory is lower than in reality.
 - name: Check if system has enough RAM
   ansible.builtin.assert:
     that:
-      - ansible_facts['memtotal_mb'] >= (tuning_vars.min_ram_mb * 0.9)
-    fail_msg: "System must have at least {{ tuning_vars.min_ram_mb }} MB RAM, but only {{ ansible_facts['memtotal_mb'] }} available."
+      - ansible_facts['memtotal_mb'] >= (_tuning_vars.min_ram_mb * 0.9)
+    fail_msg: "System must have at least {{ _tuning_vars.min_ram_mb }} MB RAM, but only {{ ansible_facts['memtotal_mb'] }} available."

--- a/src/roles/checks/tasks/main.yml
+++ b/src/roles/checks/tasks/main.yml
@@ -8,9 +8,12 @@
     name: check_database_index
   vars:
     check_database_index_database: "{{ item.database }}"
+    check_database_index_database_host: "{{ checks_database_host }}"
+    check_database_index_database_port: "{{ checks_database_port }}"
+    check_database_index_admin_password: "{{ checks_postgresql_admin_password }}"
   loop: "{{ checks_databases }}"
   no_log: true
-  when: database_mode == 'internal'
+  when: checks_database_mode == 'internal'
 
 - name: Report status of checks
   ansible.builtin.fail:

--- a/src/roles/foreman_proxy/tasks/certs.yaml
+++ b/src/roles/foreman_proxy/tasks/certs.yaml
@@ -2,8 +2,7 @@
 - name: Create the podman secret for Foreman Proxy CA certificate
   containers.podman.podman_secret:
     name: foreman-proxy-ssl-ca
-    path: "{{ ca_certificate }}"
-    state: present
+    path: "{{ foreman_proxy_ca_certificate }}"
   notify:
     - Restart Foreman Proxy
 
@@ -11,7 +10,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-proxy-ssl-cert
-    path: "{{ server_certificate }}"
+    path: "{{ foreman_proxy_server_certificate }}"
   notify:
     - Restart Foreman Proxy
 
@@ -19,7 +18,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-proxy-ssl-key
-    path: "{{ server_key }}"
+    path: "{{ foreman_proxy_server_key }}"
   notify:
     - Restart Foreman Proxy
 
@@ -27,7 +26,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-proxy-foreman-ssl-ca
-    path: "{{ server_ca_certificate }}"
+    path: "{{ foreman_proxy_server_ca_certificate }}"
   notify:
     - Restart Foreman Proxy
 
@@ -35,7 +34,7 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-proxy-foreman-ssl-cert
-    path: "{{ client_certificate }}"
+    path: "{{ foreman_proxy_client_certificate }}"
   notify:
     - Restart Foreman Proxy
 
@@ -43,6 +42,6 @@
   containers.podman.podman_secret:
     state: present
     name: foreman-proxy-foreman-ssl-key
-    path: "{{ client_key }}"
+    path: "{{ foreman_proxy_client_key }}"
   notify:
     - Restart Foreman Proxy

--- a/src/roles/foreman_proxy/tasks/feature.yaml
+++ b/src/roles/foreman_proxy/tasks/feature.yaml
@@ -1,19 +1,19 @@
 ---
-- name: Create config secret for {{ feature_name }}
+- name: Create config secret for {{ _feature_name }}
   containers.podman.podman_secret:
     state: present
-    name: foreman-proxy-{{ feature_name }}-yml
-    data: "{{ lookup('ansible.builtin.template', 'settings.d/' + feature_name + '.yml.j2') if feature_enabled != 'false' else ':enabled: false' }}"
+    name: foreman-proxy-{{ _feature_name }}-yml
+    data: "{{ lookup('ansible.builtin.template', 'settings.d/' + _feature_name + '.yml.j2') if _feature_enabled != 'false' else ':enabled: false' }}"
   notify:
     - Restart Foreman Proxy
     - Refresh Foreman Proxy
 
-- name: Mount config secret for {{ feature_name }}
+- name: Mount config secret for {{ _feature_name }}
   ansible.builtin.copy:
-    dest: /etc/containers/systemd/foreman-proxy.container.d/{{ feature_name }}.conf
+    dest: /etc/containers/systemd/foreman-proxy.container.d/{{ _feature_name }}.conf
     content: |
       [Container]
-      Secret=foreman-proxy-{{ feature_name }}-yml,type=mount,target=/etc/foreman-proxy/settings.d/{{ feature_name }}.yml
+      Secret=foreman-proxy-{{ _feature_name }}-yml,type=mount,target=/etc/foreman-proxy/settings.d/{{ _feature_name }}.yml
     mode: '0644'
     owner: root
     group: root
@@ -21,11 +21,11 @@
     - Restart Foreman Proxy
     - Refresh Foreman Proxy
 
-- name: Include additional tasks for {{ feature_name }}
+- name: Include additional tasks for {{ _feature_name }}
   ansible.builtin.include_tasks: '{{ tasks_file }}'
   when:
-    - feature_enabled != "false"
+    - _feature_enabled != "false"
     - tasks_file is not none
     - tasks_file != ""
   vars:
-    tasks_file: "{{ lookup('ansible.builtin.first_found', ['feature/' + feature_name + '.yaml'], errors='ignore') }}"
+    tasks_file: "{{ lookup('ansible.builtin.first_found', ['feature/' + _feature_name + '.yaml'], errors='ignore') }}"

--- a/src/roles/foreman_proxy/tasks/main.yaml
+++ b/src/roles/foreman_proxy/tasks/main.yaml
@@ -43,18 +43,18 @@
 - name: Configure features
   ansible.builtin.include_tasks: feature.yaml
   vars:
-    feature_enabled: "true"
+    _feature_enabled: "true"
   loop: "{{ foreman_proxy_features }}"
   loop_control:
-    loop_var: feature_name
+    loop_var: _feature_name
 
 - name: Disable features
   ansible.builtin.include_tasks: feature.yaml
   vars:
-    feature_enabled: "false"
+    _feature_enabled: "false"
   loop: "{{ foreman_proxy_disabled_features }}"
   loop_control:
-    loop_var: feature_name
+    loop_var: _feature_name
 
 - name: Run daemon reload to make Quadlet create the service files
   ansible.builtin.systemd:

--- a/src/roles/iop_advisor/tasks/main.yaml
+++ b/src/roles/iop_advisor/tasks/main.yaml
@@ -138,6 +138,6 @@
   vars:
     iop_fdw_database_name: "{{ iop_advisor_database_name }}"
     iop_fdw_database_user: "{{ iop_advisor_database_user }}"
-    iop_fdw_remote_database_name: "{{ iop_inventory_database_name }}"
-    iop_fdw_remote_user: "{{ iop_inventory_database_user }}"
-    iop_fdw_remote_password: "{{ iop_inventory_database_password }}"
+    iop_fdw_remote_database_name: "{{ iop_advisor_fdw_remote_database_name }}"
+    iop_fdw_remote_user: "{{ iop_advisor_fdw_remote_database_user }}"
+    iop_fdw_remote_password: "{{ iop_advisor_fdw_remote_database_password }}"

--- a/src/roles/iop_core/tasks/main.yaml
+++ b/src/roles/iop_core/tasks/main.yaml
@@ -39,10 +39,16 @@
 - name: Deploy IOP Inventory service
   ansible.builtin.include_role:
     name: iop_inventory
+  vars:
+    iop_inventory_postgresql_admin_password: "{{ iop_core_postgresql_admin_password }}"
 
 - name: Deploy IOP Advisor service
   ansible.builtin.include_role:
     name: iop_advisor
+  vars:
+    iop_advisor_fdw_remote_database_name: "{{ iop_core_inventory_database_name }}"
+    iop_advisor_fdw_remote_database_user: "{{ iop_core_inventory_database_user }}"
+    iop_advisor_fdw_remote_database_password: "{{ iop_core_inventory_database_password }}"
 
 - name: Deploy IOP Remediation service
   ansible.builtin.include_role:
@@ -63,6 +69,10 @@
 - name: Deploy IOP Vulnerability service
   ansible.builtin.include_role:
     name: iop_vulnerability
+  vars:
+    iop_vulnerability_fdw_remote_database_name: "{{ iop_core_inventory_database_name }}"
+    iop_vulnerability_fdw_remote_database_user: "{{ iop_core_inventory_database_user }}"
+    iop_vulnerability_fdw_remote_database_password: "{{ iop_core_inventory_database_password }}"
 
 - name: Deploy IOP Inventory Frontend
   ansible.builtin.include_role:

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -212,7 +212,7 @@
     name: postgres_fdw
     login_db: "{{ iop_inventory_database_name }}"
     login_user: postgres
-    login_password: "{{ postgresql_admin_password }}"
+    login_password: "{{ iop_inventory_postgresql_admin_password }}"
     login_host: localhost
 
 - name: Create inventory schema in inventory database
@@ -221,14 +221,14 @@
     name: inventory
     owner: "{{ iop_inventory_database_user }}"
     login_user: postgres
-    login_password: "{{ postgresql_admin_password }}"
+    login_password: "{{ iop_inventory_postgresql_admin_password }}"
     login_host: localhost
 
 - name: Create inventory.hosts view in inventory database
   community.postgresql.postgresql_query:
     login_db: "{{ iop_inventory_database_name }}"
     login_user: postgres
-    login_password: "{{ postgresql_admin_password }}"
+    login_password: "{{ iop_inventory_postgresql_admin_password }}"
     login_host: localhost
     # TODO(RHINENG-26911): remove this view once Cyndi decommission completes
     # across all IoP services.

--- a/src/roles/iop_vulnerability/defaults/main.yaml
+++ b/src/roles/iop_vulnerability/defaults/main.yaml
@@ -8,6 +8,7 @@ iop_vulnerability_database_password: "{{ undef(hint='Set a secure database passw
 iop_vulnerability_database_host: "host.containers.internal"
 iop_vulnerability_database_port: "5432"
 
+
 # Taskomatic configuration
 iop_vulnerability_taskomatic_jobs: "stale_systems:5,delete_systems:30,cacheman:5"
 iop_vulnerability_taskomatic_startup: "cacheman"

--- a/src/roles/iop_vulnerability/tasks/main.yaml
+++ b/src/roles/iop_vulnerability/tasks/main.yaml
@@ -34,9 +34,9 @@
   vars:
     iop_fdw_database_name: "{{ iop_vulnerability_database_name }}"
     iop_fdw_database_user: "{{ iop_vulnerability_database_user }}"
-    iop_fdw_remote_database_name: "{{ iop_inventory_database_name }}"
-    iop_fdw_remote_user: "{{ iop_inventory_database_user }}"
-    iop_fdw_remote_password: "{{ iop_inventory_database_password }}"
+    iop_fdw_remote_database_name: "{{ iop_vulnerability_fdw_remote_database_name }}"
+    iop_fdw_remote_user: "{{ iop_vulnerability_fdw_remote_database_user }}"
+    iop_fdw_remote_password: "{{ iop_vulnerability_fdw_remote_database_password }}"
 
 # 1. Database upgrade init container (oneshot)
 - name: Deploy Vulnerability Database Upgrade container

--- a/src/roles/post_install/tasks/message.yaml
+++ b/src/roles/post_install/tasks/message.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Post install message
-  when: flavor in ['katello']
+  when: post_install_flavor in ['katello']
   ansible.builtin.debug:
     msg:
       - "{{ _post_install_url_msg }}"

--- a/tests/ansible_lint/test_role_scoped_variables.py
+++ b/tests/ansible_lint/test_role_scoped_variables.py
@@ -1,0 +1,19 @@
+"""Tests for role-scoped-variables rule."""
+
+import pytest
+
+RULE_ID = "role-scoped-variables"
+
+
+@pytest.mark.parametrize("ansible_lint_runner", [("tests/fixtures/ansible-lint/roles/test_role_scoped_variables", RULE_ID)], indirect=True)
+def test_unscoped_variables_flagged(ansible_lint_runner) -> None:
+    """Tasks referencing variables not prefixed with the role name produce match errors."""
+    assert len(ansible_lint_runner) == 4
+    for result in ansible_lint_runner:
+        assert result.rule.id == RULE_ID
+
+
+@pytest.mark.parametrize("ansible_lint_runner", [("tests/fixtures/ansible-lint/roles/test_role_scoped_variables_pass", RULE_ID)], indirect=True)
+def test_scoped_variables_pass(ansible_lint_runner) -> None:
+    """Tasks using role-prefixed, builtin, or allowed global variables pass."""
+    assert len(ansible_lint_runner) == 0

--- a/tests/fixtures/ansible-lint/roles/test_role_scoped_variables/defaults/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_role_scoped_variables/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+test_role_scoped_variables_retries: 10
+test_role_scoped_variables_delay: 2

--- a/tests/fixtures/ansible-lint/roles/test_role_scoped_variables/tasks/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_role_scoped_variables/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Task using unscoped variable in module arg
+  ansible.builtin.file:
+    path: "{{ pulp_storage_path }}/media"
+    state: directory
+    mode: '0755'
+
+- name: Task using unscoped variable in when condition
+  ansible.builtin.fail:
+    msg: "Missing force flag"
+  when: not force | default(false)
+
+- name: Task using unscoped variable in loop
+  community.postgresql.postgresql_db:
+    name: "{{ item.database }}"
+    state: present
+    login_host: "{{ database_host }}"
+    login_port: "{{ database_port }}"
+  loop: "{{ databases }}"
+
+- name: Task using unscoped variable in environment
+  ansible.builtin.command:
+    cmd: pg_restore --dbname=test
+  environment:
+    PGPASSWORD: "{{ postgresql_admin_password }}"
+  changed_when: true

--- a/tests/fixtures/ansible-lint/roles/test_role_scoped_variables_pass/defaults/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_role_scoped_variables_pass/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+test_role_scoped_variables_pass_retries: 10
+test_role_scoped_variables_pass_storage_path: /var/lib/pulp

--- a/tests/fixtures/ansible-lint/roles/test_role_scoped_variables_pass/tasks/main.yml
+++ b/tests/fixtures/ansible-lint/roles/test_role_scoped_variables_pass/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Task using properly scoped variable
+  ansible.builtin.file:
+    path: "{{ test_role_scoped_variables_pass_storage_path }}/media"
+    state: directory
+    mode: '0755'
+
+- name: Task using ansible builtin variables
+  ansible.builtin.debug:
+    msg: "Running on {{ inventory_hostname }} with {{ ansible_os_family }}"
+
+- name: Task using item in loop
+  ansible.builtin.debug:
+    msg: "{{ item.name }}"
+  loop: "{{ test_role_scoped_variables_pass_databases }}"
+
+- name: Task using allowed global variable
+  ansible.builtin.stat:
+    path: "{{ obsah_state_path }}"
+  register: test_role_scoped_variables_pass_state
+
+- name: Task using ansible_facts
+  ansible.builtin.debug:
+    msg: "{{ ansible_facts['os_family'] }}"
+
+- name: Task with custom loop_var
+  ansible.builtin.debug:
+    msg: "{{ db_entry.name }}"
+  loop: "{{ test_role_scoped_variables_pass_databases }}"
+  loop_control:
+    loop_var: db_entry
+
+- name: Task using task-level vars as local definitions
+  ansible.builtin.set_fact:
+    test_role_scoped_variables_pass_result: "{{ local_entry }}"
+  vars:
+    local_entry:
+      name: "{{ item.name }}"
+
+- name: Task using underscore-prefixed role variable
+  ansible.builtin.debug:
+    msg: "{{ _test_role_scoped_variables_pass_internal }}"
+
+- name: Task using lookup function
+  containers.podman.podman_secret:
+    name: test-secret
+    data: "{{ lookup('file', 'secret.txt') }}"
+
+- name: Task using leading underscore internal variable
+  ansible.builtin.debug:
+    msg: "{{ _internal_var }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Roles currently reference shared variables (e.g. `database_host`, `ca_certificate`) directly, coupling them to the playbook's variable namespace. This makes it hard to tell which variables a role actually needs, creates implicit dependencies between roles, and means renaming a shared variable silently breaks every role that uses it.

This PR adds a custom ansible-lint rule that enforces role-scoped variables and fixes the existing violations in addressed roles.

#### What are the changes introduced in this pull request?

* New custom ansible-lint rule `role-scoped-variables` that flags variables inside role tasks not prefixed with the role name
  - Uses ansible-lint's `nested_items_path` to walk all task values — no manual key enumeration
  - Uses Jinja2 AST analysis to distinguish function calls (`lookup`, `query`, `now`) from variable references — no function allowlist needed
  - Allows: role-prefixed variables, `ansible_*` facts, Ansible builtins (`item`, `omit`, `inventory_hostname`, etc.), `_`-prefixed internal variables, and project globals
  - Test fixtures covering violation cases (module arg, when condition, loop, environment) and passing cases (role-prefixed, builtins, item, allowed globals, custom loop_var, task-local vars, underscore internal vars, function calls)

* Map shared variables to role-prefixed names at playbook invocation sites:
  - `deploy.yaml`, `deploy-proxy.yaml`, `checks.yaml`, `backup.yaml`, `deploy-dev.yaml`
  - Parent roles pass scoped vars through to sub-roles (e.g. `checks` passes `checks_database_*` to `check_database_index`)

* Rename role-internal variables (loop vars, include_tasks vars) to use leading underscore convention:
  - `db_item` to `_db_item` in `check_database_connection`
  - `feature_name`/`feature_enabled` to `_feature_name`/`_feature_enabled` in `foreman_proxy`
  - `tuning_vars` to `_tuning_vars` in `check_system_requirements`

* Remaining violations to address in follow-up: `certificates` (6), `restore` (26), and 7 dynamically-included check roles where `execute_check.yml` uses `include_role: name: "{{ item }}"` with no way to pass per-role vars

#### How to test this pull request

Steps to reproduce:

* Run rule unit tests: `python -m pytest tests/ansible_lint/test_role_scoped_variables.py -vv`
* Run ansible-lint on src: `ANSIBLE_COLLECTIONS_PATH="$PWD/build/collections/foremanctl" ANSIBLE_COLLECTIONS_SCAN_SYS_PATH=false bash -c '(cd src && ansible-lint)'`
* Run ansible-lint on development: `ANSIBLE_COLLECTIONS_PATH="$PWD/build/collections/forge" ANSIBLE_COLLECTIONS_SCAN_SYS_PATH=false bash -c '(cd development && ansible-lint --exclude ../build/collections)'`
* Deploy and verify functionality is unchanged: `./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development`

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

