### PR TITLE
Add documentation blob about backup/restore in dev setups

### DIFF
--- a/docs/developer/development-environment.md
+++ b/docs/developer/development-environment.md
@@ -213,3 +213,8 @@ Development certificates are copied to `/home/vagrant/foreman-certs/`:
 - `proxy_ca.pem` - CA certificate
 - `client_cert.pem` - Client certificate
 - `client_key.pem` - Client private key
+
+## Backup/Restore in Development Environment
+
+- **Backup/Restore with Multiple Nodes**: When running both quadlet and proxy nodes with the same controller, ensure you're switching to the correct `obsah_state` context before performing backup or restore operations. On user installs, foreman quadlet and smart proxy map to localhost (same machine). In the development environment, these are separate VMs which alters behavior.
+- **BACKUP_DIR Location**: The `BACKUP_DIR` argument in backup/restore commands refers to a directory on the target node (the VM running quadelt/proxy), not the controller node running foremanctl.


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Adding a section about backup/restore in developer environments where quadlet and proxy are separate VMs and not localhost like with package installed foremanctl.

There are subtle differences in backup/restore behavior in dev setups vs user setups. For user setups everything maps to localhost making the flow simpler. On dev setups, since quadlet/proxies are their own VMs, we need to add some documentation about the difference in behavior especially when managing quadlet and proxies from same controller with different branches for example..
#### What are the changes introduced in this pull request?

* 

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
