### PR TITLE
Add persistent Bootsnap cache to Foreman

### DIFF
--- a/src/roles/foreman/defaults/main.yaml
+++ b/src/roles/foreman/defaults/main.yaml
@@ -3,6 +3,9 @@ foreman_container_image: "quay.io/foreman/foreman"
 foreman_container_tag: "nightly"
 foreman_container_name: foreman
 
+foreman_bootsnap_cache_volume: foreman-bootsnap-cache
+foreman_bootsnap_cache_dir: /var/cache/foreman
+
 foreman_database_name: foreman
 foreman_database_user: foreman
 foreman_database_host: localhost
@@ -53,6 +56,7 @@ foreman_env:
   FOREMAN_PUMA_THREADS_MIN: "{{ foreman_puma_threads_min }}"
   FOREMAN_PUMA_THREADS_MAX: "{{ foreman_puma_threads_max }}"
   FOREMAN_PUMA_WORKERS: "{{ foreman_puma_workers }}"
+  BOOTSNAP_CACHE_DIR: "{{ foreman_bootsnap_cache_dir }}"
 
 foreman_dynflow_extra_env:
   DYNFLOW_REDIS_URL: "redis://localhost:6379/6"

--- a/src/roles/foreman/tasks/main.yaml
+++ b/src/roles/foreman/tasks/main.yaml
@@ -117,6 +117,7 @@
     hostname: "{{ ansible_facts['hostname'] }}.local"
     volume:
       - 'foreman-data-run:/var/run/foreman:rw,z,U'
+      - "{{ foreman_bootsnap_cache_volume }}:{{ foreman_bootsnap_cache_dir }}:rw,z,U"
     secrets: "{{ foreman_secrets }}"
     env: "{{ foreman_env }}"
     quadlet_options:
@@ -152,6 +153,7 @@
     hostname: "{{ ansible_facts['hostname'] }}.local"
     volume:
       - 'foreman-data-run:/var/run/foreman:rw,z,U'
+      - "{{ foreman_bootsnap_cache_volume }}:{{ foreman_bootsnap_cache_dir }}:rw,z,U"
     secrets: "{{ foreman_dynflow_secrets }}"
     env: "{{ foreman_dynflow_env }}"
     command: "/usr/libexec/foreman/sidekiq-selinux -e production -r ./extras/dynflow-sidekiq.rb -C /etc/foreman/dynflow/%i.yml"
@@ -198,6 +200,7 @@
     command: "foreman-rake {{ item.rake }}"
     volume:
       - 'foreman-data-run:/var/run/foreman:rw,z,U'
+      - "{{ foreman_bootsnap_cache_volume }}:{{ foreman_bootsnap_cache_dir }}:rw,z,U"
     secrets: "{{ foreman_secrets }}"
     env: "{{ foreman_env }}"
     quadlet_options:
@@ -230,6 +233,8 @@
     sdnotify: false
     network: host
     command: bash -c "bin/rails db:migrate && bin/rails db:seed"
+    volume:
+      - "{{ foreman_bootsnap_cache_volume }}:{{ foreman_bootsnap_cache_dir }}:rw,z,U"
     env: "{{ foreman_env }}"
     secrets: "{{ foreman_secrets }}"
     quadlet_options:


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

Foreman can use bootsnap cache to speed up restarts. By using a persistent volume this will last between restarts and be shared with the dynflow and migrate processes as well. The build time method of caching can easily miss code paths, and adds ~280MB to the image size. The cache generation is fast, so having this done during the initial start is an OK trade-off to keep image size small and gain performance.

For my environment, I got foreman restarts down from 16-18 seconds to 6-7 seconds. Similar gains for dynflow and the migrate service.

This will depend on:

- https://github.com/theforeman/foreman-packaging/pull/14086
- Code change to Foreman core [PR in progress](https://github.com/theforeman/foreman/pull/11234)

#### What are the changes introduced in this pull request?

* Configure a persistent `foreman-bootsnap-cache` Podman volume mounted at `/var/cache/foreman`.
* Share the cache volume with Foreman, Dynflow, recurring rake, and database migration containers.
* Set `BOOTSNAP_CACHE_DIR` explicitly in the Foreman container environment.

#### How to test this pull request

Steps to reproduce:

* Deploy Foreman with the Bootsnap-enabled image.
* Verify the generated Foreman-related quadlets mount `foreman-bootsnap-cache:/var/cache/foreman`.
* Restart or recreate the Foreman containers and verify the cache remains in the named Podman volume.
* Run `ansible-lint src/roles/foreman`.

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
