### PR TITLE
Fixes #712 - Include hostname in remote execution SSH key

### DIFF
--- a/src/roles/foreman_proxy/tasks/feature/remote_execution_ssh.yaml
+++ b/src/roles/foreman_proxy/tasks/feature/remote_execution_ssh.yaml
@@ -2,6 +2,7 @@
 - name: Create SSH Key
   community.crypto.openssh_keypair:
     path: "/root/foreman-proxy-ssh"
+    comment: "foreman-proxy@{{ foreman_proxy_name }}"
 
 - name: Create SSH Key podman secret
   containers.podman.podman_secret:

--- a/tests/feature/foreman-proxy/base_test.py
+++ b/tests/feature/foreman-proxy/base_test.py
@@ -52,6 +52,19 @@ def test_foreman_proxy_port(server):
     assert foreman_proxy.port(FOREMAN_PROXY_PORT).is_reachable
 
 
+@pytest.mark.feature('remote-execution')
+def test_remote_execution_ssh_public_key_comment(server, server_fqdn):
+    cmd = server.run(
+        "podman secret inspect "
+        "--format '{{.SecretData}}' "
+        "--showsecret foreman_proxy-remote_execution_ssh-id_rsa_foreman_proxy-pub"
+    )
+    assert cmd.succeeded
+    public_key = cmd.stdout.split()
+    assert len(public_key) == 3
+    assert public_key[2] == f"foreman-proxy@{server_fqdn}"
+
+
 @pytest.mark.xfail(reason='Fails until report feature is available')
 def test_foreman_proxy_client_auth_to_foreman(curl_request):
     test_report = {"config_report": {"host": "test.example.com", "reported_at": datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}}


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The remote execution SSH key is generated without a public key comment. Once the key is installed on target hosts, its authorized_keys entry therefore does not identify which Foreman Proxy it belongs to.

Fixes #712.

#### What are the changes introduced in this pull request?

* Set the generated key comment to `foreman-proxy@FQDN`, using the FQDN already established by the deployment facts.
* Add a feature-gated integration test that reads the public key from the Podman secret and verifies its exact comment.
* Preserve the existing private key; `community.crypto.openssh_keypair` updates the public key comment without regenerating the key pair.

#### How to test this pull request

Steps to reproduce:

1. Deploy foremanctl with the `foreman-proxy` and `remote-execution` features.
2. Inspect `foreman_proxy-remote_execution_ssh-id_rsa_foreman_proxy-pub` with `podman secret inspect --showsecret`.
3. Verify that the public key ends with `foreman-proxy@<server FQDN>`.

Local validation:

* `ansible-lint` passed for all 306 processed source files using the declared collections.
* The added Python integration test passes syntax validation. The deployment-backed test runs in CI.

#### Checklist
* [x] Tests added/updated (if applicable)
* [x] Documentation updated (not applicable; no user-facing interface changed)

#### AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an Assisted-By trailer.