### PR TITLE
Mark content/ostree feature as internal

### DIFF
--- a/src/features.d/content.yaml
+++ b/src/features.d/content.yaml
@@ -26,5 +26,6 @@ content/python:
     - pulp
 content/ostree:
   description: OSTree content type for Pulp
+  internal: true
   dependencies:
     - pulp


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)
`foremanctl features` lists `content/ostree` feature as available, which should be internal feature like other content features

#### What are the changes introduced in this pull request?

* Marking content/ostree feature as internal, so its not visible in available features list

#### How to test this pull request
1. $ foremanctl features
2. Verify `content/ostree` isn't listed as available feature

Steps to reproduce:

*

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)
