### PR TITLE
Enable SSH pipelining to speed up deploys

### DIFF
--- a/development/ansible.cfg
+++ b/development/ansible.cfg
@@ -6,3 +6,7 @@ roles_path = ./roles:../src/roles
 library = ../src/plugins/modules
 filter_plugins = ../src/filter_plugins
 display_skipped_hosts = no
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=180s

--- a/src/ansible.cfg
+++ b/src/ansible.cfg
@@ -6,3 +6,7 @@ filter_plugins = ./filter_plugins
 callback_plugins = ./callback_plugins
 callback_result_format = yaml
 stdout_callback = foremanctl
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=180s


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

A foremanctl deploy runs ~750 Ansible tasks. When the target is reached over
SSH (the development/`forge` loop against the `quadlet` VM, and any remote
target), each task without pipelining pays extra SSH round-trips to write the
module to a temp file, execute it, and clean up. That overhead is baked into
every task and dominates the run once the big single-task costs are gone.

Enabling SSH pipelining took a re-deploy from ~3:28 to ~2:30 (~28%), with every
task dropping ~35-40% as the round-trip overhead came off uniformly.

#### What are the changes introduced in this pull request?

* Enable `pipelining = True` under `[ssh_connection]` in both `src/ansible.cfg`
  and `development/ansible.cfg`.
* Set `ssh_args = -o ControlMaster=auto -o ControlPersist=180s` to keep the
  multiplexed SSH connection warm across the run (up from the 60s default).

Notes:

* No-op for production installs, which use `localhost ansible_connection=local`
  — harmless there, real win for SSH-based deploys.
* Safe with `become: true` unless the target's sudoers sets `requiretty`, which
  modern distros do not.

#### How to test this pull request

Steps to reproduce:

* Deploy to a target VM over SSH twice and compare the second (re-deploy) run
  with `profile_tasks` enabled:

  ```
  ./forge deploy-dev ...   # or ./foremanctl deploy against an SSH target
  ```

* Confirm total wall-clock drops meaningfully (~3:28 -> ~2:30 in testing) and
  that the deploy still converges — services start and checks pass as before.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

