### PR TITLE
stop pulp services in case of databse migration failure

### DIFF
--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -270,9 +270,21 @@
     daemon_reload: true
 
 - name: Migrate the Pulp database
-  ansible.builtin.systemd:
-    name: pulpcore-manager-migrate.service
-    state: restarted
+  block:
+    - name: Run Pulp database migration
+      ansible.builtin.systemd:
+        name: pulpcore-manager-migrate.service
+        state: restarted
+  rescue:
+    - name: Stop Pulp services to drain outdated components before migration
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: stopped
+      loop: "{{ pulp_all_services }}"
+    - name: Retry Pulp database migration with services stopped
+      ansible.builtin.systemd:
+        name: pulpcore-manager-migrate.service
+        state: restarted
 
 - name: Ensure Pulp admin user exists
   ansible.builtin.systemd:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
When upgrading from 3.18 to 3.19 with a major pulpcore bump (3.85 -> 3.105) the 0143_require_app_lock_zdu failed while migrating the database schema because of a guard in the migration and the old pulpcore services still running

#### What are the changes introduced in this pull request?

* Stop pulp services in case of database migration failure and retry 

#### How to test this pull request

Steps to reproduce:

* Upgrade from 3.18 to 3.19 using foremanctl by changing the image versions, see the pulp db migration hangs

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
