### PR TITLE
Improve error msg when Foreman API health check fails

### DIFF
--- a/src/roles/check_foreman_api/tasks/main.yaml
+++ b/src/roles/check_foreman_api/tasks/main.yaml
@@ -6,6 +6,19 @@
     status_code: 200
     timeout: 10
   register: check_foreman_api_ping
+  failed_when: false
+
+- name: Assert Foreman API is reachable
+  ansible.builtin.assert:
+    that:
+      - check_foreman_api_ping.status == 200
+    fail_msg: >
+      Foreman API is unreachable at {{ foreman_url }}/api/v2/ping.
+      {% if check_foreman_api_ping.status == -1 %}
+      Connection failed - foreman.service may not be running.
+      {% else %}
+      Returned HTTP status {{ check_foreman_api_ping.status }}.
+      {% endif %}
 
 - name: Check Foreman tasks status
   ansible.builtin.assert:
@@ -14,6 +27,7 @@
     fail_msg: "Foreman tasks status: {{ check_foreman_api_ping.json.results.katello.services.foreman_tasks.status | default('unknown') }}"
     success_msg: "Foreman tasks status: ok"
   when:
+    - check_foreman_api_ping.status == 200
     - enabled_features | has_feature('tasks')
     - enabled_features | has_feature('katello')
     - check_foreman_api_ping.json.results.katello is defined


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
When the Foreman API is unreachable during health checks, the error message displays a confusing "-1 status code" that isn't actually an HTTP status code. This message is correct but could be misleading to users

#### What are the changes introduced in this pull request?

Improved error message for API health check to show clear context instead of "-1 status code", when Foreman API health check fails

#### How to test this pull request
  - Deploy foremanctl successfully
  - Stop foreman service: systemctl stop foreman.service
  - Run health check: foremanctl health
  - Verify error message shows: "Connection failed - foreman.service may not be running" instead of "Status code was -1"
  - Restart service and verify health check passes normally
 
Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
