### PR TITLE
add extra_iop_packages for satellite flavor

### DIFF
--- a/src/vars/flavors/satellite.yml
+++ b/src/vars/flavors/satellite.yml
@@ -34,3 +34,7 @@ health_checks_to_execute:
   - check_duplicate_permissions
 
 post_install_message_enabled: true
+
+iop_engine_extra_packages:
+  - "prodsec.rules"
+  - "telemetry.rules.plugins"


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

When you deploy Satellite using foremanctl the iop-core-engine is missing some packages that are necessary for correct Lightspeed recommendations.

#### What are the changes introduced in this pull request?

* two packages are into `iop_engine_extra_packages` for satellite flavor

#### How to test this pull request

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
