### PR TITLE
Pulp volume ownership followup (SAT-47249)

### DIFF
--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -7,8 +7,8 @@
     path: "{{ item | split(':') | first }}"
     state: directory
     mode: "0755"
-    owner: "700"
-    group: "700"
+    owner: "{{ pulp_container_uid }}"
+    group: "{{ pulp_container_gid }}"
     recurse: true
   loop: "{{ pulp_volumes }}"
 
@@ -17,8 +17,8 @@
     path: "{{ pulp_storage_path }}/{{ item }}"
     state: directory
     mode: "0755"
-    owner: "700"
-    group: "700"
+    owner: "{{ pulp_container_uid }}"
+    group: "{{ pulp_container_gid }}"
     recurse: true
   loop:
     - tmp
@@ -30,8 +30,8 @@
     path: "{{ item }}"
     state: directory
     mode: "0755"
-    owner: "700"
-    group: "700"
+    owner: "{{ pulp_container_uid }}"
+    group: "{{ pulp_container_gid }}"
     recurse: true
   loop: "{{ pulp_default_import_paths + pulp_import_paths }}"
   when: not pulp_mirror
@@ -41,8 +41,8 @@
     path: "{{ item }}"
     state: directory
     mode: "0755"
-    owner: "700"
-    group: "700"
+    owner: "{{ pulp_container_uid }}"
+    group: "{{ pulp_container_gid }}"
     recurse: true
   loop: "{{ pulp_default_export_paths + pulp_export_paths }}"
   when: not pulp_mirror
@@ -75,8 +75,8 @@
 - name: Set secret key file permissions
   ansible.builtin.file:
     path: "{{ pulp_storage_path }}/django_secret_key"
-    owner: "700"
-    group: "700"
+    owner: "{{ pulp_container_uid }}"
+    group: "{{ pulp_container_gid }}"
     mode: '0600'
 
 - name: Create django pulp secret key secret

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -9,7 +9,6 @@
     mode: "0755"
     owner: "{{ pulp_container_uid }}"
     group: "{{ pulp_container_gid }}"
-    recurse: true
   loop: "{{ pulp_volumes }}"
 
 - name: Create Pulp storage subdirs
@@ -19,7 +18,6 @@
     mode: "0755"
     owner: "{{ pulp_container_uid }}"
     group: "{{ pulp_container_gid }}"
-    recurse: true
   loop:
     - tmp
     - assets
@@ -32,7 +30,6 @@
     mode: "0755"
     owner: "{{ pulp_container_uid }}"
     group: "{{ pulp_container_gid }}"
-    recurse: true
   loop: "{{ pulp_default_import_paths + pulp_import_paths }}"
   when: not pulp_mirror
 
@@ -43,9 +40,26 @@
     mode: "0755"
     owner: "{{ pulp_container_uid }}"
     group: "{{ pulp_container_gid }}"
-    recurse: true
   loop: "{{ pulp_default_export_paths + pulp_export_paths }}"
   when: not pulp_mirror
+
+- name: Check ownership of Pulp volume paths
+  ansible.builtin.stat:
+    path: "{{ item | split(':') | first }}"
+  register: pulp_volume_path_stats
+  loop: "{{ pulp_volumes }}"
+
+- name: Migrate root-owned Pulp volume paths to container user
+  ansible.builtin.file:
+    path: "{{ item.item | split(':') | first }}"
+    owner: "{{ pulp_container_uid }}"
+    group: "{{ pulp_container_gid }}"
+    recurse: true
+  loop: "{{ pulp_volume_path_stats.results }}"
+  when:
+    - item.stat.exists
+    - item.stat.uid == 0
+    - item.stat.gid == 0
 
 - name: Create DB password secret
   containers.podman.podman_secret:

--- a/src/roles/pulp/tasks/main.yaml
+++ b/src/roles/pulp/tasks/main.yaml
@@ -89,8 +89,8 @@
 - name: Set secret key file permissions
   ansible.builtin.file:
     path: "{{ pulp_storage_path }}/django_secret_key"
-    owner: "{{ pulp_container_uid }}"
-    group: "{{ pulp_container_gid }}"
+    owner: root
+    group: root
     mode: '0600'
 
 - name: Create django pulp secret key secret
@@ -107,6 +107,13 @@
   ansible.builtin.command: "bash -c 'openssl rand -base64 32 | tr \"+/\" \"-_\" > {{ pulp_storage_path }}/database_fields.symmetric.key'"
   args:
     creates: "{{ pulp_storage_path }}/database_fields.symmetric.key"
+
+- name: Set database symmetric key file permissions
+  ansible.builtin.file:
+    path: "{{ pulp_storage_path }}/database_fields.symmetric.key"
+    owner: root
+    group: root
+    mode: '0600'
 
 - name: Create database symmetric key secret
   containers.podman.podman_secret:

--- a/src/roles/restore/tasks/restore_pulp_content.yaml
+++ b/src/roles/restore/tasks/restore_pulp_content.yaml
@@ -35,20 +35,34 @@
         remote_src: true
       when: not restore_is_incremental
 
-    - name: Check ownership of restored Pulp content
+    - name: Check ownership of restored Pulp storage
+      ansible.builtin.stat:
+        path: "{{ pulp_storage_path }}"
+      register: restore_pulp_storage_ownership
+
+    - name: Check ownership of restored Pulp media directory
       ansible.builtin.stat:
         path: "{{ pulp_storage_path }}/media"
       register: restore_pulp_media_ownership
 
-    - name: Fix ownership after restore for non-root containers
+    - name: Migrate restored Pulp storage ownership from root to container user
       ansible.builtin.file:
         path: "{{ pulp_storage_path }}"
-        owner: "700"
-        group: "700"
+        owner: "{{ pulp_container_uid }}"
+        group: "{{ pulp_container_gid }}"
         recurse: true
       when:
-        - restore_pulp_media_ownership.stat.exists
-        - restore_pulp_media_ownership.stat.uid == 0
+        - restore_pulp_storage_ownership.stat.exists
+        - >-
+          (
+            restore_pulp_storage_ownership.stat.uid == 0 and
+            restore_pulp_storage_ownership.stat.gid == 0
+          ) or
+          (
+            restore_pulp_media_ownership.stat.exists and
+            restore_pulp_media_ownership.stat.uid == 0 and
+            restore_pulp_media_ownership.stat.gid == 0
+          )
 
     - name: Verify Pulp encryption key was restored
       ansible.builtin.stat:

--- a/src/roles/restore/tasks/restore_pulp_content.yaml
+++ b/src/roles/restore/tasks/restore_pulp_content.yaml
@@ -64,6 +64,16 @@
             restore_pulp_media_ownership.stat.gid == 0
           )
 
+    - name: Set restored secret key file permissions
+      ansible.builtin.file:
+        path: "{{ item }}"
+        owner: root
+        group: root
+        mode: '0600'
+      loop:
+        - "{{ pulp_storage_path }}/django_secret_key"
+        - "{{ pulp_storage_path }}/database_fields.symmetric.key"
+
     - name: Verify Pulp encryption key was restored
       ansible.builtin.stat:
         path: "{{ pulp_storage_path }}/database_fields.symmetric.key"

--- a/src/vars/base.yaml
+++ b/src/vars/base.yaml
@@ -44,6 +44,8 @@ httpd_pulp_trusted_hosts:
 httpd_aliases: "{{ server_aliases | default([]) }}"
 
 pulp_storage_path: /var/lib/pulp
+pulp_container_uid: 700
+pulp_container_gid: 700
 pulp_content_origin: "https://{{ ansible_facts['fqdn'] }}"
 pulp_pulp_url: "https://{{ ansible_facts['fqdn'] }}"
 pulp_plugins: "{{ enabled_features | select('contains', 'content/') | map('replace', 'content/', 'pulp_') | list }}"

--- a/tests/feature/pulp/basic_test.py
+++ b/tests/feature/pulp/basic_test.py
@@ -1,9 +1,12 @@
 import json
+import time
 
 import pytest
 
 PULP_API_SOCKET = '/run/httpd.pulp-api.sock'
 PULP_CONTENT_SOCKET = '/run/httpd.pulp-content.sock'
+PULP_STATUS_POLL_INTERVAL = 5
+PULP_STATUS_POLL_TIMEOUT = 60
 
 
 @pytest.fixture(scope="module")
@@ -79,8 +82,24 @@ def test_pulp_status_content(pulp_status):
     assert pulp_status['online_content_apps']
 
 
-def test_pulp_status_workers(pulp_status):
-    assert pulp_status['online_workers']
+def _fetch_pulp_status(server, server_fqdn):
+    result = server.run(
+        f"curl -k -s --unix-socket {PULP_API_SOCKET} http://{server_fqdn}/pulp/api/v3/status/"
+    )
+    assert result.succeeded, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_pulp_status_workers(server, server_fqdn):
+    # Workers can take a moment to heartbeat after systemd reports them running.
+    deadline = time.monotonic() + PULP_STATUS_POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        if _fetch_pulp_status(server, server_fqdn)['online_workers']:
+            return
+        time.sleep(PULP_STATUS_POLL_INTERVAL)
+
+    status = _fetch_pulp_status(server, server_fqdn)
+    assert status['online_workers'], "Pulp workers did not appear online in status endpoint"
 
 
 def test_pulp_volumes(server):


### PR DESCRIPTION
Few changes as a follow-up to https://github.com/theforeman/foremanctl/pull/734

* Use variables instead harcoding 700
* Recursing pulp content is a trap! Implemented suggested solution by @arvind4501 which only recurse when permissions were previously root:root.
* Secrets should be owned by root, at least that is the pattern in the file

