### PR TITLE
Ensure httpd starts after foreman.socket

### DIFF
--- a/src/roles/httpd/tasks/main.yml
+++ b/src/roles/httpd/tasks/main.yml
@@ -125,6 +125,16 @@
       [Unit]
       PartOf=foreman.target
 
+- name: Ensure httpd starts after foreman.socket
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/httpd.service.d/foreman-socket.conf
+    mode: "0644"
+    content: |
+      [Unit]
+      Wants=foreman.socket
+      After=foreman.socket
+  when: httpd_with_foreman
+
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

httpd can start before foreman.socket is ready, causing intermittent 502 Bad Gateway errors after deployment or restart.

#### What are the changes introduced in this pull request?

Adds a systemd drop-in for httpd.service with Wants=foreman.socket and After=foreman.socket, only when Foreman is present

#### How to test this pull request
- Deploy and verify drop-in exists: cat /etc/systemd/system/httpd.service.d/foreman-socket.conf
- Restart foreman.target and confirm no 502 errors on immediate access

####  Steps to reproduce:

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
