### PR TITLE
Enable ansible feature in the capsule flavor

### DIFF
--- a/src/vars/flavors/capsule.yml
+++ b/src/vars/flavors/capsule.yml
@@ -6,6 +6,7 @@ flavor_features:
   - content/ansible
   - content/container
   - content/rpm
+  - ansible
   - remote-execution
   - templates
   - registration


### PR DESCRIPTION
## Summary
- Add `ansible` to `flavor_features` in the capsule flavor so `foremanctl deploy-proxy` enables the Ansible smart proxy plugin on Capsules.
- Aligns capsule deployments with the satellite flavor, which already includes `ansible` for Ansible-based remote execution.

## Context
Without this, Capsule smart proxies only expose Script/Templates/Dynflow features. Ansible remote execution jobs on hosts registered to capsules fail because no applicable proxy offers the Ansible feature.

Validated by patching `capsule.yml` and running `foremanctl deploy-proxy` on all capsules; Ansible REX jobs then succeeded for capsule-located hosts.

## Test plan
- [ ] Deploy a capsule with `foremanctl deploy-proxy` and confirm `hammer proxy list` shows the Ansible feature after `hammer proxy refresh-features`
- [ ] Run an Ansible remote execution job against hosts in a capsule location and verify success
- [ ] Confirm existing capsule deployments can pick up the feature via `foremanctl deploy-proxy` without other flavor changes


Made with [Cursor](https://cursor.com)