### PR TITLE
Use legacy OpenSSL cipher naming for Candlepin's TLS connector

### DIFF
--- a/src/roles/candlepin/defaults/main.yml
+++ b/src/roles/candlepin/defaults/main.yml
@@ -5,10 +5,7 @@ candlepin_tls_versions:
   - "TLSv1.2"
   - "TLSv1.3"
 candlepin_ciphers:
-  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - "PROFILE=SYSTEM"
 candlepin_container_image: quay.io/foreman/candlepin
 candlepin_container_tag: "4.4.14"
 candlepin_secret_mount_opts: "mode=0440,uid=0,gid=53,type=mount"


### PR DESCRIPTION
Candlepin 5.0's Tomcat uses the new OpenSSL FFM connector, which fails to handle the IANA-style cipher names (TLS_ECDHE_...) we were using, leaving the connector with no usable ciphers and every TLS handshake failing. Switch to the legacy OpenSSL cipher naming (ECDHE-ECDSA-AES256-GCM-SHA384, ...) to make it work.

(cherry picked from commit dfe678c2452f9e89aa9656cbc9252060bdf2c5d2)