### PR TITLE
Fix parameters.md links in docs

### DIFF
--- a/docs/developer/development-environment.md
+++ b/docs/developer/development-environment.md
@@ -189,7 +189,7 @@ Run all the steps as the root user in the foremanctl source directory unless oth
 3. Switch to the preferred target branch:
     - Switch to a stable Y-stream: `git fetch origin && git checkout origin/X.y-stable`
     - Switch to nightly: `git fetch origin && git checkout origin/master`
-4. Run upgrade tasks by re-deploying foremanctl with your customized deploy command: `foremanctl deploy [...]`. Please see [Parameters](parameters.md) for available deploy options.
+4. Run upgrade tasks by re-deploying foremanctl with your customized deploy command: `foremanctl deploy [...]`. Please see [Parameters](../user/parameters.md) for available deploy options.
 
 This final deploy command will pull new images and run all upgrade jobs required by Foreman, its dependencies, and your configured plugins. Expect this deploy to take longer than typical deploys.
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -94,7 +94,7 @@ foremanctl migrate --output /tmp/migrated.yaml
 
 ## Parameter Mappings
 
-The migrate command automatically maps foreman-installer parameters to foremanctl parameters. For a complete list of all parameter mappings, see the [Parameters documentation](parameters.md#mapping).
+The migrate command automatically maps foreman-installer parameters to foremanctl parameters. For a complete list of all parameter mappings, see the [Parameters documentation](user/parameters.md#mapping).
 
 ## Example
 
@@ -136,7 +136,7 @@ When the migration completes, you may see warnings like:
 >  - katello::enable_ostree
 > - foreman::some_other_param
 
-These parameters need to be manually reviewed and added to the new configuration if needed. Check the [parameters documentation](parameters.md) for equivalent foremanctl parameters.
+These parameters need to be manually reviewed and added to the new configuration if needed. Check the [parameters documentation](user/parameters.md) for equivalent foremanctl parameters.
 
 ## Using the Migrated Configuration
 


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Various links were broken after the file moved in 5429d57ae488 ("Split docs for users and developers").

#### What are the changes introduced in this pull request?

* The paths to parameters.md are updated

#### How to test this pull request

Steps to reproduce:

* Go to each modified file and verify the links work
* Verify I haven't forgotten any links

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)