### PR TITLE
Fix: Support systemd property compatibility for CentOS Stream 10

### DIFF
--- a/tests/feature/foreman/base_test.py
+++ b/tests/feature/foreman/base_test.py
@@ -82,8 +82,9 @@ def test_foreman_recurring_services_exist(server, instance):
 def test_foreman_recurring_timer_last_trigger(server, instance):
     """Verify that timers have a valid last trigger time (if they've run)."""
     timer_name = f"foreman-recurring@{instance}.timer"
-    timer = server.service(timer_name) 
-    assert "LastTriggerUSec" in timer.systemd_properties
+    timer = server.service(timer_name)
+    props = timer.systemd_properties
+    assert 'LastTriggerUSec' in props or 'LastTriggerUSecRealtime' in props
 
 
 @pytest.mark.parametrize("instance", RECURRING_INSTANCES)


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

While testing https://github.com/Katello/katello/pull/11835 at https://github.com/theforeman/foreman-oci-images/pull/90 I found one testing missing that is related to https://github.com/theforeman/foremanctl/commit/1d1617b20fb1a61597c097ebccf6ff31703566a9, looks like the issue started switched to CS10 base containers.

#### What are the changes introduced in this pull request?

The LastTriggerUSec property was renamed in newer systemd versions. CentOS Stream 10 uses systemd 256+ which reports LastTriggerUSecMonotonic and LastTriggerUSecRealtime instead. Support all three property names to maintain compatibility across systemd versions.

#### How to test this pull request

Test Integration needs to run with CS10 based containers.

