### PR TITLE
Use official CentOS Stream Vagrant images for all VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,13 @@
 DOMAIN = ENV.fetch('VAGRANT_DOMAIN', 'example.com'.freeze)
 
+# Official CentOS libvirt images include swap; Vagrant Cloud boxes do not.
+def set_centos_box_url(vm)
+  stream = vm.box[/^centos\/stream(\d+)$/, 1]
+  return unless stream
+
+  vm.box_url = "https://cloud.centos.org/centos/#{stream}-stream/x86_64/images/CentOS-Stream-Vagrant-#{stream}-latest.x86_64.vagrant-libvirt.box"
+end
+
 Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant"
 
@@ -18,9 +26,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "quadlet" do |override|
     override.vm.box = ENV.fetch("FOREMANCTL_BASE_BOX", "centos/stream9")
-    if override.vm.box == "centos/stream10"
-      override.vm.box_url = "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-libvirt.box"
-    end
+    set_centos_box_url(override.vm)
     override.vm.hostname = "quadlet.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
@@ -32,6 +38,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "client" do |override|
     override.vm.box = "centos/stream9"
+    set_centos_box_url(override.vm)
     override.vm.hostname = "client.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
@@ -43,6 +50,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "database" do |override|
     override.vm.box = "centos/stream9"
+    set_centos_box_url(override.vm)
     override.vm.hostname = "database.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
@@ -54,6 +62,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "proxy" do |override|
     override.vm.box = "centos/stream9"
+    set_centos_box_url(override.vm)
     override.vm.hostname = "proxy.#{DOMAIN}"
 
     override.vm.provider "libvirt" do |libvirt, provider|
@@ -70,6 +79,7 @@ Vagrant.configure("2") do |config|
     user_boxes.compact.each do |name, settings|
       config.vm.define name do |override|
         override.vm.box = settings.fetch('box') { ENV.fetch('FOREMANCTL_BASE_BOX', 'centos/stream9') }
+        set_centos_box_url(override.vm)
 
         override.vm.provider "libvirt" do |libvirt, _provider|
           libvirt.memory = settings.fetch('memory', 3072)


### PR DESCRIPTION
## Summary
- Point all CentOS Stream VM definitions at the official libvirt images from cloud.centos.org, which include swap
- Replace the stream10-only special case with a shared helper that works for any `centos/streamN` box
- Apply the same box URL to client, database, proxy, and user-defined boxes so Vagrant's global box cache stays consistent

## Test plan
- [ ] `vagrant up quadlet` with the default `centos/stream9` box
- [ ] `FOREMANCTL_BASE_BOX=centos/stream10 vagrant up quadlet`
- [ ] Confirm swap is present in the VM (`swapon --show`)
- [ ] Run `./forge test` against a VM started with the updated Vagrantfile
