### PR TITLE
Improve the description/help text...

### DIFF
--- a/docs/user/parameters.md
+++ b/docs/user/parameters.md
@@ -78,7 +78,7 @@ There are multiple use cases from the users perspective that dictate what parame
 
 | Parameter | Description |
 | ----------| ----------- |
-| `--log-level` | Default log level for all services. Accepted values: `debug`, `info`, `warn`, `error`, `fatal`. Defaults to `info`. |
+| `--log-level` | Default log level for all services, unless overridden by the service-specific parameters. Accepted values: `debug`, `info`, `warn`, `error`, `fatal`. Defaults to `info`. | 
 | `--valkey-log-level` | Log level for Valkey. Uses Valkey's native levels. Overrides `--log-level`. Accepted values: `debug`, `verbose`, `notice`, `warning` & `nothing`. Defaults to `notice`. |
 
 ##### Mapped

--- a/src/playbooks/_logging/metadata.obsah.yaml
+++ b/src/playbooks/_logging/metadata.obsah.yaml
@@ -1,7 +1,7 @@
 ---
 variables:
   log_level:
-    help: Default log level for all services.
+    help: Default log level for all services, unless overridden by the service-specific parameters.
     parameter: --log-level
     choices:
       - debug
@@ -10,7 +10,7 @@ variables:
       - error
       - fatal
   foreman_proxy_log_level:
-    help: Log level for Foreman Proxy. Defaults to the global log level.
+    help: Defaults to the global log level, can be set independently. Once set, it overrides --log-level and is unaffected by later changes.
     choices:
       - debug
       - info
@@ -18,7 +18,7 @@ variables:
       - error
       - fatal
   valkey_log_level:
-    help: Log level for Valkey.
+    help: Defaults to the global log level, can be set independently. Once set, it overrides --log-level and is unaffected by later changes.
     choices:
       - debug
       - verbose
@@ -26,7 +26,7 @@ variables:
       - warning
       - nothing
   pulp_log_level:
-    help: Log level for Pulp. Defaults to the global log level.
+    help: Defaults to the global log level, can be set independently. Once set, it overrides --log-level and is unaffected by later changes.
     parameter: --pulp-log-level
     choices:
       - debug

--- a/src/playbooks/deploy/metadata.obsah.yaml
+++ b/src/playbooks/deploy/metadata.obsah.yaml
@@ -15,7 +15,7 @@ variables:
   external_authentication_pam_service:
     help: Name of the PAM service to use for IPA authentication
   foreman_log_level:
-    help: Log level for Foreman. Defaults to the global log level.
+    help: Defaults to the global log level, can be set independently. Once set, it overrides --log-level and is unaffected by later changes.
     choices:
       - debug
       - info


### PR DESCRIPTION
Improve the help text so that --help provides clear and accurate descriptions for the following parameters:

--log-level
--foreman-log-level
--foreman-proxy-log-level
--valkey-log-level
--pulp-log-level

Previously, the descriptions were not clear. They are now more precise and provide better information about the purpose and behavior of each parameter.