### PR TITLE
Closes #39652 - unconfigure SMTP as an email delivery method

### DIFF
--- a/src/roles/foreman/templates/settings.yaml.j2
+++ b/src/roles/foreman/templates/settings.yaml.j2
@@ -41,6 +41,3 @@
 :ssl_client_dn_env: HTTP_SSL_CLIENT_S_DN
 :ssl_client_verify_env: HTTP_SSL_CLIENT_VERIFY
 :ssl_client_cert_env: HTTP_SSL_CLIENT_CERT
-
-# Configure SMTP as delivery method
-:delivery_method: smtp

--- a/tests/feature/foreman/base_test.py
+++ b/tests/feature/foreman/base_test.py
@@ -116,11 +116,6 @@ def test_foreman_recurring_timer_execution(server, instance):
     assert service.systemd_properties["Result"] == "success"
 
 
-def test_foreman_delivery_method_setting(foremanapi):
-    delivery_method_setting = foremanapi.list('settings', search='name=delivery_method')
-    assert delivery_method_setting[0]['value'] == 'smtp'
-
-
 @pytest.mark.parametrize("setting", ["foreman_url", "unattended_url"])
 def test_foreman_fqdn_in_url_settings(foremanapi, server_fqdn, setting):
     settings = foremanapi.list('settings', search=f'name={setting}')


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Part of an effort to remove sendmail delivery method altogether. SAT-43109.

#### What are the changes introduced in this pull request?

* Rolls back https://github.com/theforeman/foremanctl/pull/386/changes

#### How to test this pull request

Since SMTP is now the default, it will be set even without explicitly setting it.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
