### PR TITLE
remove ingress auth variable

### DIFF
--- a/src/roles/iop_ingress/tasks/main.yaml
+++ b/src/roles/iop_ingress/tasks/main.yaml
@@ -10,7 +10,6 @@
     env:
       INGRESS_VALID_UPLOAD_TYPES: "advisor,compliance,qpc,rhv,tower,leapp-reporting,xavier,playbook,playbook-sat,malware-detection,tasks"
       INGRESS_KAFKABROKERS: "iop-core-kafka:9092"
-      INGRESS_AUTH: "false"
       BOOTSTRAP_SERVERS: "iop-core-kafka:9092"
       INGRESS_STAGERIMPLEMENTATION: "filebased"
       INGRESS_STORAGEFILESYSTEMPATH: "/var/tmp"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

INGRESS_AUTH variable causes `missing org_id` error when registering new host to IoP. 

#### What are the changes introduced in this pull request?

* removal of INGRESS_AUTH variable from `src/roles/iop_ingress/tasks/main.yaml`

#### How to test this pull request

Steps to reproduce:

* register new host to IoP and the host is registered.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
