### PR TITLE
Use 5.0 in packit & tests/container_user_test.py

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -13,7 +13,7 @@ srpm_build_deps:
 
 actions:
   post-upstream-clone:
-    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foremanctl/foremanctl.spec -O foremanctl.spec"
+    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/5.0/packages/foreman/foremanctl/foremanctl.spec -O foremanctl.spec"
   create-archive:
     - make dist
     - bash -c 'ls -1t foremanctl-*.tar.gz | head -n1'

--- a/tests/container_user_test.py
+++ b/tests/container_user_test.py
@@ -1,5 +1,6 @@
 # These still need to be fixed
 EXPECTED_ROOT_IMAGES = {
+    "quay.io/foreman/pulp:foreman-5.0",
     "quay.io/iop/puptoo:foreman-3.18",
     "quay.io/iop/yuptoo:foreman-3.18",
 }


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

To fix the failing CI in `3.2-stable`

#### TODO

Update RELEASE.md in the `master` branch.

#### Related fixes

https://github.com/theforeman/foreman-oci-images/pull/95
