### PR TITLE
Ensure container image names are lowercase and have product

### DIFF
--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -208,11 +208,11 @@ When the private registry mirrors upstream image names and tags exactly, `regist
 # /etc/containers/registries.conf.d/50-foremanctl-mirror.conf
 [[registry]]
 prefix = "quay.io/foreman"
-location = "katello.example.com/Default_Organization"
+location = "katello.example.com/default_organization/my_product"
 
 [[registry]]
 prefix = "quay.io/sclorg"
-location = "katello.example.com/Default_Organization"
+location = "katello.example.com/default_organization/my_product"
 ```
 
 When the private registry uses different image names or tags, use `.image.d` drop-ins instead:
@@ -220,8 +220,10 @@ When the private registry uses different image names or tags, use `.image.d` dro
 ```ini
 # /etc/containers/systemd/foreman.image.d/90-user.conf
 [Image]
-Image=katello.example.com/Default_Organization/foreman-rhel9:stream
+Image=katello.example.com/default_organization/my_product/foreman-rhel9:stream
 ```
+
+Adjust the container image naming above to match your lifecycle environment's registry name pattern.
 
 ##### Developer testing a container build
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The OCI spec says container image names must match `[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*`.

This means that uppercase letters are not allowed.

Katello also includes the product in the name by default:

On my default setup machine, for example: 

```
katello.example.com/default_organization/sauron/synced_busybox
```

Users can edit the path format, so I added a note about the "registry name pattern".

<img width="2170" height="712" alt="image" src="https://github.com/user-attachments/assets/49113301-7bc9-4c99-b90a-f1f8aa991b28" />


#### Checklist
* [x] Documentation updated (if applicable)
