### PR TITLE
Fix no-change deploy restarts Foreman issue

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -246,7 +246,7 @@
 - name: Migrate and seed the Foreman database
   ansible.builtin.systemd:
     name: foreman-db-migrate.service
-    state: restarted
+    state: "{{ 'restarted' if (images_changed.foreman | default(false) | bool) else 'started' }}"
 
 - name: Flush handlers to restart services
   ansible.builtin.meta: flush_handlers

--- a/src/roles/images/tasks/deploy_image.yaml
+++ b/src/roles/images/tasks/deploy_image.yaml
@@ -11,6 +11,7 @@
       - |
         [Service]
         Environment=REGISTRY_AUTH_FILE={{ images_registry_auth_file }}
+  register: image_deploy_result
 
 - name: Create drop-in directory for {{ images_definition.name }}
   ansible.builtin.file:
@@ -21,3 +22,9 @@
 - name: Register deployed image name
   ansible.builtin.set_fact:
     images_deployed_names: "{{ images_deployed_names + [images_definition.name] }}"
+
+- name: Track whether image changed for {{ images_definition.name }}
+  ansible.builtin.set_fact:
+    images_changed: >-
+      {{ images_changed | default({})
+         | combine({images_definition.name: (image_deploy_result is changed)}) }}

--- a/src/roles/images/tasks/deploy_image.yaml
+++ b/src/roles/images/tasks/deploy_image.yaml
@@ -11,7 +11,7 @@
       - |
         [Service]
         Environment=REGISTRY_AUTH_FILE={{ images_registry_auth_file }}
-  register: image_deploy_result
+  register: images_deploy_result
 
 - name: Create drop-in directory for {{ images_definition.name }}
   ansible.builtin.file:
@@ -27,4 +27,4 @@
   ansible.builtin.set_fact:
     images_changed: >-
       {{ images_changed | default({})
-         | combine({images_definition.name: (image_deploy_result is changed)}) }}
+         | combine({images_definition.name: (images_deploy_result is changed)}) }}


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

foremanctl deploy that changes nothing takes Foreman down for about a minute. foreman-db-migrate.service is driven with state: restarted unconditionally on every deploy. Both foreman.container and the dynflow-sidekiq@ template declare Requires=foreman-db-migrate.service, so systemd propagates the restart stopping and starting Foreman and all three dynflow-sidekiq workers even when nothing has changed.

Fixes: https://github.com/theforeman/foremanctl/issues/769

#### What are the changes introduced in this pull request?

- Register the result of the image quadlet generation task in the shared deploy_image.yaml and accumulate per-image change status into an images_changed dict

- Make the Foreman migration task conditional: use state: restarted only when the foreman image actually changed, state: started otherwise. Since the migration service is Type=oneshot with RemainAfterExit=yes, started is a genuine no-op when the service is already active, no restart cascade

#### How to test this pull request

Steps to reproduce:

* Run `foremanctl deploy` without any changes to images

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
