### PR TITLE
Fixes #449 - Add container-gateway to capsule flavor features

### DIFF
--- a/src/vars/flavors/capsule.yml
+++ b/src/vars/flavors/capsule.yml
@@ -2,6 +2,7 @@
 flavor_features:
   - foreman-proxy
   - pulp
+  - container-gateway
   - content/ansible
   - content/container
   - content/rpm


### PR DESCRIPTION
## What are the changes introduced in this pull request?

Adds `container-gateway` to the `capsule` flavor's `flavor_features`, matching
the `foreman-proxy-content` flavor which has carried it since #611.

## Why are you introducing these changes?

Issue #449 originally scoped the container-gateway feature for "foreman proxy
content, or capsules in the Satellite ecosystem" -- but #611 only added it to
`foreman-proxy-content.yml`, and the `capsule` flavor (introduced later in
#735) never got it either. As a result, capsules deployed with
`--flavor capsule` respond with a raw 404 to registry pulls (`/v2/`) routed
through them, directly or via a load-balanced capsule proxy, since nothing on
the capsule's httpd config recognizes that path.

## How to test this pull request

1. Deploy a proxy with `--flavor capsule`.
2. Confirm `container-gateway` shows as `enabled` in `foremanctl features`.
3. `podman login <capsule-fqdn> --tls-verify=false` should succeed (this is
   exercised by the existing `tests/feature/container-gateway` suite, which
   is feature-based and will now also run against the `capsule` flavor).

Verified live end-to-end on a real capsule (foremanctl RPM install): before
the fix, `container-gateway` showed as `available` (not enabled) and `/v2/`
returned a raw HTML 404; after redeploying with the patched flavor file,
`container-gateway` shows `enabled`, `/v2/` returns a proper `401` challenge,
and `podman login` succeeds.

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)