### PR TITLE
Fix shellcheck warnings in foremanctl script

### DIFF
--- a/foremanctl
+++ b/foremanctl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 OBSAH_NAME=foremanctl
-OBSAH_BASE=$(dirname $(readlink -f $0))
+OBSAH_BASE=$(dirname "$(readlink -f "$0")")
 OBSAH_DATA=${OBSAH_BASE}/src
 OBSAH_INVENTORY=${OBSAH_BASE}/inventories
 OBSAH_STATE=${OBSAH_BASE}/.var/lib/foremanctl


### PR DESCRIPTION
#### Why are you introducing these changes? (Problem description, related links)

My editor runs shellcheck and these warnings annoyed me. In practice I think it's unlikely to really cause problems, but it's technically correct.

#### What are the changes introduced in this pull request?

* Introduce quoting for variables to deal with spaces in filenames

#### How to test this pull request

Steps to reproduce:

* Run shellcheck against `foremanctl`

#### Checklist
* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)