### PR TITLE
Don't require oauth credential from parameters in the restore task

### DIFF
--- a/src/playbooks/restore/restore.yaml
+++ b/src/playbooks/restore/restore.yaml
@@ -37,8 +37,6 @@
     - name: Set proxy deploy parameters
       ansible.builtin.set_fact:
         foreman_name: "{{ restore_params.foreman_name }}"
-        foreman_proxy_oauth_consumer_key: "{{ restore_params.foreman_proxy_oauth_consumer_key }}"
-        foreman_proxy_oauth_consumer_secret: "{{ restore_params.foreman_proxy_oauth_consumer_secret }}"
       when:
         - restore_params is defined
         - restore_enabled_features | default([]) | has_feature('foreman-proxy')


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
Restore on proxy was requiring oauth key and secret in parameters.yaml. The commit https://github.com/theforeman/foremanctl/pull/698/changes#diff-b005bb841010b9f9006d7ff1e0fa0d8988b8b6a066091afc982a40abd7e3102aR135 removed the need for it and now oauth creds can be read directly from state directory/oauth.
#### What are the changes introduced in this pull request?

* Stop reading oauth from parameters.yaml since those don't exist anymore since change above. Let the creds come from default oauth directory that restore extracts state into.

#### How to test this pull request

Steps to reproduce:

* Set up a proxy
* Run foremanctl backup /tmp/backup --target-host proxy
* Run foremanctl restore /tmp/backup/backup_dir --target-host proxy --force

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
