### PR TITLE
Resolve transitive dependencies when listing enabled features

### DIFF
--- a/src/filter_plugins/foremanctl.py
+++ b/src/filter_plugins/foremanctl.py
@@ -79,7 +79,7 @@ def list_all_features(enabled_features, only_enabled=False):
         if internal and not list_internal:
             continue
         description = meta.get('description', '')
-        if name in enabled_features:
+        if has_feature(enabled_features, name):
             enabled_list.append((name, 'enabled', internal, description))
         elif not only_enabled:
             available_list.append((name, 'available', internal, description))

--- a/tests/unit/filter_test.py
+++ b/tests/unit/filter_test.py
@@ -1,5 +1,6 @@
 from foremanctl import FEATURE_MAP
 from foremanctl import conflicting_features
+from foremanctl import list_all_features
 
 
 def _asymmetric_conflicts():
@@ -54,3 +55,11 @@ def test_conflict_with_unknown_feature_detected(monkeypatch):
     monkeypatch.setitem(FEATURE_MAP, 'test-a', {'conflicts': ['nonexistent']})
     errors = _asymmetric_conflicts()
     assert any('unknown feature nonexistent' in e for e in errors)
+
+
+def test_list_all_features_marks_dependency_as_enabled(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-parent', {'dependencies': ['test-child']})
+    monkeypatch.setitem(FEATURE_MAP, 'test-child', {})
+    output = list_all_features(['test-parent'])
+    child_line = next(line for line in output.splitlines() if line.startswith('test-child'))
+    assert 'enabled' in child_line


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

`foremanctl features` reported dependency-only features (e.g. `tasks` and `dynflow`, pulled in by `remote-execution`) as `available` instead of `enabled`. The list checked for literal membership in `enabled_features` instead of using the existing `has_feature` dependency resolution already used elsewhere (plugin installation, health checks), so the displayed state didn't match what was actually being installed/configured.

#### What are the changes introduced in this pull request?

* `list_all_features()` now checks each feature with `has_feature()` instead of `name in enabled_features`, so features enabled only as a dependency of another feature are correctly marked `enabled`.
* Added a unit test covering a dependency-only feature showing as `enabled`.

#### How to test this pull request

Steps to reproduce:

* Deploy with a feature that has dependencies, e.g. `--add-feature remote-execution`.
* Run `FOREMANCTL_FEATURES_LIST_INTERNAL=true ./foremanctl features`.
* Before this change: `tasks` and `dynflow` show as `available`. After this change: they show as `enabled`.
* `python -m pytest tests/unit/filter_test.py -vv`

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)