### PR TITLE
Remove valueless recurring timer last-trigger test

### DIFF
--- a/tests/feature/foreman/base_test.py
+++ b/tests/feature/foreman/base_test.py
@@ -79,15 +79,6 @@ def test_foreman_recurring_services_exist(server, instance):
 
 
 @pytest.mark.parametrize("instance", RECURRING_INSTANCES)
-def test_foreman_recurring_timer_last_trigger(server, instance):
-    """Verify that timers have a valid last trigger time (if they've run)."""
-    timer_name = f"foreman-recurring@{instance}.timer"
-    timer = server.service(timer_name)
-    props = timer.systemd_properties
-    assert 'LastTriggerUSec' in props or 'LastTriggerUSecRealtime' in props
-
-
-@pytest.mark.parametrize("instance", RECURRING_INSTANCES)
 def test_foreman_recurring_timer_next_trigger(server, instance):
     """Verify that timers have a scheduled next trigger time."""
     timer_name = f"foreman-recurring@{instance}.timer"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The test provids no unique value: `test_foreman_recurring_timer_next_trigger`
already proves each timer is scheduled to fire, and
`test_foreman_recurring_timer_execution` already proves the service and its
container plumbing actually run. Asserting that systemd recorded a past
trigger timestamp verifies nothing about the deployment's correctness.

See failures: https://github.com/theforeman/foreman-oci-images/actions/runs/33086235201/job/98566514040?pr=91

#### What are the changes introduced in this pull request?

* Remove the `test_foreman_recurring_timer_last_trigger` test, which was
  deploy-timing-dependent and duplicated coverage already provided by the
  next-trigger and execution tests.

#### How to test this pull request

Steps to reproduce:

* Deploy a VM with recurring timers enabled and run the recurring timer
  tests:
  `python -m pytest tests/feature/foreman/base_test.py -vv -k recurring`
* Confirm the suite passes on a fast fresh deploy (no pre-pulled images, no
  re-deploy) — previously `test_foreman_recurring_timer_last_trigger[monthly]`
  would fail in that scenario.

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

