### PR TITLE
Fix plugin list ordering for quadlet idempotency

### DIFF
--- a/src/filter_plugins/foremanctl.py
+++ b/src/filter_plugins/foremanctl.py
@@ -61,8 +61,9 @@ def get_dependencies(features):
 
 def foreman_plugins(value):
     dependencies = list(get_dependencies(filter_features(value)))
-    plugins = [FEATURE_MAP.get(feature, {}).get('foreman', {}).get('plugin_name') for feature in filter_features(value + dependencies)]
-    return compact_list(plugins)
+    features = set(filter_features(value + dependencies))
+    plugins = [FEATURE_MAP.get(feature, {}).get('foreman', {}).get('plugin_name') for feature in features]
+    return sorted(compact_list(plugins))
 
 
 def available_foreman_plugins(_value):
@@ -113,14 +114,16 @@ def conflicting_features(features):
 
 def hammer_plugins(value):
     dependencies = list(get_dependencies(filter_features(value)))
-    plugins = [FEATURE_MAP.get(feature, {}).get('hammer') for feature in filter_features(value + dependencies)]
-    return compact_list(plugins)
+    features = set(filter_features(value + dependencies))
+    plugins = [FEATURE_MAP.get(feature, {}).get('hammer') for feature in features]
+    return sorted(compact_list(plugins))
 
 
 def foreman_proxy_plugins(value):
     dependencies = list(get_dependencies(filter_features(value)))
-    plugins = [FEATURE_MAP.get(feature, {}).get('foreman_proxy', {}).get('plugin_name') for feature in filter_features(value + dependencies)]
-    return compact_list(plugins)
+    features = set(filter_features(value + dependencies))
+    plugins = [FEATURE_MAP.get(feature, {}).get('foreman_proxy', {}).get('plugin_name') for feature in features]
+    return sorted(compact_list(plugins))
 
 
 def available_foreman_proxy_plugins(_value):

--- a/tests/unit/filter_test.py
+++ b/tests/unit/filter_test.py
@@ -1,5 +1,8 @@
 from foremanctl import FEATURE_MAP
 from foremanctl import conflicting_features
+from foremanctl import foreman_plugins
+from foremanctl import foreman_proxy_plugins
+from foremanctl import hammer_plugins
 from foremanctl import list_all_features
 
 
@@ -63,3 +66,73 @@ def test_list_all_features_marks_dependency_as_enabled(monkeypatch):
     output = list_all_features(['test-parent'])
     child_line = next(line for line in output.splitlines() if line.startswith('test-child'))
     assert 'enabled' in child_line
+
+
+def test_foreman_plugins_deduplicates(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-parent', {
+        'dependencies': ['test-child'],
+        'foreman': {'plugin_name': 'parent_plugin'}
+    })
+    monkeypatch.setitem(FEATURE_MAP, 'test-child', {
+        'foreman': {'plugin_name': 'child_plugin'}
+    })
+    result = foreman_plugins(['test-parent', 'test-child'])
+    assert result.count('child_plugin') == 1
+    assert result.count('parent_plugin') == 1
+
+
+def test_foreman_plugins_sorted(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-z', {'foreman': {'plugin_name': 'z_plugin'}})
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'foreman': {'plugin_name': 'a_plugin'}})
+    monkeypatch.setitem(FEATURE_MAP, 'test-m', {'foreman': {'plugin_name': 'm_plugin'}})
+    result = foreman_plugins(['test-z', 'test-a', 'test-m'])
+    assert result == ['a_plugin', 'm_plugin', 'z_plugin']
+
+
+def test_foreman_plugins_filters_none(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-with-plugin', {'foreman': {'plugin_name': 'has_plugin'}})
+    monkeypatch.setitem(FEATURE_MAP, 'test-no-plugin', {})
+    result = foreman_plugins(['test-with-plugin', 'test-no-plugin'])
+    assert result == ['has_plugin']
+
+
+def test_hammer_plugins_deduplicates(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-parent', {
+        'dependencies': ['test-child'],
+        'hammer': 'parent_hammer'
+    })
+    monkeypatch.setitem(FEATURE_MAP, 'test-child', {
+        'hammer': 'child_hammer'
+    })
+    result = hammer_plugins(['test-parent', 'test-child'])
+    assert result.count('child_hammer') == 1
+    assert result.count('parent_hammer') == 1
+
+
+def test_hammer_plugins_sorted(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-z', {'hammer': 'z_hammer'})
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'hammer': 'a_hammer'})
+    monkeypatch.setitem(FEATURE_MAP, 'test-m', {'hammer': 'm_hammer'})
+    result = hammer_plugins(['test-z', 'test-a', 'test-m'])
+    assert result == ['a_hammer', 'm_hammer', 'z_hammer']
+
+
+def test_foreman_proxy_plugins_deduplicates(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-parent', {
+        'dependencies': ['test-child'],
+        'foreman_proxy': {'plugin_name': 'parent_proxy'}
+    })
+    monkeypatch.setitem(FEATURE_MAP, 'test-child', {
+        'foreman_proxy': {'plugin_name': 'child_proxy'}
+    })
+    result = foreman_proxy_plugins(['test-parent', 'test-child'])
+    assert result.count('child_proxy') == 1
+    assert result.count('parent_proxy') == 1
+
+
+def test_foreman_proxy_plugins_sorted(monkeypatch):
+    monkeypatch.setitem(FEATURE_MAP, 'test-z', {'foreman_proxy': {'plugin_name': 'z_proxy'}})
+    monkeypatch.setitem(FEATURE_MAP, 'test-a', {'foreman_proxy': {'plugin_name': 'a_proxy'}})
+    monkeypatch.setitem(FEATURE_MAP, 'test-m', {'foreman_proxy': {'plugin_name': 'm_proxy'}})
+    result = foreman_proxy_plugins(['test-z', 'test-a', 'test-m'])
+    assert result == ['a_proxy', 'm_proxy', 'z_proxy']


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Fix non-deterministic plugin list ordering that causes quadlet files to regenerate on every deploy, triggering unnecessary service restarts. Currently, the `FOREMAN_ENABLED_PLUGINS` environment variable in foreman.service has unstable ordering with duplicates, causing the quadlet file to differ between consecutive deploys even when nothing changed. This contributes to Item 5 (quadlet idempotency) from redeploy-timing-improvements-plan.md.

Example diff showing the problem:
```
< Environment='FOREMAN_ENABLED_PLUGINS=katello foreman_google foreman_remote_execution foreman_webhooks foreman_ansible foreman-tasks foreman_remote_execution katello foreman_rh_cloud'
---
> Environment='FOREMAN_ENABLED_PLUGINS=katello foreman_google foreman_remote_execution foreman_webhooks foreman_ansible katello foreman_remote_execution foreman_rh_cloud foreman-tasks'
```

Note the duplicates (katello, foreman_remote_execution) and different ordering.

#### What are the changes introduced in this pull request?

* Deduplicate features before extracting plugin names using `dict.fromkeys()`
* Sort plugin lists alphabetically for stable ordering
* Apply fix to `foreman_plugins()`, `hammer_plugins()`, and `foreman_proxy_plugins()` filters
* Add unit tests for deduplication and sorting behavior

#### How to test this pull request

Steps to reproduce:

* Deploy foremanctl: `./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development`
* Save quadlet file: `cp /etc/containers/systemd/foreman.service /tmp/foreman.service.1`
* Run second deploy: `./foremanctl deploy --foreman-initial-admin-password=changeme --tuning development`
* Save quadlet again: `cp /etc/containers/systemd/foreman.service /tmp/foreman.service.2`
* Compare: `diff /tmp/foreman.service.1 /tmp/foreman.service.2`
* Verify FOREMAN_ENABLED_PLUGINS is identical (no diff)
* Run unit tests: `cd tests/unit && python -m pytest filter_test.py::test_foreman_plugins_sorted -v`

Expected behavior:
- Plugin lists are alphabetically sorted
- No duplicates in plugin lists
- Quadlet files are byte-for-byte identical on consecutive deploys

#### Checklist
* [x] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

