### PR TITLE
feat(iop): csaf eval, cpes, release graph

### DIFF
--- a/src/roles/iop_vmaas/tasks/main.yaml
+++ b/src/roles/iop_vmaas/tasks/main.yaml
@@ -85,7 +85,7 @@
     env:
       REPOSCAN_PUBLIC_URL: "http://iop-service-vmaas-reposcan:8000"
       REPOSCAN_PRIVATE_URL: "http://iop-service-vmaas-reposcan:10000"
-      CSAF_UNFIXED_EVAL_ENABLED: "FALSE"
+      CSAF_UNFIXED_EVAL_ENABLED: "TRUE"
       GIN_MODE: "release"
       POSTGRESQL_SSL_MODE: "disable"
     secrets:

--- a/src/roles/iop_vmaas/tasks/main.yaml
+++ b/src/roles/iop_vmaas/tasks/main.yaml
@@ -87,7 +87,7 @@
     env:
       REPOSCAN_PUBLIC_URL: "http://iop-service-vmaas-reposcan:8000"
       REPOSCAN_PRIVATE_URL: "http://iop-service-vmaas-reposcan:10000"
-      CSAF_UNFIXED_EVAL_ENABLED: "FALSE"
+      CSAF_UNFIXED_EVAL_ENABLED: "TRUE"
       GIN_MODE: "release"
       POSTGRESQL_SSL_MODE: "disable"
     secrets:

--- a/src/roles/iop_vmaas/tasks/main.yaml
+++ b/src/roles/iop_vmaas/tasks/main.yaml
@@ -48,12 +48,14 @@
       SYNC_REPO_LIST_SOURCE: "katello"
       SYNC_REPOS: "yes"
       SYNC_CVE_MAP: "yes"
-      SYNC_CPE: "no"
+      SYNC_CPE: "yes"
       SYNC_CSAF: "yes"
       SYNC_RELEASES: "no"
-      SYNC_RELEASE_GRAPH: "no"
+      SYNC_RELEASE_GRAPH: "yes"
       KATELLO_URL: "http://iop-core-gateway:9090"
       REDHAT_CVEMAP_URL: "http://iop-core-gateway:9090/pub/iop/data/meta/v1/cvemap.xml"
+      CPE_DICT_URL: http://iop-core-gateway:9090/pub/iop/data/meta/v1/cpe-dictionary.xml
+      REPOLIST_GIT: http://iop-core-gateway:9090/static/vmaas-assets/.git
       CSAF_VEX_BASE_URL: "http://iop-core-gateway:9090/pub/iop/data/csaf/v2/vex/"
       CSAF_VEX_INDEX_CSV_ENABLED: "no"
       POSTGRESQL_SSL_MODE: "disable"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Enabling the CVE's without errata feature in VMaas.

This requires additional data syncs of CPEs and Release Graphs.

#### What are the changes introduced in this pull request?

* Enables `CSAF_UNFIXED_EVAL_ENABLED` on VMaaS web app
* Enables reposcan to import CPE and release graphs data through/from IoP Gateway

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
