### PR TITLE
Fix IOP/Postgres dependency race on foreman.target restart

### DIFF
--- a/src/roles/iop_advisor/tasks/main.yaml
+++ b/src/roles/iop_advisor/tasks/main.yaml
@@ -68,8 +68,8 @@
       - |
         [Unit]
         Description=Advisor Backend API
-        After=iop-core-kafka.service
-        Wants=iop-core-kafka.service
+        After=postgresql.service iop-core-kafka.service iop-core-host-inventory-api.service
+        Wants=postgresql.service iop-core-kafka.service iop-core-host-inventory-api.service
         PartOf=foreman.target
         [Service]
         Restart=on-failure
@@ -98,8 +98,8 @@
       - |
         [Unit]
         Description=Advisor Backend Service
-        After=iop-core-kafka.service
-        Wants=iop-core-kafka.service
+        After=postgresql.service iop-core-kafka.service
+        Wants=postgresql.service iop-core-kafka.service
         PartOf=foreman.target
         [Service]
         Restart=on-failure

--- a/src/roles/iop_inventory/tasks/main.yaml
+++ b/src/roles/iop_inventory/tasks/main.yaml
@@ -54,6 +54,8 @@
       - |
         [Unit]
         Description=Database Readiness and Migration Init Container
+        After=postgresql.service
+        Wants=postgresql.service
         PartOf=foreman.target
         [Service]
         Type=oneshot
@@ -117,6 +119,8 @@
       - |
         [Unit]
         Description=IOP Core Host-Based Inventory Web Container
+        After=postgresql.service iop-core-host-inventory-migrate.service
+        Wants=postgresql.service iop-core-host-inventory-migrate.service
         PartOf=foreman.target
         [Service]
         Restart=on-failure

--- a/src/roles/iop_remediation/tasks/main.yaml
+++ b/src/roles/iop_remediation/tasks/main.yaml
@@ -64,8 +64,8 @@
       - |
         [Unit]
         Description=Remediations API
-        Wants=iop-core-host-inventory-api.service iop-service-advisor-backend-api.service
-        After=iop-core-host-inventory-api.service iop-service-advisor-backend-api.service
+        Wants=postgresql.service iop-core-host-inventory-api.service iop-service-advisor-backend-api.service
+        After=postgresql.service iop-core-host-inventory-api.service iop-service-advisor-backend-api.service
         PartOf=foreman.target
         [Service]
         Restart=on-failure

--- a/src/roles/iop_vmaas/tasks/main.yaml
+++ b/src/roles/iop_vmaas/tasks/main.yaml
@@ -68,6 +68,8 @@
       - |
         [Unit]
         Description=VMAAS Reposcan Service
+        After=postgresql.service
+        Wants=postgresql.service
         PartOf=foreman.target
         [Service]
         Restart=on-failure

--- a/src/roles/iop_vulnerability/tasks/main.yaml
+++ b/src/roles/iop_vulnerability/tasks/main.yaml
@@ -61,6 +61,8 @@
       - |
         [Unit]
         Description=Vulnerability Database Upgrade Init Container
+        After=postgresql.service
+        Wants=postgresql.service
         PartOf=foreman.target
         [Service]
         Type=oneshot


### PR DESCRIPTION
## Summary
- Every IOP container that connects directly to Postgres (`iop_advisor`, `iop_inventory`, `iop_vmaas`, `iop_vulnerability`, `iop_remediation`) was joined to `foreman.target`'s restart lifecycle without ever declaring `After=`/`Wants=postgresql.service`. During a coordinated `foreman.target` stop/start cycle, this let the affected containers race against Postgres's own restart and crash (`django.db.utils.OperationalError: FATAL: the database system is shutting down`), then burn through systemd's default crash-loop rate limit and get left permanently failed.
- Fixed by adding the same `After=`/`Wants=postgresql.service` pattern already used by the `foreman`, `pulp`, and `candlepin` roles in this repo. `iop-core-host-inventory-api` additionally needed `iop-core-host-inventory-migrate.service` (matching its sibling MQ container's existing pattern), and `iop-service-advisor-backend-api` additionally needed `iop-core-host-inventory-api.service` (it calls that REST endpoint directly via `INVENTORY_SERVER_URL`).

## Test plan
- [x] `ansible-lint` passes on all changed files
- [x] Applied live on a real deployment (satcpt): confirmed `hammer ping` and all affected services healthy after multiple `foreman.target` stop/start cycles
- [x] Confirmed via journal timestamps that the dependency fix correctly orders IOP container shutdown before Postgres's own stop (systemd's `After=` ordering is bidirectional - reversed on stop)

