### PR TITLE
Use SIGINT (fast shutdown) instead of SIGTERM to stop postgresql

### DIFF
--- a/src/roles/postgresql/tasks/main.yml
+++ b/src/roles/postgresql/tasks/main.yml
@@ -28,6 +28,7 @@
     healthcheck: pg_isready
     healthcheck_interval: 5s
     sdnotify: healthy
+    stop_signal: 2
     network: host
     volumes:
       - "{{ postgresql_data_dir }}:/var/lib/pgsql/data:rw,Z"


### PR DESCRIPTION
## Summary
`postgresql.container` currently stops via `SIGTERM` ("smart" shutdown), which waits indefinitely for every connected client to disconnect before checkpointing. This switches it to `SIGINT` ("fast" shutdown): disconnect clients immediately, checkpoint, exit.

Found via a reproducible hang: a host running `collectd` (3 persistent, idle monitoring connections to Postgres) caused every `foreman.target` restart to hang the full stop timeout and get `SIGKILL`ed - "smart" shutdown was waiting on connections that never voluntarily close. More generally, any long-lived client can block the whole stack from stopping this way, with no timeout on Postgres's side.

This brings the container in line with how Postgres already stops everywhere else Foreman ships it:
- RPM Satellite's `postgresql.service` has no `ExecStop=` - it uses `KillMode=mixed` + `KillSignal=SIGINT` (verified live, 6.19.4/EL9).
- The `sclorg/postgresql-16-c10s` base image `exec`s `postgres` as PID 1 with no shutdown-mode env var, so the container's stop signal is the only lever available - same role as `KillSignal=` on RPM.

## Test plan
- [x] `ansible-lint` passes
- [x] Applied to a live deployment: `hammer ping` and all services healthy across multiple `foreman.target` stop/start cycles
- [x] Confirmed via `pg_stat_activity`/connection logs that the pre-fix hang was idle monitoring connections, not application traffic
- [x] Verified parity with RPM Satellite's `KillSignal=SIGINT` and confirmed the base image has no alternate way to configure shutdown mode
