### PR TITLE
[DRAFT] Add iop_compliance and iop_compliance_frontend roles

### DIFF
--- a/src/playbooks/iop_server_compliance/iop_server_compliance.yaml
+++ b/src/playbooks/iop_server_compliance/iop_server_compliance.yaml
@@ -1,0 +1,96 @@
+---
+# Deploy compliance services onto an existing IoP server (forklift iop-server).
+# Unlike the main deploy.yaml which targets a foremanctl quadlet VM, this
+# playbook targets a forklift iop-server where postgres is managed by puppet
+# via unix socket. All other IoP services must already be running.
+- name: Ensure foremanctl state directory exists on controller
+  hosts: localhost
+  gather_facts: false
+  vars:
+    obsah_state_path: /var/lib/foreman/foremanctl
+  tasks:
+    - name: Create foremanctl state directory
+      ansible.builtin.file:
+        path: "{{ obsah_state_path }}"
+        state: directory
+        mode: "0700"
+
+- name: Deploy compliance services on IoP server
+  hosts: all
+  become: true
+  vars:
+    obsah_state_path: /var/lib/foreman/foremanctl
+    # postgres is on the host, accessible via unix socket from containers
+    iop_compliance_database_host: /var/run/postgresql
+    iop_compliance_database_port: 5432
+    iop_compliance_database_name: compliance_db
+    iop_compliance_database_user: compliance_admin
+    iop_compliance_database_password_file: "{{ obsah_state_path }}/iop-compliance-db-password"
+    iop_compliance_database_password: >-
+      {{ lookup('ansible.builtin.password', iop_compliance_database_password_file,
+                chars=['ascii_letters', 'digits']) }}
+    iop_compliance_database_volumes:
+      - '/var/run/postgresql:/var/run/postgresql:rw'
+    # skip foremanctl's internal postgres extension tasks (handled below via peer auth)
+    database_mode: external
+    # iop-devel image builds assets to /opt/app-root/src/dist, not /srv/dist
+    iop_compliance_frontend_source_path: "/opt/app-root/src/dist/."
+  handlers:
+    - name: "Restart httpd"
+      listen: "httpd : Restart httpd"
+      ansible.builtin.systemd:
+        name: httpd
+        state: restarted
+
+  pre_tasks:
+    - name: Ensure foremanctl state directory exists
+      ansible.builtin.file:
+        path: "{{ obsah_state_path }}"
+        state: directory
+        mode: '0700'
+
+    - name: Create compliance_admin PostgreSQL role
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_user:
+        name: "{{ iop_compliance_database_user }}"
+        password: "{{ iop_compliance_database_password }}"
+        state: present
+
+    - name: Create compliance_db database
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_db:
+        name: "{{ iop_compliance_database_name }}"
+        owner: "{{ iop_compliance_database_user }}"
+        encoding: UTF8
+        lc_collate: en_US.utf8
+        lc_ctype: en_US.utf8
+        state: present
+
+    - name: Ensure pgcrypto extension in compliance database
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_ext:
+        name: pgcrypto
+        login_db: "{{ iop_compliance_database_name }}"
+        login_user: postgres
+        state: present
+
+    - name: Ensure dblink extension in compliance database
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_ext:
+        name: dblink
+        login_db: "{{ iop_compliance_database_name }}"
+        login_user: postgres
+        state: present
+
+  tasks:
+    - name: Deploy iop_compliance role
+      ansible.builtin.include_role:
+        name: iop_compliance
+
+    - name: Deploy iop_compliance_frontend role
+      ansible.builtin.include_role:
+        name: iop_compliance_frontend

--- a/src/playbooks/iop_server_compliance/metadata.obsah.yaml
+++ b/src/playbooks/iop_server_compliance/metadata.obsah.yaml
@@ -1,0 +1,3 @@
+---
+help: |
+  Deploy compliance services on an IoP server

--- a/src/playbooks/pull-images/pull-images.yaml
+++ b/src/playbooks/pull-images/pull-images.yaml
@@ -64,9 +64,11 @@
         - iop_remediation
         - iop_vmaas
         - iop_vulnerability
+        - iop_compliance
         - iop_advisor_frontend
         - iop_inventory_frontend
         - iop_vulnerability_frontend
+        - iop_compliance_frontend
       when: enabled_features | has_feature('iop')
 
     - name: Pull images

--- a/src/roles/iop_compliance/defaults/main.yaml
+++ b/src/roles/iop_compliance/defaults/main.yaml
@@ -1,0 +1,49 @@
+---
+iop_compliance_container_image: "quay.io/rblanco/compliance-backend"
+iop_compliance_container_tag: "iop-devel"
+iop_compliance_ssg_container_image: "quay.io/rblanco/compliance-ssg-upstream"
+iop_compliance_ssg_container_tag: "latest"
+
+iop_compliance_database_volumes: []
+
+iop_compliance_ssg_port: 8080
+iop_compliance_ssg_url: "http://iop-service-compl-ssg:{{ iop_compliance_ssg_port }}"
+iop_compliance_host_inventory_url: "http://iop-core-host-inventory-api:8081"
+
+# SECRET_KEY_BASE is randomly generated once and persisted to the state
+# directory, mirroring the DB-password pattern (vars/database.yml). This keeps
+# it stable across restarts without shipping a hardcoded key in the repo.
+iop_compliance_secret_key_base_file: "{{ obsah_state_path }}/iop-compliance-secret-key-base"
+iop_compliance_secret_key_base: "{{ lookup('ansible.builtin.password', iop_compliance_secret_key_base_file, chars=['ascii_letters', 'digits'], length=64) }}"
+
+# Shared environment applied to every compliance container. Per-container
+# additions (APPLICATION_TYPE, tuning) are merged on top in tasks/main.yaml.
+iop_compliance_common_env:
+  DISABLE_RBAC: "true"
+  RAILS_ENV: "foreman"
+  RAILS_LOG_TO_STDOUT: "true"
+  PATH_PREFIX: "/api"
+  APP_NAME: "compliance-backend"
+  RUBY_YJIT_ENABLE: "true"
+  SETTINGS__REPORT_DOWNLOAD_SSL_ONLY: "false"
+  MAX_INIT_TIMEOUT_SECONDS: "120"
+  KAFKA_BROKERS: "iop-core-kafka:9092"
+  KAFKA_SECURITY_PROTOCOL: "plaintext"
+  POSTGRESQL_SSLMODE: "disable"
+  HOST_INVENTORY_URL: "{{ iop_compliance_host_inventory_url }}"
+  COMPLIANCE_SSG_URL: "{{ iop_compliance_ssg_url }}"
+  KAFKA_TOPIC_INVENTORY_EVENTS: "platform.inventory.events"
+  KAFKA_TOPIC_UPLOAD_COMPLIANCE: "platform.upload.compliance"
+  KAFKA_TOPIC_PAYLOAD_STATUS: "platform.payload-status"
+  KAFKA_TOPIC_NOTIFICATIONS_INGRESS: "platform.notifications.ingress"
+  KAFKA_TOPIC_REMEDIATION_UPDATES: "platform.remediation-updates.compliance"
+  KAFKA_TOPIC_INVENTORY_HOST_APPS: "platform.inventory.host-apps"
+
+# DB credentials + SECRET_KEY_BASE are injected as podman secrets (env-targeted).
+iop_compliance_common_secrets:
+  - 'iop-service-compliance-database-username,type=env,target=POSTGRESQL_USER'
+  - 'iop-service-compliance-database-password,type=env,target=POSTGRESQL_PASSWORD'
+  - 'iop-service-compliance-database-name,type=env,target=POSTGRESQL_DATABASE'
+  - 'iop-service-compliance-database-host,type=env,target=POSTGRESQL_HOST'
+  - 'iop-service-compliance-database-port,type=env,target=POSTGRESQL_PORT'
+  - 'iop-service-compliance-secret-key-base,type=env,target=SECRET_KEY_BASE'

--- a/src/roles/iop_compliance/handlers/main.yaml
+++ b/src/roles/iop_compliance/handlers/main.yaml
@@ -1,0 +1,10 @@
+---
+- name: Restart compliance
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: restarted
+  loop:
+    - iop-service-compliance-backend-api
+    - iop-service-compl-inventory-consumer
+    - iop-service-compl-goodjob
+    - iop-service-compl-ssg

--- a/src/roles/iop_compliance/tasks/image.yaml
+++ b/src/roles/iop_compliance/tasks/image.yaml
@@ -1,0 +1,18 @@
+---
+- name: Deploy iop-compliance image unit
+  ansible.builtin.include_role:
+    name: images
+    tasks_from: deploy_image.yaml
+  vars:
+    images_definition:
+      name: iop-compliance
+      image: "{{ iop_compliance_container_image }}:{{ iop_compliance_container_tag }}"
+
+- name: Deploy iop-compliance-ssg image unit
+  ansible.builtin.include_role:
+    name: images
+    tasks_from: deploy_image.yaml
+  vars:
+    images_definition:
+      name: iop-compliance-ssg
+      image: "{{ iop_compliance_ssg_container_image }}:{{ iop_compliance_ssg_container_tag }}"

--- a/src/roles/iop_compliance/tasks/main.yaml
+++ b/src/roles/iop_compliance/tasks/main.yaml
@@ -1,0 +1,259 @@
+---
+- name: Deploy iop-compliance images
+  ansible.builtin.include_tasks: image.yaml
+
+- name: Create podman secret for compliance database username
+  containers.podman.podman_secret:
+    name: iop-service-compliance-database-username
+    data: "{{ iop_compliance_database_user }}"
+  notify: Restart compliance
+
+- name: Create podman secret for compliance database password
+  containers.podman.podman_secret:
+    name: iop-service-compliance-database-password
+    data: "{{ iop_compliance_database_password }}"
+  notify: Restart compliance
+
+- name: Create podman secret for compliance database name
+  containers.podman.podman_secret:
+    name: iop-service-compliance-database-name
+    data: "{{ iop_compliance_database_name }}"
+  notify: Restart compliance
+
+- name: Create podman secret for compliance database host
+  containers.podman.podman_secret:
+    name: iop-service-compliance-database-host
+    data: "{{ iop_compliance_database_host }}"
+  notify: Restart compliance
+
+- name: Create podman secret for compliance database port
+  containers.podman.podman_secret:
+    name: iop-service-compliance-database-port
+    data: "{{ iop_compliance_database_port | string }}"
+  notify: Restart compliance
+
+- name: Create podman secret for compliance SECRET_KEY_BASE
+  containers.podman.podman_secret:
+    name: iop-service-compliance-secret-key-base
+    data: "{{ iop_compliance_secret_key_base }}"
+  notify: Restart compliance
+
+- name: Ensure pgcrypto extension exists in compliance database
+  community.postgresql.postgresql_ext:
+    name: pgcrypto
+    login_db: "{{ iop_compliance_database_name }}"
+    login_user: postgres
+    login_password: "{{ postgresql_admin_password }}"
+    login_host: localhost
+    state: present
+  when: database_mode == 'internal'
+
+- name: Ensure dblink extension exists in compliance database
+  community.postgresql.postgresql_ext:
+    name: dblink
+    login_db: "{{ iop_compliance_database_name }}"
+    login_user: postgres
+    login_password: "{{ postgresql_admin_password }}"
+    login_host: localhost
+    state: present
+  when: database_mode == 'internal'
+
+- name: Deploy Compliance Database Upgrade Init Container
+  containers.podman.podman_container:
+    name: iop-service-compl-dbmigrate
+    image: iop-compliance.image
+    state: quadlet
+    command: sh -c "bundle exec rake db:migrate --trace"
+    network:
+      - iop-core-network
+    volumes: "{{ iop_compliance_database_volumes }}"
+    env: "{{ iop_compliance_common_env | combine({'RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR': '2.0'}) }}"
+    secrets: "{{ iop_compliance_common_secrets }}"
+    quadlet_options:
+      - |
+        [Unit]
+        Description=Compliance Database Upgrade Init Container
+        After=iop-core-kafka.service
+        Wants=iop-core-kafka.service
+        PartOf=foreman.target
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        [Install]
+        WantedBy=default.target foreman.target
+
+- name: Deploy Compliance Backend API Container
+  containers.podman.podman_container:
+    name: iop-service-compliance-backend-api
+    image: iop-compliance.image
+    state: quadlet
+    network:
+      - iop-core-network
+    volumes: "{{ iop_compliance_database_volumes }}"
+    env: >-
+      {{ iop_compliance_common_env | combine({
+        'APPLICATION_TYPE': 'compliance-backend',
+        'RAILS_LOGLEVEL': 'info',
+        'PUMA_WORKERS': '3',
+        'PUMA_MIN_THREADS': '1',
+        'PUMA_MAX_THREADS': '3',
+        'MALLOC_ARENA_MAX': '2',
+        'OLD_PATH_PREFIX': '/r/insights/platform',
+        'RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR': '1.2',
+      }) }}
+    secrets: "{{ iop_compliance_common_secrets }}"
+    quadlet_options:
+      - |
+        [Unit]
+        Description=Compliance Service
+        After=iop-service-compl-dbmigrate.service
+        Wants=iop-service-compl-dbmigrate.service
+        Requires=iop-service-compl-dbmigrate.service
+        PartOf=foreman.target
+        [Service]
+        Restart=on-failure
+        [Install]
+        WantedBy=default.target foreman.target
+
+- name: Deploy Compliance SSG Container
+  containers.podman.podman_container:
+    name: iop-service-compl-ssg
+    image: iop-compliance-ssg.image
+    state: quadlet
+    network:
+      - iop-core-network
+    quadlet_options:
+      - |
+        [Unit]
+        Description=Compliance SSG Service
+        PartOf=foreman.target
+        [Service]
+        Restart=on-failure
+        [Install]
+        WantedBy=default.target foreman.target
+
+- name: Deploy Compliance Inventory Consumer Container
+  containers.podman.podman_container:
+    name: iop-service-compl-inventory-consumer
+    image: iop-compliance.image
+    state: quadlet
+    env: >-
+      {{ iop_compliance_common_env | combine({
+        'APPLICATION_TYPE': 'compliance-inventory',
+        'MALLOC_ARENA_MAX': '2',
+      }) }}
+    secrets: "{{ iop_compliance_common_secrets }}"
+    network:
+      - iop-core-network
+    volumes: "{{ iop_compliance_database_volumes }}"
+    quadlet_options:
+      - |
+        [Unit]
+        Description=Compliance Inventory Consumer Service
+        After=iop-service-compl-dbmigrate.service iop-core-kafka.service
+        Wants=iop-service-compl-dbmigrate.service
+        Requires=iop-service-compl-dbmigrate.service
+        PartOf=foreman.target
+        [Service]
+        Restart=on-failure
+        [Install]
+        WantedBy=default.target foreman.target
+
+- name: Deploy Compliance GoodJob Worker Container
+  containers.podman.podman_container:
+    name: iop-service-compl-goodjob
+    image: iop-compliance.image
+    state: quadlet
+    env: >-
+      {{ iop_compliance_common_env | combine({
+        'APPLICATION_TYPE': 'compliance-goodjob',
+      }) }}
+    secrets: "{{ iop_compliance_common_secrets }}"
+    network:
+      - iop-core-network
+    volumes: "{{ iop_compliance_database_volumes }}"
+    quadlet_options:
+      - |
+        [Unit]
+        Description=Compliance GoodJob Worker
+        After=iop-service-compl-dbmigrate.service
+        Wants=iop-service-compl-dbmigrate.service
+        Requires=iop-service-compl-dbmigrate.service
+        PartOf=foreman.target
+        [Service]
+        Restart=on-failure
+        [Install]
+        WantedBy=default.target foreman.target
+
+- name: Deploy Compliance Import SSG Container
+  containers.podman.podman_container:
+    name: iop-service-compl-import-ssg
+    image: iop-compliance.image
+    state: quadlet
+    env: >-
+      {{ iop_compliance_common_env | combine({
+        'APPLICATION_TYPE': 'compliance-import-ssg',
+      }) }}
+    secrets: "{{ iop_compliance_common_secrets }}"
+    network:
+      - iop-core-network
+    volumes: "{{ iop_compliance_database_volumes }}"
+    quadlet_options:
+      - |
+        [Unit]
+        Description=Compliance Import SSG Job
+        After=iop-service-compl-dbmigrate.service
+        Wants=iop-service-compl-dbmigrate.service
+        [Service]
+        Type=oneshot
+
+- name: Create Compliance Import SSG timer unit
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/iop-service-compl-import-ssg.timer
+    content: |
+      [Unit]
+      Description=Timer for Compliance Import SSG Job
+
+      [Timer]
+      OnBootSec=5min
+      OnUnitActiveSec=5min
+      Persistent=true
+
+      [Install]
+      WantedBy=timers.target
+    mode: '0644'
+
+- name: Run daemon reload to make Quadlet create the service files
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Flush handlers to restart services
+  ansible.builtin.meta: flush_handlers
+
+- name: Start Compliance services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: started
+  async: 60
+  poll: 0
+  loop:
+    - iop-service-compl-dbmigrate
+    - iop-service-compl-ssg
+    - iop-service-compliance-backend-api
+    - iop-service-compl-inventory-consumer
+    - iop-service-compl-goodjob
+  register: iop_compliance_services
+
+- name: Wait for Compliance services to start
+  ansible.builtin.async_status:
+    jid: "{{ item.ansible_job_id }}"
+  loop: "{{ iop_compliance_services.results }}"
+  register: _iop_compliance_job_result
+  until: _iop_compliance_job_result is finished
+  retries: 100
+
+- name: Enable and start Compliance Import SSG timer
+  ansible.builtin.systemd:
+    name: iop-service-compl-import-ssg.timer
+    enabled: true
+    state: started

--- a/src/roles/iop_compliance_frontend/defaults/main.yaml
+++ b/src/roles/iop_compliance_frontend/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+iop_compliance_frontend_container_image: "quay.io/rblanco/compliance-frontend"
+iop_compliance_frontend_container_tag: "iop-devel"
+iop_compliance_frontend_assets_path: "/var/www/iop/assets/apps/compliance"
+iop_compliance_frontend_source_path: "/srv/dist/."

--- a/src/roles/iop_compliance_frontend/tasks/image.yaml
+++ b/src/roles/iop_compliance_frontend/tasks/image.yaml
@@ -1,0 +1,9 @@
+---
+- name: Deploy iop-compliance-frontend image unit
+  ansible.builtin.include_role:
+    name: images
+    tasks_from: deploy_image.yaml
+  vars:
+    images_definition:
+      name: iop-compliance-frontend
+      image: "{{ iop_compliance_frontend_container_image }}:{{ iop_compliance_frontend_container_tag }}"

--- a/src/roles/iop_compliance_frontend/tasks/main.yaml
+++ b/src/roles/iop_compliance_frontend/tasks/main.yaml
@@ -1,0 +1,98 @@
+---
+- name: Deploy iop-compliance-frontend image
+  ansible.builtin.include_tasks: image.yaml
+
+- name: Run daemon reload for image unit
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Pull Compliance Frontend image via quadlet unit
+  ansible.builtin.systemd:
+    name: iop-compliance-frontend-image.service
+    state: started
+
+- name: Ensure parent assets directory exists
+  ansible.builtin.file:
+    path: /var/www/iop/assets/apps
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure assets directory exists
+  ansible.builtin.file:
+    path: "{{ iop_compliance_frontend_assets_path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Create temporary container for asset extraction
+  containers.podman.podman_container:
+    name: iop-compliance-frontend-temp
+    image: "{{ iop_compliance_frontend_container_image }}:{{ iop_compliance_frontend_container_tag }}"
+    state: created
+
+- name: Extract compliance frontend assets from container
+  containers.podman.podman_container_copy:
+    container: iop-compliance-frontend-temp
+    src: "{{ iop_compliance_frontend_source_path }}"
+    dest: "{{ iop_compliance_frontend_assets_path }}"
+    from_container: true
+
+- name: Restore SELinux context for compliance frontend assets
+  ansible.builtin.command:
+    cmd: restorecon -R "{{ iop_compliance_frontend_assets_path }}"
+  when: ansible_facts['selinux']['status'] == "enabled"
+  changed_when: false
+
+- name: Remove temporary container
+  containers.podman.podman_container:
+    name: iop-compliance-frontend-temp
+    state: absent
+
+- name: Set ownership of compliance frontend assets
+  ansible.builtin.file:
+    path: "{{ iop_compliance_frontend_assets_path }}"
+    owner: root
+    group: root
+    recurse: true
+
+- name: Ensure Apache SSL config directory exists
+  ansible.builtin.file:
+    path: /etc/httpd/conf.d/05-foreman-ssl.d
+    state: directory
+    mode: '0755'
+
+- name: Configure Apache for compliance frontend assets
+  ansible.builtin.copy:
+    dest: /etc/httpd/conf.d/05-foreman-ssl.d/compliance-frontend.conf
+    content: |
+      # IOP Compliance Frontend Assets Configuration
+      Alias /assets/apps/compliance {{ iop_compliance_frontend_assets_path }}
+      ProxyPass /assets/apps/compliance !
+
+      <LocationMatch "^/assets/apps/compliance">
+        Options SymLinksIfOwnerMatch
+        AllowOverride None
+        Require all granted
+
+        # Use standard http expire header for assets instead of ETag
+        <IfModule mod_expires.c>
+          Header unset ETag
+          FileETag None
+          ExpiresActive On
+          ExpiresDefault "access plus 1 year"
+        </IfModule>
+
+        # Return compressed assets if they are precompiled
+        RewriteEngine On
+        # Make sure the browser supports gzip encoding and file with .gz added
+        # does exist on disc before we rewrite with the extension
+        RewriteCond %{HTTP:Accept-Encoding} \b(x-)?gzip\b
+        RewriteCond %{REQUEST_FILENAME} \.(css|js|svg)$
+        RewriteCond %{REQUEST_FILENAME}.gz -s
+        RewriteRule ^(.+) $1.gz [L]
+      </LocationMatch>
+    mode: '0644'
+  notify: "httpd : Restart httpd"

--- a/src/roles/iop_core/tasks/main.yaml
+++ b/src/roles/iop_core/tasks/main.yaml
@@ -64,6 +64,10 @@
   ansible.builtin.include_role:
     name: iop_vulnerability
 
+- name: Deploy IOP Compliance service
+  ansible.builtin.include_role:
+    name: iop_compliance
+
 - name: Deploy IOP Inventory Frontend
   ansible.builtin.include_role:
     name: iop_inventory_frontend
@@ -75,3 +79,7 @@
 - name: Deploy IOP Vulnerability Frontend
   ansible.builtin.include_role:
     name: iop_vulnerability_frontend
+
+- name: Deploy IOP Compliance Frontend
+  ansible.builtin.include_role:
+    name: iop_compliance_frontend

--- a/src/roles/iop_gateway/defaults/main.yaml
+++ b/src/roles/iop_gateway/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
-iop_gateway_container_image: "quay.io/iop/gateway"
-iop_gateway_container_tag: "foreman-5.0"
+iop_gateway_container_image: "quay.io/rblanco/iop-gateway"
+iop_gateway_container_tag: "iop-devel"
 
 iop_gateway_server_certificate: "/var/lib/foremanctl/certs/certs/localhost.crt"
 iop_gateway_server_key: "/var/lib/foremanctl/certs/private/localhost.key"

--- a/src/vars/database.yml
+++ b/src/vars/database.yml
@@ -81,6 +81,13 @@ iop_vulnerability_database_user: vulnerability_admin
 iop_vulnerability_database_password_file: "{{ obsah_state_path }}/iop-vulnerability-db-password"
 iop_vulnerability_database_password: "{{ lookup('ansible.builtin.password', iop_vulnerability_database_password_file, chars=['ascii_letters', 'digits']) }}"
 
+iop_compliance_database_host: "{{ iop_database_host }}"
+iop_compliance_database_port: "{{ iop_database_port }}"
+iop_compliance_database_name: compliance_db
+iop_compliance_database_user: compliance_admin
+iop_compliance_database_password_file: "{{ obsah_state_path }}/iop-compliance-db-password"
+iop_compliance_database_password: "{{ lookup('ansible.builtin.password', iop_compliance_database_password_file, chars=['ascii_letters', 'digits']) }}"
+
 databases:
   - name: foreman
     database: "{{ foreman_database_name }}"
@@ -150,6 +157,13 @@ databases:
     port: "{{ iop_vulnerability_database_port }}"
     user: "{{ iop_vulnerability_database_user }}"
     password: "{{ iop_vulnerability_database_password }}"
+    feature: iop
+  - name: iop_compliance
+    database: "{{ iop_compliance_database_name }}"
+    host: "{{ iop_compliance_database_host }}"
+    port: "{{ iop_compliance_database_port }}"
+    user: "{{ iop_compliance_database_user }}"
+    password: "{{ iop_compliance_database_password }}"
     feature: iop
 
 all_databases: >-

--- a/tests/feature/iop/images_test.py
+++ b/tests/feature/iop/images_test.py
@@ -12,9 +12,12 @@ IOP_IMAGES = [
     "iop-remediation",
     "iop-vmaas",
     "iop-vulnerability",
+    "iop-compliance",
+    "iop-compliance-ssg",
     "iop-advisor-frontend",
     "iop-inventory-frontend",
     "iop-vulnerability-frontend",
+    "iop-compliance-frontend",
 ]
 
 

--- a/tests/feature/iop/test_compliance.py
+++ b/tests/feature/iop/test_compliance.py
@@ -1,0 +1,87 @@
+def test_compliance_backend_api_service(server):
+    service = server.service("iop-service-compliance-backend-api")
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_compliance_ssg_service(server):
+    service = server.service("iop-service-compl-ssg")
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_compliance_inventory_consumer_service(server):
+    service = server.service("iop-service-compl-inventory-consumer")
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_compliance_goodjob_service(server):
+    service = server.service("iop-service-compl-goodjob")
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_compliance_dbmigrate_quadlet_file(server):
+    quadlet_file = server.file("/etc/containers/systemd/iop-service-compl-dbmigrate.container")
+    assert quadlet_file.exists
+    assert quadlet_file.is_file
+
+
+def test_compliance_api_container(server):
+    result = server.run("podman ps --format '{{.Names}}' | grep iop-service-compliance-backend-api")
+    assert result.succeeded
+    assert "iop-service-compliance-backend-api" in result.stdout
+
+
+def test_compliance_ssg_container(server):
+    result = server.run("podman ps --format '{{.Names}}' | grep iop-service-compl-ssg")
+    assert result.succeeded
+    assert "iop-service-compl-ssg" in result.stdout
+
+
+def test_compliance_api_quadlet_file(server):
+    quadlet_file = server.file("/etc/containers/systemd/iop-service-compliance-backend-api.container")
+    assert quadlet_file.exists
+    assert quadlet_file.is_file
+
+
+def test_compliance_api_service_dependencies(server):
+    result = server.run("systemctl show iop-service-compliance-backend-api --property=After")
+    assert result.succeeded
+    assert "iop-service-compl-dbmigrate.service" in result.stdout
+
+
+def test_compliance_inventory_consumer_dependencies(server):
+    result = server.run("systemctl show iop-service-compl-inventory-consumer --property=After")
+    assert result.succeeded
+    assert "iop-core-kafka.service" in result.stdout
+
+
+def test_compliance_database_secrets(server):
+    result = server.run("podman secret ls --format '{{.Name}}'")
+    assert result.succeeded
+    assert "iop-service-compliance-database-username" in result.stdout
+    assert "iop-service-compliance-database-password" in result.stdout
+    assert "iop-service-compliance-database-name" in result.stdout
+    assert "iop-service-compliance-database-host" in result.stdout
+    assert "iop-service-compliance-database-port" in result.stdout
+
+
+def test_compliance_secret_key_base_secret(server):
+    result = server.run("podman secret ls --format '{{.Name}}'")
+    assert result.succeeded
+    assert "iop-service-compliance-secret-key-base" in result.stdout
+
+
+def test_compliance_import_ssg_timer(server):
+    service = server.service("iop-service-compl-import-ssg.timer")
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_compliance_import_ssg_timer_file(server):
+    timer_file = server.file("/etc/systemd/system/iop-service-compl-import-ssg.timer")
+    assert timer_file.exists
+    assert timer_file.is_file
+    assert "OnUnitActiveSec=5min" in timer_file.content_string

--- a/tests/feature/iop/test_compliance_frontend.py
+++ b/tests/feature/iop/test_compliance_frontend.py
@@ -1,0 +1,23 @@
+def test_compliance_frontend_assets_directory(server):
+    assets_dir = server.file("/var/www/iop/assets/apps/compliance")
+    assert assets_dir.exists
+    assert assets_dir.is_directory
+    assert assets_dir.mode == 0o755
+
+
+def test_compliance_frontend_app_info_file(server):
+    app_info_file = server.file("/var/www/iop/assets/apps/compliance/app.info.json")
+
+    assert app_info_file.exists
+    assert app_info_file.is_file
+
+
+def test_compliance_frontend_javascript_assets_accessible(server):
+    result = server.run("find /var/www/iop/assets/apps/compliance -name '*.js' | head -1")
+    assert result.succeeded
+    assert result.stdout.strip()
+    js_file = result.stdout.strip().replace("/var/www/iop", "")
+    curl_result = server.run(f"curl -s -o /dev/null -w '%{{http_code}}' -k https://localhost{js_file}")
+    assert curl_result.succeeded
+    http_code = curl_result.stdout.strip()
+    assert http_code in ["200"]


### PR DESCRIPTION
### :exclamation: Draft: should be merged only after branching.

---

Deploy the compliance service like the other iop services: included from iop_core, added to the pull-images loop, and provisioned via vars/database.yml.

iop_compliance runs the backend API, an SSG content server, a Kafka inventory consumer, a goodjob worker, a db:migrate init container, and an import-ssg oneshot on a 5-minute timer. iop_compliance_frontend serves the frontend assets via Apache.

The API container is named iop-service-compliance-backend-api in full so the gateway proxy_pass upstream resolves it over iop-core-network.

#### Why are you introducing these changes? (Problem description, related links)

#### What are the changes introduced in this pull request?

* https://github.com/theforeman/puppet-iop/pull/112#issuecomment-5410157623

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
