### PR TITLE
Reduce deploy time by ~60s with parallel restarts and faster healthchecks

### DIFF
--- a/src/roles/candlepin/tasks/main.yml
+++ b/src/roles/candlepin/tasks/main.yml
@@ -98,6 +98,7 @@
         [Service]
         TimeoutStartSec=300
     healthcheck: curl --fail --insecure --noproxy localhost https://localhost:23443/candlepin/status
+    healthcheck_interval: 5s
     sdnotify: healthy
 
 - name: Run daemon reload to make Quadlet create the service files

--- a/src/roles/foreman/handlers/main.yml
+++ b/src/roles/foreman/handlers/main.yml
@@ -9,11 +9,27 @@
     name: foreman
     state: restarted
 
-- name: Restart dynflow-sidekiq@
+- name: Restart dynflow-sidekiq@ instances
+  listen: Restart dynflow-sidekiq@
   ansible.builtin.systemd:
     name: "dynflow-sidekiq@{{ item }}"
     state: restarted
+  async: 120
+  poll: 0
   loop:
     - orchestrator
     - worker
     - worker-hosts-queue
+  register: foreman_dynflow_restart
+
+- name: Wait for dynflow-sidekiq@ restarts
+  listen: Restart dynflow-sidekiq@
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: foreman_dynflow_restart_result
+  until: foreman_dynflow_restart_result is finished
+  retries: 120
+  delay: 1
+  loop: "{{ foreman_dynflow_restart.results }}"
+  loop_control:
+    label: "{{ item.item }}"

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -268,9 +268,11 @@
     url: '{{ foreman_url }}/api/v2/ping'
     ca_path: '{{ foreman_ca_certificate }}'
     timeout: 120
-  until: foreman_status.status == 200
-  retries: 60
-  delay: 5
+  until:
+    - foreman_status.status == 200
+    - not (enabled_features | has_feature('katello')) or foreman_status.json['results']['katello']['services']['foreman_tasks']['status'] == 'ok'
+  retries: 120
+  delay: 2
   register: foreman_status
 
 - name: Enable & start recurring timers
@@ -282,20 +284,6 @@
   loop: "{{ foreman_recurring_tasks }}"
   loop_control:
     label: "{{ item.instance }}"
-
-- name: Wait for Foreman tasks to be ready
-  ansible.builtin.uri:
-    url: '{{ foreman_url }}/api/v2/ping'
-    ca_path: '{{ foreman_ca_certificate }}'
-    timeout: 120
-  until:
-    - foreman_tasks_status.status == 200
-    - foreman_tasks_status.json['results']['katello']['services']['foreman_tasks']['status'] == 'ok'
-  retries: 60
-  delay: 5
-  register: foreman_tasks_status
-  when:
-    - "'katello' in foreman_status.json['results']"
 
 - name: Warn about unrecognized Pulp Smart Proxy features
   ansible.builtin.debug:

--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -26,6 +26,7 @@
     image: postgresql.image
     state: quadlet
     healthcheck: pg_isready
+    healthcheck_interval: 5s
     sdnotify: healthy
     network: host
     volumes:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The deploy playbook spends ~60 unnecessary seconds on serial service restarts, redundant API polling loops, and slow healthcheck intervals. The three dynflow-sidekiq instances restart one at a time (~30s total), the Foreman API readiness check runs as two separate polling loops with 5s delays, and PostgreSQL/Candlepin containers use the default 30s Podman healthcheck interval with `sdnotify: healthy`, meaning systemd can wait up to 30s after the service is actually ready before being notified.

#### What are the changes introduced in this pull request?

* Restart dynflow-sidekiq@ instances in parallel using async/poll instead of a serial loop, matching the pattern already used for service starts
* Combine the two sequential Foreman API wait tasks (ping + foreman_tasks readiness) into a single polling loop with a 2s delay instead of two loops with 5s delays
* Set `healthcheck_interval: 5s` on PostgreSQL and Candlepin containers so the `sdnotify: healthy` signal fires within 5s of the service becoming ready instead of up to 30s

#### How to test this pull request

Steps to reproduce:

* Deploy with `./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development`
* Enable `ansible.posix.profile_tasks` callback to compare task timings before and after
* Verify PostgreSQL restart drops from ~31s to ~6s
* Verify dynflow-sidekiq restart no longer appears in the top-20 slowest tasks
* Verify Candlepin restart drops from ~31s to ~21s
* Verify Foreman services start and the API becomes accessible
* Verify Pulp smart proxy registration completes successfully

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)