### PR TITLE
Run database migrations only when pending

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -129,8 +129,6 @@
         PartOf=foreman.target
         Wants=valkey.service postgresql.service candlepin.service
         After=valkey.service postgresql.service candlepin.service
-        Wants=foreman-db-migrate.service
-        After=foreman-db-migrate.service
   notify: Restart foreman
 
 - name: Install foreman-rake wrapper
@@ -163,8 +161,6 @@
         PartOf=foreman.target
         Wants=valkey.service postgresql.service
         After=valkey.service postgresql.service
-        Wants=foreman-db-migrate.service
-        After=foreman-db-migrate.service
       - |
         [Service]
         Restart=on-failure
@@ -222,6 +218,24 @@
   loop_control:
     label: "{{ item.instance }}"
 
+- name: Deploy foreman database migration check container
+  containers.podman.podman_container:
+    name: foreman-db-migration-check
+    state: quadlet
+    image: foreman.image
+    sdnotify: false
+    network: host
+    command: bash -c "bin/rails db:abort_if_pending_migrations"
+    env: "{{ foreman_env }}"
+    secrets: "{{ foreman_secrets }}"
+    quadlet_options:
+      - |
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        SuccessExitStatus=1
+        TimeoutStartSec=30m
+
 - name: Deploy foreman database migration container
   containers.podman.podman_container:
     name: foreman-db-migrate
@@ -229,7 +243,7 @@
     image: foreman.image
     sdnotify: false
     network: host
-    command: bash -c "bin/rails db:migrate && bin/rails db:seed"
+    command: bash -c "bin/rails db:migrate"
     env: "{{ foreman_env }}"
     secrets: "{{ foreman_secrets }}"
     quadlet_options:
@@ -243,10 +257,31 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: Migrate and seed the Foreman database
+- name: Check for pending Foreman migrations
+  ansible.builtin.systemd:
+    name: foreman-db-migration-check.service
+    state: restarted
+  failed_when: false
+
+- name: Get Foreman migration check exit status  # noqa command-instead-of-module
+  ansible.builtin.command:
+    cmd: systemctl show --property=ExecMainStatus --value foreman-db-migration-check.service
+  register: foreman_migration_check_status
+  changed_when: false
+  failed_when: >-
+    foreman_migration_check_status.rc != 0 or
+    (foreman_migration_check_status.stdout | trim) not in ['0', '1']
+
+- name: Determine if Foreman migration is needed
+  ansible.builtin.set_fact:
+    foreman_migration_needed: >-
+      {{ (foreman_migration_check_status.stdout | trim | int) == 1 }}
+
+- name: Migrate the Foreman database
   ansible.builtin.systemd:
     name: foreman-db-migrate.service
     state: restarted
+  when: foreman_migration_needed
 
 - name: Flush handlers to restart services
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Foreman database migration containers currently run on deployments where their databases are already up to date. These containers add unnecessary startup time. Database migrations should be checked explicitly, and the migration containers should only run when pending migrations are reported.

#### What are the changes introduced in this pull request?

* Add one-shot Foreman migration-check containers.
* Run the migration container only when the migration check reports pending migrations.
* Remove database seeding from the Foreman migration container; Foreman performs seeding during application startup.

#### How to test this pull request

Steps to reproduce:

* Run `ANSIBLE_COLLECTIONS_PATH="$PWD/build/collections/foremanctl" ANSIBLE_COLLECTIONS_SCAN_SYS_PATH=false bash -c 'source .venv/bin/activate && cd src && ansible-lint'`; expect no findings.
* Run `source .venv/bin/activate && ruff check tests/ src/ development/scripts/ inventories/`; expect all checks to pass.
* Run `git diff --check`; expect no whitespace errors.
* Deploy on a provisioned test VM and verify that the migration service runs when migrations are pending and is skipped when the database is current.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)


