### PR TITLE
Optimize Kafka topic initialization on re-deploy

### DIFF
--- a/src/roles/iop_kafka/files/kafka/init
+++ b/src/roles/iop_kafka/files/kafka/init
@@ -38,11 +38,37 @@ create_topics() {
 
   echo -e "====================="
   echo -e "Creating Kafka topics:"
+
+  existing_topics_list=$("$kafka_cmd" --bootstrap-server "$kafka_bootstrap_server" --list 2>&1)
+  list_exit_code=$?
+  if [ $list_exit_code -ne 0 ]; then
+    echo "Error: Failed to list Kafka topics" >&2
+    echo "Output/Error:" >&2
+    echo "$existing_topics_list" >&2
+    return 1
+  fi
+
+  local pids=()
   for topic in "${topics[@]}"; do
-    echo -e "Creating topic ""$topic"
-    $kafka_cmd --create --if-not-exists --topic "$topic" --bootstrap-server $kafka_bootstrap_server --partitions 1 replication-factor 1 &
+    if ! echo "$existing_topics_list" | grep -q -x -F -- "$topic"; then
+        echo -e "Creating topic ""$topic"
+        $kafka_cmd --create --if-not-exists --topic "$topic" --bootstrap-server $kafka_bootstrap_server --partitions 1 replication-factor 1 &
+        pids+=($!)
+    else
+        echo -e "$topic exists"
+    fi
   done
-  wait
+
+  local failed=0
+  for pid in "${pids[@]}"; do
+    if ! wait "$pid"; then
+      failed=1
+    fi
+  done
+  if [ $failed -ne 0 ]; then
+    echo "Error: One or more topic creations failed" >&2
+    return 1
+  fi
 
   echo -e "=========================="
   echo -e "Listing all Kafka topics:"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

On every re-deploy, the Kafka topic initialization task (`iop_kafka : Initialize Kafka topics`) runs the expensive `init.sh --create` operation, which spawns 17 parallel JVMs to create topics. This takes ~11.4 seconds even when all topics already exist and no actual work is needed.

This pattern mirrors the puppet-iop implementation (`puppet-iop/manifests/core_kafka.pp:80-91`), which guards topic creation with an `unless` check.

#### What are the changes introduced in this pull request?

* Add `Check whether Kafka topics already exist` task that runs `/opt/kafka/init.sh --check` before topic creation
* Make the `Initialize Kafka topics` task conditional on `iop_kafka_check.rc != 0`
* The `--check` operation runs a single JVM vs 17 parallel JVMs in `--create`

#### How to test this pull request

Steps to reproduce:

* Deploy with IoP enabled: `./foremanctl deploy --flavor katello --features iop`
* Verify topics are created: `podman exec iop-core-kafka /opt/kafka/init.sh --check` (should succeed)
* Re-deploy without changes: `./foremanctl deploy --flavor katello --features iop`
* Observe timing: `iop_kafka : Check whether Kafka topics already exist` should run in ~1-2s and `Initialize Kafka topics` should be skipped
* Compare to before: previously `Initialize Kafka topics` ran every deploy and took ~11.4s

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

