### PR TITLE
forge iso - Install Satellite/foremanctl from ISO

### DIFF
--- a/development/playbooks/iso/iso.yaml
+++ b/development/playbooks/iso/iso.yaml
@@ -1,0 +1,61 @@
+---
+- name: Prepare a disconnected installation from an ISO
+  hosts:
+    - quadlet
+  become: true
+  vars:
+    iso_download_path: /root/satellite.iso
+    iso_mount_path: /mnt/satellite
+  tasks:
+    - name: Install packages
+      ansible.builtin.package:
+        name:
+          - podman
+          - skopeo
+        state: present
+
+    - name: Check if ISO already exists on target
+      ansible.builtin.stat:
+        path: "{{ iso_download_path }}"
+      register: iso_stat
+
+    - name: Upload the ISO from local path
+      ansible.builtin.copy:
+        src: "{{ iso_path }}"
+        dest: "{{ iso_download_path }}"
+        mode: "0644"
+      when: not iso_stat.stat.exists
+
+    - name: Ensure ISO mount point exists
+      ansible.builtin.file:
+        path: "{{ iso_mount_path }}"
+        state: directory
+        mode: "0755"
+
+    - name: Mount the ISO, run prepare_system, then always unmount
+      block:
+        - name: Mount the ISO
+          ansible.posix.mount:
+            path: "{{ iso_mount_path }}"
+            src: "{{ iso_download_path }}"
+            fstype: iso9660
+            opts: loop,ro
+            state: ephemeral
+
+        - name: Run the prepare_system script from the mounted ISO
+          ansible.builtin.command:
+            argv: "{{ ['python3', 'prepare_system'] + (['--nogpgcheck'] if iso_nogpgcheck | default(false) else []) }}"
+            chdir: "{{ iso_mount_path }}"
+          register: iso_prepare_system_result
+          changed_when: true
+
+        - name: Show prepare_system output
+          ansible.builtin.debug:
+            msg:
+              stdout: "{{ iso_prepare_system_result.stdout }}"
+              stderr: "{{ iso_prepare_system_result.stderr }}"
+      always:
+        - name: Unmount the ISO
+          ansible.posix.mount:
+            path: "{{ iso_mount_path }}"
+            state: unmounted

--- a/development/playbooks/iso/metadata.obsah.yaml
+++ b/development/playbooks/iso/metadata.obsah.yaml
@@ -1,0 +1,21 @@
+---
+help: |
+  Prepare a disconnected installation from an ISO.
+
+  Uploads the ISO (unless already present), mounts it, and runs the
+  prepare_system script shipped on the ISO to install the foremanctl
+  package and import container images into local storage. The ISO is
+  unmounted afterwards. Once complete, run foremanctl deploy (as
+  suggested by the script) to finish the installation.
+
+  Use --nogpgcheck when installing from unsigned/nightly composes.
+
+variables:
+  iso_path:
+    parameter: iso_path
+    help: Path to a local ISO file to upload to the target machine.
+    type: AbsolutePath
+  iso_nogpgcheck:
+    parameter: --nogpgcheck
+    help: Skip GPG signature verification when installing packages (for unsigned/nightly composes).
+    action: store_true


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Allow developers to install Satellite / foremanctl from an ISO (disconnected scenario)

#### What are the changes introduced in this pull request?

* `forge iso`

#### How to test this pull request

Steps to reproduce:

* `forge iso --help`

#### TODOs

* Tests (?)
* Documentation

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
