### PR TITLE
Run only rails server in foreman container command

### DIFF
--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -115,6 +115,7 @@
     sdnotify: true
     network: host
     hostname: "{{ ansible_facts['hostname'] }}.local"
+    command: "/usr/share/foreman/bin/rails server --environment production --pid /tmp/rails.pid"
     volume:
       - 'foreman-data-run:/var/run/foreman:rw,z,U'
     secrets: "{{ foreman_secrets }}"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

The foreman container inherits the image's default CMD, which chains three
full-boot `rails` invocations:

```
rails db:migrate && rails db:seed && rails server ...
```

Each is a separate process that loads the full Rails + plugin environment.
foremanctl already runs `db:migrate` and `db:seed` via the dedicated
`foreman-db-migrate.service` one-shot, which the foreman container `Requires=`
and runs `After=`. So the `db:migrate` and `db:seed` in the container CMD are
pure duplication — two extra full Rails boots (~14s) on every foreman start,
doing work the one-shot already did.

Journal analysis of a restart confirmed the identical env-load sequence
(`Rails cache backend: Redis` -> plugin permission registration -> app metadata)
running three times, with `=> Booting Puma` appearing only on the third; the
second pass ends with `Acquiring Advisory-Transaction-Lock 'database_seed'`.

Follow-up to the `Requires=` -> `Wants=` restart fix (#769).

#### What are the changes introduced in this pull request?

* Override the foreman container command to run only `rails server`, so the
  container no longer re-runs `db:migrate` and `db:seed` on start. Migration and
  seeding remain owned by `foreman-db-migrate.service` at deploy time.

#### How to test this pull request

Steps to reproduce:

* Deploy foreman, then time a restart: `time systemctl restart foreman`.
* Before: ~26s, with three env-load passes in
  `journalctl -u foreman -o short-monotonic`.
* After: ~11s, a single env-load pass (one `=> Booting Puma`), workers fork in
  ~0.4s, socket activation / sdnotify / preload all intact.
* Confirm migrate/seed still run on a full `./foremanctl deploy` (the
  `Migrate and seed the Foreman database` task restarts
  `foreman-db-migrate.service`).
* Confirm the app serves `/api/v2/ping` after restart. Note a bare
  `systemctl restart foreman` intentionally no longer migrates — the one-shot
  owns that at deploy time.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
